### PR TITLE
Backend integration + architecture ADRs (auth, all-TS on-device, monorepo)

### DIFF
--- a/docs/adr/0002-authentication.md
+++ b/docs/adr/0002-authentication.md
@@ -1,0 +1,124 @@
+# ADR 0002 — Authentication for neeme
+
+**Status:** Proposed (managed third-party provider; defers behind sync per ADR 0003)
+**Date:** 2026-06-01 (rev. 3 — dropped self-host; re-centered on managed providers + the
+"Electron = shared OIDC flow" reality. Rev. 1 assumed Stack Auth; rev. 2 corrected to Better
+Auth and weighed self-hosting — now ruled out by the "keep it easy / don't self-host" call.)
+**Context owners:** jlee (+ Claude)
+**Related:** simplified + gated by [[0003-all-typescript-on-device-pipeline]]; see [[0001-sync-and-processing-architecture]]
+
+## Problem
+
+neeme has **no authentication today** — every endpoint is open and app data (items, todos) is
+**global, with no `user_id` scoping**. We need an identity story before any multi-user / synced /
+deployed use.
+
+Two constraints now shape the choice:
+1. **Managed only — no self-hosting.** Keep it easy to start; we don't want to operate an auth
+   service. (This rules out self-hosted Better Auth, which rev. 2 had weighed.)
+2. **Must serve both clients: Electron desktop (the flagship) *and* React Native (planned mobile).**
+
+## Two reframes that make this low-stakes
+
+- **Auth defers behind sync (per [[0003-all-typescript-on-device-pipeline]]).** If the app is
+  local-first and the on-device store is the source of truth, the **local experience needs no
+  login at all.** Auth only matters once we add **accounts / cross-device sync / cloud offload**.
+  So this is not on the critical path — pick something reasonable and move on.
+- **No provider has a real "Electron SDK."** Desktop auth is the *same pattern everywhere*: OIDC
+  **Authorization Code + PKCE** in the **system browser** (never an embedded webview), with a
+  **loopback** (`127.0.0.1`) or **custom-scheme** (`neeme://`) redirect, via a generic client lib
+  (`openid-client` / AppAuth-JS). Token in OS keychain (`safeStorage`) → the existing
+  `getToken()` seam. So "works for Electron" ≈ "supports a public OIDC client with PKCE" — which
+  nearly all do. **The real differentiator is the React Native SDK + DX + price**, and because
+  it's standard OIDC, **switching providers later is mostly a config change.**
+
+## Options considered (managed only)
+
+Legend: ✅ strong · ⚠️ caveats · ❌ poor
+
+| Option | React Native | Electron (all via OIDC/PKCE) | DX / ease | Price posture | Notes |
+|---|---|---|---|---|---|
+| **A. Kinde** | ✅ RN + web SDKs | ⚠️ shared OIDC flow | ✅✅ very easy, modern | ✅ generous free, simple | Consumer-app focused; strong easy-start pick |
+| **B. Logto Cloud** | ✅ RN SDK | ✅ OIDC-purist → cleanest desktop flow | ✅ clean | ✅ cheap/modern | Managed **and** OSS — "managed now, self-host someday" stays open, no re-platform |
+| **C. Auth0** | ✅ first-class (`react-native-auth0`) | ⚠️ documented desktop sample | ⚠️ powerful but heavy | ⚠️ **7.5k MAU free; per-MAU +~300% ($0.023→$0.07)** | Safe known quantity; cost ceiling at scale; busy console (Okta-owned) |
+| **D. Clerk** | ✅ first-class Expo | ❌ **not first-class for Electron** | ✅✅ best DX | ⚠️ Pro $25/mo+ | Dreamy for mobile/web; weak on the desktop flagship → not the fit here |
+| **E. Neon Auth (managed Better Auth)** | ⚠️ via BA client | ⚠️ no public-client/device plugin on managed; client-SDK-in-Electron unproven | ✅ if it fits | ✅ in our Neon DB | Branchable users in our DB, but the desktop path is the *least proven* (rev. 2) |
+| ~~Self-hosted Better Auth~~ | — | — | — | — | **Ruled out** — we won't operate auth infra |
+| ~~Roll-your-own~~ | — | — | — | — | **Rejected** — security footgun |
+
+### Notes
+
+- **A. Kinde** — Easiest on-ramp: modern dashboard, RN + web SDKs, simple/generous pricing, clean
+  OIDC for the Electron flow. Good default if "just works, cheap, modern" is the goal.
+- **B. Logto Cloud** — OIDC-purist, so the hand-rolled desktop PKCE flow is textbook; real RN SDK;
+  **OSS lineage means no lock-in** (could self-host later if the stance changes — useful given
+  [[0001-sync-and-processing-architecture]]'s privacy thread). My co-favourite with Kinde.
+- **C. Auth0** — Mature, first-class RN, a documented Electron sample. Honest downsides: free tier
+  shrank to **7,500 MAU**, per-user price **rose ~300%**, and the console is heavy. Fine to start;
+  a cost ceiling later. The "boring, known" choice.
+- **D. Clerk** — Best DX and first-class Expo/RN, but **Electron isn't a first-class target**.
+  Since neeme-desktop is the flagship, that weakness disqualifies it as the primary pick (revisit
+  if mobile/web ever leads).
+- **E. Neon Auth / Better Auth (managed)** — Tempting (users branch with our Neon DB, JWKS for
+  backend verify), but rev. 2 found the **desktop path least proven**: managed Neon Auth doesn't
+  expose the public-client/device plugins, so you'd run the Better Auth client SDK *inside
+  Electron*, which isn't documented. Keep as a "watch the roadmap" option, not the starting pick.
+
+## When auth does get built — the three layers
+
+1. **Token issuance** — the chosen managed provider (hosted login + social).
+2. **Backend verification** — only exists once there's a cloud/sync backend. Per ADR 0003 that
+   backend is **TypeScript**, so it verifies the provider's JWT against the provider's **JWKS URL**
+   (e.g. `jose`/`jwks-rsa`) — provider-agnostic, a few lines. (No FastAPI, no cross-language dance.)
+3. **Desktop/mobile flow** — **shared OIDC + PKCE** via system browser; token in `safeStorage`
+   (desktop) / secure store (RN) → existing `getToken()` seam; silent refresh.
+
+Plus, whenever multi-user lands: the **`user_id` data-scoping migration** to de-global items/todos.
+
+## Recommendation
+
+**Pick a managed, OIDC-clean provider — default to Kinde or Logto Cloud** (modern, cheap, real RN
+SDK, painless desktop OIDC). **Auth0** is the safe known fallback if you'd rather a battle-tested
+incumbent and accept the price ceiling. **Avoid Clerk as primary** (Electron-weak) and **don't
+self-host**. Because it's standard OIDC, treat the choice as **low-commitment and swappable.**
+
+**Sequencing:** **defer building auth until sync/accounts are on the table** (ADR 0003 makes the
+local app work without it). When that day comes, **spike the chosen provider's RN SDK + the
+Electron system-browser PKCE flow** before committing.
+
+## Consequences
+
+- **Easier:** auth is off the critical path (local-first needs none); standard OIDC = cheap to
+  swap providers; one shared desktop/mobile flow; TS backend verifies via JWKS in a few lines.
+- **Harder:** the Electron OIDC + `safeStorage` flow is bespoke (no SDK) — but written once;
+  whenever multi-user arrives, the backend needs the **`user_id` migration** onto currently-global
+  data (and a call on existing unowned rows).
+- **Revisit when:** sync/accounts are prioritized; the privacy stance shifts (Logto's self-host
+  path, or back toward 0001's E2E goal); or a provider's native/Electron support materially
+  improves (e.g. Neon Auth roadmap adds public-client flows).
+
+## Action items (not now — when sync/accounts are scheduled)
+
+1. [ ] Decide provider (lean **Kinde** or **Logto Cloud**); create a project, register a **public
+       client** with loopback + `neeme://` redirects.
+2. [ ] **Spike:** the provider's **RN SDK** + the **Electron system-browser PKCE** flow →
+       `safeStorage` → `getToken()`. Confirm token refresh.
+3. [ ] **TS backend:** JWKS-verify middleware; add `user_id` to items/todos + migration; scope all
+       queries.
+4. [ ] **CSP:** allow the auth + JWKS origins (and redirect handling) in `src/renderer/index.html`.
+
+## Open questions
+
+- Exact current **free-tier limits / pricing** for Kinde and Logto Cloud (verify at decision time).
+- **Existing global items/todos** on the multi-user migration — assign to a first user, or wipe in dev?
+- Single-user-per-install vs multi-account switching in the desktop app?
+- Does identity (who you are) stay cleanly separable from data privacy (server can't read content),
+  per 0001 — or co-design if sync goes E2E?
+
+## Sources
+
+- Auth0 free tier / pricing / RN — https://github.com/auth0/react-native-auth0 · https://auth0.com/pricing
+- Clerk RN/Expo + Feb-2026 pricing — https://clerk.com/react-authentication · https://clerk.com/pricing
+- Logto (cloud + OSS, OIDC, native) — https://blog.logto.io/top-7-auth-providers-2026 · https://logto.io
+- Kinde (consumer apps comparison) — https://www.kinde.com/comparisons/authentication-providers-for-consumer-software-apps-compared-top-10-options-in-2026/
+- OAuth for native apps (PKCE, system browser, loopback) — RFC 8252

--- a/docs/adr/0003-all-typescript-on-device-pipeline.md
+++ b/docs/adr/0003-all-typescript-on-device-pipeline.md
@@ -1,0 +1,167 @@
+# ADR 0003 — All-TypeScript stack with an on-device-first pipeline
+
+**Status:** Proposed (recommends all-TS + on-device pipeline; go/no-go = a local-embed + libSQL-vector spike)
+**Date:** 2026-06-01
+**Context owners:** jlee (+ Claude); the Python pipeline's owner must sign off (it's their code)
+**Related:** reframes [[0001-sync-and-processing-architecture]]; simplifies [[0002-authentication]]
+
+## Problem
+
+Two decisions have converged:
+1. **Do we still need Python?** The backend (`/Users/jlee/src/retrospct/neeme`, FastAPI) is the
+   only non-TS part of a stack that is otherwise Electron + React (+ planned Expo mobile), all
+   TypeScript. The language split is already taxing us — it's why ADR 0002's auth story needed a
+   cross-language JWKS dance.
+2. **Run as much as possible on-device** — the stated driver is **speed / latency / offline**
+   (not, primarily, privacy). That pulls compute toward the client.
+
+The instinct "local ML ⇒ Python" makes these feel opposed. They are not.
+
+### What the Python backend actually is (measured)
+
+- **~2,787 LOC of glue**, not ML. Runtime deps: `upstash-redis`, `upstash-search`, `boto3`,
+  `pypdf`, `python-dotenv`. Optional: `openai`, `pillow`+`pillow-heif`, `fastapi`, `psycopg`.
+- **No local ML exists yet.** `embedding.py` is a `FakeEmbedder` (hashes tokens into buckets);
+  its own comment says the real on-device model "lands in a follow-up." Real semantic embedding is
+  currently done **server-side by Upstash Search**.
+- **Zero `torch`/`transformers`/`numpy`/`cv2`/`sklearn`.** The only Python-specific import in the
+  whole tree is a **lazy, optional `pytesseract`** behind a pluggable OCR seam with a vision-model
+  fallback.
+- Every dependency has a first-class TS equivalent, several **TS-native** (Upstash ships TS SDKs;
+  `boto3`→AWS SDK for JS; `pypdf`→`unpdf`; `psycopg`→Drizzle, which the desktop already uses).
+
+### The packaging fact that flips the intuition
+
+Shipping **Python inside Electron** (PyInstaller/PyOxidizer, per-platform signing, size, a Node↔Py
+bridge) is a distribution nightmare. Node, by contrast, has **mature native ML addons** —
+`onnxruntime-node`, `node-llama-cpp`, `whisper.cpp` bindings, `sharp` (libvips), `tesseract.js`,
+HF `tokenizers` (itself Rust via napi-rs) — that run in the **Electron main process** with full
+**Metal/CUDA acceleration**. For *inference of existing models*, TS + native addons is the
+**easier** local-first path, not a compromise. And **libSQL already in our deps has native vector
+search** (DiskANN, offline, no extension) — the local vector store needs no new infrastructure.
+
+## Options considered
+
+Legend: ✅ strong · ⚠️ caveats · ❌ poor
+
+| Option | One language | On-device fit | Ships in Electron | Throws away working code | Aligns with local-for-speed |
+|---|---|---|---|---|---|
+| **A. Status quo — Python FastAPI cloud backend** | ❌ Py + TS | ❌ server-side, network-bound | n/a (separate service) | ✅ keeps it | ❌ |
+| **B. Port backend to TS, keep cloud-server shape** | ✅ TS | ⚠️ still a network hop | n/a | ⚠️ rewrite, same shape | ⚠️ partial |
+| **C. All-TS + on-device pipeline in Electron main; cloud = offload/sync** *(recommended)* | ✅ TS | ✅ local-first | ✅ native addons | ⚠️ rewrite, but small + activates existing design | ✅ |
+| **D. Polyglot — Python for ML, TS for app** | ❌ worst of both | ⚠️ Py-in-Electron packaging hell | ❌ | ✅ | ⚠️ |
+
+### Notes
+
+- **A** — Works today (verified live: S3 + Upstash + vision + todos). But it's network-bound, two
+  languages, and the deferred-deploy + auth complexity all stem from it. Fine as the *fallback
+  service*, not the core.
+- **B** — Removes the language split but keeps a round-trip to a server; doesn't deliver the
+  speed/offline goal. A way-station at best.
+- **C — recommended** — The pipeline (ingest → preprocess → OCR/caption/transcribe → **embed
+  locally** → index in **libSQL vector**) runs in the **main process**, surfaced to the renderer
+  over the **IPC seam already built** (`window.api.*`). No HTTP server on the local path. Cloud
+  demotes to **(i) offload** for what a device can't do well (large VLM caption, big chat LLM) and
+  **(ii) sync** via **Turso embedded replicas** (same libSQL driver — no rewrite). This is *not*
+  new architecture: ADR 0001 records that libSQL was chosen **deliberately** to enable exactly this
+  ("local-first now → sync later"), with sqlite-vec/LanceDB already "planned." C **activates the
+  design we already chose** and had parked.
+- **D** — Rejected. Combines the language split *and* the Python-in-Electron packaging pain.
+
+## Capability → on-device TS mapping
+
+| Pipeline stage | On-device TS |
+|---|---|
+| Raw/file store | local filesystem (content-hash) |
+| Metadata + todos | **libSQL** (already in main process) |
+| Vector index + search | **libSQL native vector** (DiskANN, offline) |
+| Embeddings | `transformers.js` / `onnxruntime-node` (e.g. EmbeddingGemma, bge-small) |
+| OCR | `tesseract.js` (WASM) or native binding; vision-model fallback |
+| Image prep (EXIF/dims/**HEIC**) | `sharp` (libvips) — ⚠️ HEIC decode is the one "verify" item |
+| Audio transcription | `whisper.cpp` node bindings / `transformers.js` whisper |
+| Vision caption / chat | `node-llama-cpp` (small VLM/LLM) **or cloud offload** |
+| PDF text | `unpdf` / `pdfjs-dist` |
+
+## Performance strategy / native escape hatch
+
+- **Default: TypeScript** for app, orchestration, IPC, UI, glue.
+- **Consume native freely.** The perf-critical work is already compiled native (ONNX/C++,
+  libvips/C, llama.cpp/C++, HF `tokenizers`/Rust). "Rust-class performance behind a TS API" is the
+  native-addon ecosystem — we get it without writing Rust.
+- **Hand-written Rust only behind a *profiled* bottleneck**, per-function, never as a pillar:
+  **napi-rs** when it's main-process/server-only (prebuilt binaries, slots into our existing
+  `electron-builder` native-addon rebuild; async bridges to JS Promises); **WASM** (`wasm-bindgen`/
+  `wasm-pack`) when the same code must also run in the renderer or mobile. `Tokio` only if that
+  Rust does concurrent async I/O — CPU-bound work wants a thread pool (`rayon`), not an async
+  runtime. Candidate hot paths *if profiled*: bulk file hashing (`blake3`), custom vector
+  quantization — likely **none needed at current scale**.
+- ⚠️ **Naming collision:** the Rust→Node binding crate **Neon** (neon-bindings) is *not* **Neon**
+  the database / Neon Auth. Never write bare "Neon" for the binding in this codebase.
+
+## Consequences
+
+- **Easier:** one language across desktop + future mobile + any backend; the auth story collapses
+  (see below); local-first speed/offline; shared types/validation (zod); the typed API client can
+  become a shared package or tRPC instead of OpenAPI codegen; **libSQL vector means no new infra**.
+- **Harder / risks:**
+  - **Device variance** — Apple Silicon flies; old Intel / GPU-less Windows will crawl on
+    embeddings/ASR/LLM. "Everything local" really means "everything the device can handle, cloud
+    fallback otherwise" → we still build the offload path.
+  - **App size / model downloads** — don't bundle multi-GB models; lazy-download on first use + cache.
+  - **Native-addon packaging** — `onnxruntime-node`/`node-llama-cpp`/`sharp` need per-platform
+    prebuilt binaries + `electron-rebuild` (muscle exists — we already rebuild `better-sqlite3`),
+    but the CI matrix grows.
+  - **Model quality** — on-device models < cloud frontier models; the offload path covers
+    quality-sensitive cases.
+  - **Ownership** — it's the other contributor's pipeline; this is a coordination decision, and a
+    rewrite (even a small one) discards working, tested code.
+
+## Effect on the other ADRs
+
+- **[[0002-authentication]] gets easier and later.** If the local path is the source of truth and
+  single-user, auth is only needed for the **sync/cloud** path — so it **defers until sync is
+  turned on**, and Better Auth (TS) becomes the backend's **in-process** auth then. The
+  managed-vs-self-hosted / cross-language JWKS fork largely dissolves.
+- **[[0001-sync-and-processing-architecture]] is activated, not contradicted.** Its libSQL +
+  Turso-embedded-replica plan *is* the sync story here. Its "compute offload via TEEs/trusted
+  cloud" axis *is* the offload path. Note the **motivation shift**: 0001 framed local-first as
+  *privacy*; here it's *speed/latency/offline* (privacy is a welcome side effect, not the driver).
+
+## Recommendation
+
+**Adopt Option C: go all-TypeScript and move the pipeline on-device into the Electron main process,
+with cloud as an optional offload + sync layer.** Retire Python from the core (it may live on
+briefly as the offload service until that's also TS, or be replaced by direct provider calls).
+**Gate on a spike** (below) to prove the local embed + vector path and measure real per-device
+latency before committing the rewrite. Coordinate with the pipeline's owner first.
+
+## Action items
+
+1. [ ] **Spike (go/no-go):** in the Electron **main process**, fully offline — capture a note →
+       embed locally (`transformers.js`/`onnxruntime-node`) → store vector in **libSQL** →
+       semantic search locally, surfaced via the existing IPC seam. Measure cold-start + query
+       latency on a target low-end device, not just Apple Silicon.
+2. [ ] **HEIC decode check** — confirm `sharp` (or `heic-convert`) handles iPhone HEIC in our
+       Electron build (the one image-prep risk).
+3. [ ] **Coordinate** with the Python pipeline's owner on ownership + sequencing.
+4. [ ] **Pick the backend shape for offload/sync** — Hono service vs. Next/Vercel functions vs.
+       direct-from-client provider calls; decide what (if anything) the cloud still runs.
+5. [ ] **Port incrementally** behind the IPC seam: local store + search first (highest speed win),
+       then ingest/extract, then offload fallback. Re-point/retire `VITE_NEEME_API_URL` per stage.
+
+## Open questions
+
+- Real on-device **latency on weak hardware** — where's the line that triggers cloud fallback?
+- **Which models** (embedder, ASR, OCR, optional VLM/LLM) and their **download sizes** — bundled vs
+  lazy?
+- Does "everything local" include a **local chat LLM** (heavy, `node-llama-cpp`) or is that always
+  cloud-offload?
+- Migration of **existing cloud data** (Upstash/S3) to local stores, or start fresh on-device?
+- Does the offload service stay **Python** short-term, or is the rewrite atomic?
+
+## Sources
+
+- libSQL native vector (DiskANN, on-device, offline) — https://turso.tech/vector · https://turso.tech/blog/turso-brings-native-vector-search-to-sqlite · https://turso.tech/blog/local-first-ai-assistant-kin-leverages-tursos-libsql-for-on-device-native-vector-search
+- On-device TS inference — https://huggingface.co/blog/transformersjs-v3 · https://developers.googleblog.com/introducing-embeddinggemma/ · https://vpawar.hashnode.dev/offline-first-react-apps-local-ai
+- Rust-in-Node — napi-rs (https://napi.rs) · Neon bindings (https://neon-bindings.com) · node-bindgen · wasm-bindgen/wasm-pack
+- Backend inventory — measured from `/Users/jlee/src/retrospct/neeme` (deps, `embedding.py`, `ocr.py`, import scan), 2026-06-01

--- a/docs/adr/0003-all-typescript-on-device-pipeline.md
+++ b/docs/adr/0003-all-typescript-on-device-pipeline.md
@@ -98,6 +98,23 @@ Legend: ✅ strong · ⚠️ caveats · ❌ poor
 - ⚠️ **Naming collision:** the Rust→Node binding crate **Neon** (neon-bindings) is *not* **Neon**
   the database / Neon Auth. Never write bare "Neon" for the binding in this codebase.
 
+## Repo strategy
+
+- **Turborepo monorepo** for the TypeScript surface — `apps/desktop` (this Electron app),
+  `apps/expo` (planned mobile), shared `packages/*` (db/Drizzle, pipeline, api/tRPC, ui, auth). This
+  is the home the all-TS + shared-code direction implies, and aligns with the `create-t3-turbo`
+  skeleton the team is standing up — **this repo becomes `apps/desktop`** within it.
+- **Steal the structure, keep our spine:** T3-Turbo defaults are web-centric (Next/TanStack server)
+  and ship Better Auth in `packages/auth`. We keep the **on-device-first** shape (pipeline as a
+  shared package consumed by the Electron *main process*; the web/server is an **offload/sync**
+  layer, not the center) and treat `packages/auth` as **deferred + swappable** (see
+  [[0002-authentication]] — pencilled in: Logto Cloud).
+- **Legacy Python backend stays a separate repo until retired** — no need to migrate it in just to
+  delete it.
+- **Agent-context hygiene** (a real concern with monorepos): per-package `CLAUDE.md`, root agents at
+  the app/package under work, and use worktrees — so a desktop task isn't polluted by mobile/server
+  code. Monorepo gives the *option* to share; scoping stays per-task.
+
 ## Consequences
 
 - **Easier:** one language across desktop + future mobile + any backend; the auth story collapses

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -3,10 +3,14 @@
   <head>
     <meta charset="UTF-8" />
     <title>Electron</title>
-    <!-- https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP -->
+    <!-- https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP
+         connect-src must list the Neeme API origin or the renderer's fetch() is
+         blocked (CSP falls back to default-src 'self', which excludes it). Local
+         dev points at http://localhost:8000 (VITE_NEEME_API_URL). When a deployed
+         backend lands (with auth), add its https origin here. -->
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:"
+      content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self' http://localhost:8000"
     />
   </head>
 

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -1,9 +1,12 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import ApiStatus from './components/ApiStatus'
 import {
   addNote,
   getRecent,
   search as searchApi,
+  ingest,
+  getItem,
+  forgetItem,
   unwrap,
   type ItemSummary,
   type SearchHitView
@@ -11,7 +14,12 @@ import {
 
 // NOTE: the local libSQL path (`window.api.memory.*`) still exists in main/preload
 // as the deferred offline seam. These views are backend-driven for now; unifying
-// local ↔ backend storage is a separate, parked decision.
+// local ↔ backend storage is a separate, parked decision (the sync spike).
+
+// /items/{id} has no response_model on the backend yet, so the generated type is
+// `unknown`. This local shape mirrors what the handler returns (summary + full text
+// + presigned URL); it goes away once the backend adds a response model and we re-sync.
+type ItemDetail = ItemSummary & { text?: string; raw_url?: string | null }
 
 function App(): React.JSX.Element {
   const [draft, setDraft] = useState('')
@@ -20,6 +28,15 @@ function App(): React.JSX.Element {
   const [hits, setHits] = useState<SearchHitView[] | null>(null)
   const [busy, setBusy] = useState(false)
   const [error, setError] = useState<string | null>(null)
+
+  // File ingest
+  const [file, setFile] = useState<File | null>(null)
+  const [tags, setTags] = useState('')
+  const fileInputRef = useRef<HTMLInputElement>(null)
+
+  // Item detail overlay
+  const [detail, setDetail] = useState<ItemDetail | null>(null)
+  const [detailBusy, setDetailBusy] = useState(false)
 
   async function refreshRecent(): Promise<void> {
     setRecent((await unwrap(getRecent({ query: { limit: 20 } }))).items)
@@ -45,6 +62,23 @@ function App(): React.JSX.Element {
     }
   }
 
+  async function uploadFile(): Promise<void> {
+    if (!file) return
+    setBusy(true)
+    setError(null)
+    try {
+      await unwrap(ingest({ body: { file, tags: tags.trim() || undefined } }))
+      setFile(null)
+      setTags('')
+      if (fileInputRef.current) fileInputRef.current.value = ''
+      await refreshRecent()
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e))
+    } finally {
+      setBusy(false)
+    }
+  }
+
   async function runSearch(): Promise<void> {
     const q = query.trim()
     if (!q) {
@@ -62,17 +96,48 @@ function App(): React.JSX.Element {
     }
   }
 
+  async function openItem(id: string): Promise<void> {
+    setDetailBusy(true)
+    setError(null)
+    try {
+      const data = (await unwrap(getItem({ path: { item_id: id } }))) as ItemDetail
+      setDetail(data)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e))
+    } finally {
+      setDetailBusy(false)
+    }
+  }
+
+  async function forget(id: string): Promise<void> {
+    setBusy(true)
+    setError(null)
+    try {
+      await unwrap(forgetItem({ path: { item_id: id } }))
+      setDetail(null)
+      // Drop it from any visible search results, then refresh recent.
+      setHits((prev) => (prev ? prev.filter((h) => h.id !== id) : prev))
+      await refreshRecent()
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e))
+    } finally {
+      setBusy(false)
+    }
+  }
+
   return (
     <div className="min-h-screen bg-neutral-950 text-neutral-100 p-8">
       <div className="mx-auto flex max-w-xl flex-col gap-6">
         <header>
           <h1 className="text-2xl font-semibold tracking-tight">neeme</h1>
-          <p className="text-sm text-neutral-400">Capture a memory, then search across everything.</p>
+          <p className="text-sm text-neutral-400">
+            Capture a memory or a file, then search across everything.
+          </p>
         </header>
 
         <ApiStatus />
 
-        {/* Capture */}
+        {/* Capture: note */}
         <div className="flex gap-2">
           <input
             className="flex-1 rounded-md border border-neutral-700 bg-neutral-900 px-3 py-2 text-sm outline-none focus:border-indigo-500"
@@ -87,6 +152,29 @@ function App(): React.JSX.Element {
             disabled={busy}
           >
             Add
+          </button>
+        </div>
+
+        {/* Capture: file ingest */}
+        <div className="flex flex-wrap items-center gap-2">
+          <input
+            ref={fileInputRef}
+            type="file"
+            className="flex-1 text-sm text-neutral-400 file:mr-3 file:rounded-md file:border-0 file:bg-neutral-800 file:px-3 file:py-1.5 file:text-sm file:text-neutral-200 hover:file:bg-neutral-700"
+            onChange={(e) => setFile(e.target.files?.[0] ?? null)}
+          />
+          <input
+            className="w-40 rounded-md border border-neutral-700 bg-neutral-900 px-3 py-2 text-sm outline-none focus:border-indigo-500"
+            placeholder="tags (comma sep)"
+            value={tags}
+            onChange={(e) => setTags(e.target.value)}
+          />
+          <button
+            className="rounded-md bg-indigo-500 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-indigo-400 disabled:opacity-50"
+            onClick={uploadFile}
+            disabled={busy || !file}
+          >
+            Upload
           </button>
         </div>
 
@@ -110,23 +198,25 @@ function App(): React.JSX.Element {
 
         {error && <p className="text-sm text-red-400">{error}</p>}
 
-        {/* Results: search hits when a query is active, else recent items */}
+        {/* Results: search hits when a query is active, else recent items.
+            Rows are clickable → open the item detail overlay. */}
         {hits !== null ? (
           <section className="flex flex-col gap-2">
             <h2 className="text-xs font-medium uppercase tracking-wide text-neutral-500">
               Search results
             </h2>
             {hits.map((h) => (
-              <article
+              <button
                 key={h.id}
-                className="rounded-md border border-neutral-800 bg-neutral-900 px-3 py-2 text-sm"
+                onClick={() => openItem(h.id)}
+                className="rounded-md border border-neutral-800 bg-neutral-900 px-3 py-2 text-left text-sm transition-colors hover:border-neutral-700 hover:bg-neutral-800"
               >
                 <p>{h.excerpt || h.source_filename || '(no preview)'}</p>
                 <p className="mt-1 text-xs text-neutral-500">
                   score {h.score.toFixed(3)}
                   {h.content_type ? ` · ${h.content_type}` : ''}
                 </p>
-              </article>
+              </button>
             ))}
             {hits.length === 0 && (
               <p className="text-sm text-neutral-500">No matches for “{query}”.</p>
@@ -136,9 +226,10 @@ function App(): React.JSX.Element {
           <section className="flex flex-col gap-2">
             <h2 className="text-xs font-medium uppercase tracking-wide text-neutral-500">Recent</h2>
             {recent.map((m) => (
-              <article
+              <button
                 key={m.id}
-                className="rounded-md border border-neutral-800 bg-neutral-900 px-3 py-2 text-sm"
+                onClick={() => openItem(m.id)}
+                className="rounded-md border border-neutral-800 bg-neutral-900 px-3 py-2 text-left text-sm transition-colors hover:border-neutral-700 hover:bg-neutral-800"
               >
                 <p>{m.excerpt || m.source_filename}</p>
                 <p className="mt-1 flex items-center gap-2 text-xs text-neutral-500">
@@ -147,7 +238,7 @@ function App(): React.JSX.Element {
                     {m.extraction_status}
                   </span>
                 </p>
-              </article>
+              </button>
             ))}
             {recent.length === 0 && (
               <p className="text-sm text-neutral-500">No memories yet — add one above.</p>
@@ -155,6 +246,83 @@ function App(): React.JSX.Element {
           </section>
         )}
       </div>
+
+      {/* Item detail overlay */}
+      {(detail || detailBusy) && (
+        <div
+          className="fixed inset-0 z-10 flex items-start justify-center overflow-y-auto bg-black/60 p-8"
+          onClick={() => setDetail(null)}
+        >
+          <div
+            className="mt-8 w-full max-w-xl rounded-lg border border-neutral-800 bg-neutral-900 p-5 text-sm shadow-xl"
+            onClick={(e) => e.stopPropagation()}
+          >
+            {detailBusy && !detail ? (
+              <p className="text-neutral-500">Loading…</p>
+            ) : (
+              detail && (
+                <>
+                  <div className="mb-3 flex items-start justify-between gap-3">
+                    <div>
+                      <h2 className="font-medium">
+                        {detail.source_filename || detail.id.slice(0, 12)}
+                      </h2>
+                      <p className="mt-0.5 flex flex-wrap items-center gap-2 text-xs text-neutral-500">
+                        <span>{new Date(detail.created_at).toLocaleString()}</span>
+                        {detail.content_type && (
+                          <span className="rounded bg-neutral-800 px-1.5 py-0.5 text-[10px] uppercase">
+                            {detail.content_type}
+                          </span>
+                        )}
+                        {detail.tags?.map((t) => (
+                          <span
+                            key={t}
+                            className="rounded bg-neutral-800 px-1.5 py-0.5 text-[10px]"
+                          >
+                            #{t}
+                          </span>
+                        ))}
+                      </p>
+                    </div>
+                    <button
+                      onClick={() => setDetail(null)}
+                      className="rounded-md border border-neutral-700 px-2 py-1 text-xs transition-colors hover:bg-neutral-800"
+                    >
+                      Close
+                    </button>
+                  </div>
+
+                  {detail.text && (
+                    <pre className="mb-3 max-h-72 overflow-y-auto whitespace-pre-wrap rounded-md bg-neutral-950 p-3 text-xs text-neutral-300">
+                      {detail.text}
+                    </pre>
+                  )}
+
+                  <div className="flex items-center gap-3">
+                    {detail.raw_url && (
+                      <a
+                        href={detail.raw_url}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="text-xs text-indigo-400 hover:underline"
+                      >
+                        Open raw file ↗
+                      </a>
+                    )}
+                    <button
+                      onClick={() => forget(detail.id)}
+                      disabled={busy}
+                      className="ml-auto rounded-md border border-red-900/60 px-3 py-1.5 text-xs text-red-400 transition-colors hover:bg-red-950/40 disabled:opacity-50"
+                    >
+                      Forget
+                    </button>
+                  </div>
+                </>
+              )
+            )}
+          </div>
+        </div>
+      )}
     </div>
   )
 }

--- a/src/renderer/src/components/ApiStatus.tsx
+++ b/src/renderer/src/components/ApiStatus.tsx
@@ -2,15 +2,12 @@ import { useEffect, useState } from 'react'
 import { getHealth } from '../../../shared/api'
 
 type Health = { status?: string; backends?: Record<string, boolean> }
-type State =
-  | { kind: 'loading' }
-  | { kind: 'ok'; data: Health }
-  | { kind: 'error'; message: string }
+type State = { kind: 'loading' } | { kind: 'ok'; data: Health } | { kind: 'error'; message: string }
 
 /**
  * Smoke test of the typed HTTP client: calls GET /health on the Neeme API and
  * renders the result. Proves the renderer → FastAPI round-trip end-to-end.
- * Start the backend with: cd mr-matcha && pip install -e ".[api]" && neeme serve
+ * Start the backend with: cd neeme && uv run python -m uvicorn neeme.api:app
  */
 function ApiStatus(): React.JSX.Element {
   const [state, setState] = useState<State>({ kind: 'loading' })
@@ -37,7 +34,7 @@ function ApiStatus(): React.JSX.Element {
       </div>
       {state.kind === 'error' && (
         <p className="text-xs text-neutral-500">
-          {state.message} — is the backend running? (<code>neeme serve</code>)
+          {state.message} — is the backend running? (<code>uvicorn neeme.api:app</code>)
         </p>
       )}
       {state.kind === 'ok' && state.data.backends && (


### PR DESCRIPTION
## What's here

Two things: the **working backend integration** (code), and **two ADRs** that capture the architecture direction this session surfaced — the ADRs are the part to review/discuss.

### 📄 ADRs to review (status: **Proposed** — want your input)

- **[`docs/adr/0002-authentication.md`](docs/adr/0002-authentication.md)** — Auth = a **managed third-party provider**, **deferred behind sync** (the local-first app needs no login). Leaning **Logto Cloud** (Auth0 = safe pricier fallback; Clerk weak on Electron; self-hosting ruled out). Key point: no provider has a real Electron SDK, so desktop auth is the same OIDC + PKCE + system-browser flow everywhere → the choice is **swappable**. Verified Logto's "Native app" (public client + PKCE) covers Electron cleanly and it has first-class Expo/RN.
- **[`docs/adr/0003-all-typescript-on-device-pipeline.md`](docs/adr/0003-all-typescript-on-device-pipeline.md)** — Go **all-TypeScript** and move the pipeline **on-device into the Electron main process**; cloud demotes to optional **offload + sync**. Rationale: the Python backend is ~2.8k LOC of cloud glue with **no real local ML yet** (FakeEmbedder; zero torch/transformers), every dep has a TS equivalent, **libSQL already ships native vector search**, and bundling Python into Electron is the harder path. Includes the **Rust escape-hatch** policy (napi-rs/WASM behind a profiled bottleneck) and the **repo strategy** (Turborepo monorepo; **this repo → `apps/desktop`**, aligned with the `create-t3-turbo` skeleton; legacy Python backend stays separate until retired).

**Specifically want your take on:** retiring Python, the monorepo shape (this repo as `apps/desktop`), and the eventual `user_id` data-scoping migration (items/todos are currently global).

### 💻 Code in this PR (already verified end-to-end vs the live backend)

- `fix`: CSP `connect-src` so the renderer can actually reach the API (was silently blocking all calls).
- `feat`: file ingest + item detail/forget in the cataloging UI.
- (env cleanup: desktop reads only `VITE_NEEME_API_URL`; gitignored, no diff.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)