### PR TITLE
Logto auth scaffold (Electron OIDC + PKCE, inert until configured)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,11 @@
 # Base URL of the Neeme HTTP API (the FastAPI backend in mr-matcha).
 # Defaults to http://localhost:8000 if unset. Copy this file to `.env`.
 VITE_NEEME_API_URL=http://localhost:8000
+
+# --- Logto auth (OPTIONAL, main process) ---
+# Auth is deferred behind sync; leave blank and the app runs unauthenticated.
+# To enable: create a Logto "Native app", set redirect URI neeme://callback,
+# and fill these in. See docs/auth-logto-setup.md.
+# MAIN_VITE_LOGTO_ENDPOINT=https://your-tenant.logto.app
+# MAIN_VITE_LOGTO_APP_ID=your-native-app-id
+# MAIN_VITE_LOGTO_RESOURCE=https://api.neeme.app

--- a/docs/auth-logto-setup.md
+++ b/docs/auth-logto-setup.md
@@ -1,0 +1,41 @@
+# Logto auth — setup
+
+> Status: **scaffolded, deferred.** The flow is wired end-to-end but **inert until
+> configured** — the local-first app needs no login. Auth only matters once cloud
+> sync/accounts land (see [docs/adr/0002-authentication.md](adr/0002-authentication.md)).
+
+## What's implemented
+
+- **Main process** (`src/main/auth/logto.ts`): OIDC Authorization Code + PKCE in the
+  **system browser**, custom-scheme redirect `neeme://callback`, token exchange + refresh,
+  refresh token sealed via Electron `safeStorage`. Inert when unconfigured.
+- **IPC** (`src/shared/ipc.ts`, `src/preload`): `window.api.auth.{login,logout,getAccessToken,getState,onChanged}`.
+- **Renderer** (`src/renderer/src/hooks/useAuth.ts`): hydrates the API client's bearer token
+  (`src/shared/api/token-store.ts` → `runtime.ts` `getToken()` seam) and shows a Sign in/out
+  control in the header. No CSP change needed — the renderer never calls Logto.
+
+## To turn it on
+
+1. **Logto Cloud** → create a project → **Create application → "Native app"** (public client, PKCE).
+2. Set the **Redirect URI** to `neeme://callback` (and add a Post sign-out redirect if you want).
+3. Copy the tenant **endpoint** and **App ID** into `.env` (main-process, `MAIN_VITE_` prefix):
+
+   ```
+   MAIN_VITE_LOGTO_ENDPOINT=https://<your-tenant>.logto.app
+   MAIN_VITE_LOGTO_APP_ID=<your-native-app-id>
+   # Optional: scope the access token to your API resource indicator
+   # MAIN_VITE_LOGTO_RESOURCE=https://api.neeme.app
+   ```
+
+4. Restart `pnpm dev`. A **Sign in** button appears once `configured` is true.
+
+## Caveats
+
+- **Custom-scheme deep link (`neeme://`)** registers reliably in a **packaged** build. In `pnpm dev`
+  on macOS the `open-url` event usually still fires; on Windows/Linux deep links rely on the
+  single-instance lock + argv parsing (already wired). If dev redirects don't return, test in a
+  packaged build or switch the redirect to a loopback (`http://127.0.0.1:<port>/callback`).
+- The `id_token` is decoded for display claims only (not signature-verified client-side). The
+  **backend** is the trust boundary: it verifies the access token against Logto's **JWKS**. Harden
+  with a JWKS check or `openid-client` if this graduates past a scaffold.
+- Backend `user_id` data-scoping (items/todos are currently global) is separate work — see ADR 0002.

--- a/src/main/auth/logto.ts
+++ b/src/main/auth/logto.ts
@@ -1,0 +1,247 @@
+/**
+ * Logto authentication for the Electron desktop client (main process).
+ *
+ * Logto is a standard OIDC provider, so this is a textbook native-app flow —
+ * Authorization Code + PKCE in the *system browser*, with a custom-scheme
+ * redirect (`neeme://callback`). No Logto SDK needed; we drive the discovered
+ * OIDC endpoints directly. Running it in main (not the renderer) means:
+ *   - credentials only ever live in the user's real browser,
+ *   - the refresh token is sealed in the OS keychain via `safeStorage`,
+ *   - only the short-lived access token is handed to the renderer for requests,
+ *   - and the renderer needs no CSP changes (it never talks to Logto).
+ *
+ * Inert until configured: with no MAIN_VITE_LOGTO_ENDPOINT / _APP_ID, every
+ * entry point no-ops or throws a friendly error, and the app stays unauthenticated
+ * (local-first; auth is deferred behind sync — see docs/adr/0002-authentication.md).
+ *
+ * NOTE: the access token is consumed by our own backend, which verifies it via
+ * Logto's JWKS. We intentionally don't cryptographically validate the id_token
+ * here (it's used only for display claims); harden with a JWKS check or swap in
+ * `openid-client` if this graduates past a scaffold.
+ */
+import { app, safeStorage, shell } from 'electron'
+import { createHash, randomBytes } from 'node:crypto'
+import { readFile, writeFile, rm } from 'node:fs/promises'
+import { join } from 'node:path'
+import type { AuthClaims, AuthState } from '../../shared/ipc'
+
+const REDIRECT_URI = 'neeme://callback'
+const SCOPE = 'openid profile offline_access'
+
+type Listener = (state: AuthState, accessToken?: string) => void
+
+interface OidcConfig {
+  authorization_endpoint: string
+  token_endpoint: string
+  end_session_endpoint?: string
+}
+interface TokenResponse {
+  access_token: string
+  refresh_token?: string
+  id_token?: string
+  expires_in?: number
+}
+interface Session {
+  accessToken: string
+  refreshToken?: string
+  expiresAt: number // epoch ms
+  claims: AuthClaims | null
+}
+
+const endpoint = (import.meta.env.MAIN_VITE_LOGTO_ENDPOINT ?? '').replace(/\/+$/, '')
+const appId = import.meta.env.MAIN_VITE_LOGTO_APP_ID ?? ''
+const resource = import.meta.env.MAIN_VITE_LOGTO_RESOURCE || undefined
+
+let discovery: OidcConfig | null = null
+let session: Session | null = null
+let pending: { verifier: string; state: string } | null = null
+let listener: Listener | null = null
+
+export function isConfigured(): boolean {
+  return Boolean(endpoint && appId)
+}
+
+function base64url(buf: Buffer): string {
+  return buf.toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+}
+
+function decodeClaims(idToken?: string): AuthClaims | null {
+  if (!idToken) return null
+  try {
+    const json = Buffer.from(
+      idToken.split('.')[1].replace(/-/g, '+').replace(/_/g, '/'),
+      'base64'
+    ).toString('utf8')
+    const c = JSON.parse(json) as Record<string, string>
+    return { sub: c.sub, email: c.email, name: c.name, picture: c.picture }
+  } catch {
+    return null
+  }
+}
+
+function sessionFile(): string {
+  return join(app.getPath('userData'), 'neeme-auth.bin')
+}
+
+async function persist(): Promise<void> {
+  if (!session?.refreshToken) {
+    await rm(sessionFile(), { force: true }).catch(() => {})
+    return
+  }
+  // Only the refresh token + display claims are persisted; access tokens stay in memory.
+  const plain = JSON.stringify({ refreshToken: session.refreshToken, claims: session.claims })
+  const blob = safeStorage.isEncryptionAvailable()
+    ? safeStorage.encryptString(plain)
+    : Buffer.from(plain, 'utf8') // fallback (e.g. Linux w/o keyring); still inside userData
+  await writeFile(sessionFile(), blob)
+}
+
+async function discover(): Promise<OidcConfig> {
+  if (discovery) return discovery
+  const res = await fetch(`${endpoint}/oidc/.well-known/openid-configuration`)
+  if (!res.ok) throw new Error(`Logto OIDC discovery failed (HTTP ${res.status})`)
+  discovery = (await res.json()) as OidcConfig
+  return discovery
+}
+
+async function exchange(body: URLSearchParams): Promise<void> {
+  const cfg = await discover()
+  if (resource) body.set('resource', resource)
+  const res = await fetch(cfg.token_endpoint, {
+    method: 'POST',
+    headers: { 'content-type': 'application/x-www-form-urlencoded' },
+    body
+  })
+  if (!res.ok) throw new Error(`Logto token request failed (HTTP ${res.status})`)
+  const t = (await res.json()) as TokenResponse
+  session = {
+    accessToken: t.access_token,
+    refreshToken: t.refresh_token ?? session?.refreshToken,
+    expiresAt: Date.now() + (t.expires_in ?? 3600) * 1000,
+    claims: decodeClaims(t.id_token) ?? session?.claims ?? null
+  }
+  await persist()
+  emit()
+}
+
+async function refresh(): Promise<void> {
+  if (!session?.refreshToken) throw new Error('no refresh token')
+  await exchange(
+    new URLSearchParams({
+      grant_type: 'refresh_token',
+      refresh_token: session.refreshToken,
+      client_id: appId
+    })
+  )
+}
+
+/** Kick off interactive login by opening the system browser to Logto. */
+export async function startLogin(): Promise<void> {
+  if (!isConfigured()) {
+    throw new Error(
+      'Logto is not configured (set MAIN_VITE_LOGTO_ENDPOINT and MAIN_VITE_LOGTO_APP_ID).'
+    )
+  }
+  const cfg = await discover()
+  const verifier = base64url(randomBytes(32))
+  const challenge = base64url(createHash('sha256').update(verifier).digest())
+  const state = base64url(randomBytes(16))
+  pending = { verifier, state }
+
+  const url = new URL(cfg.authorization_endpoint)
+  url.searchParams.set('client_id', appId)
+  url.searchParams.set('redirect_uri', REDIRECT_URI)
+  url.searchParams.set('response_type', 'code')
+  url.searchParams.set('scope', SCOPE)
+  url.searchParams.set('code_challenge', challenge)
+  url.searchParams.set('code_challenge_method', 'S256')
+  url.searchParams.set('state', state)
+  url.searchParams.set('prompt', 'consent')
+  if (resource) url.searchParams.set('resource', resource)
+  await shell.openExternal(url.toString())
+}
+
+/** Handle the `neeme://callback?code=...&state=...` deep link from the browser. */
+export async function handleCallback(callbackUrl: string): Promise<void> {
+  if (!pending) return
+  const u = new URL(callbackUrl)
+  const code = u.searchParams.get('code')
+  const state = u.searchParams.get('state')
+  const expected = pending
+  pending = null
+  if (!code || state !== expected.state) {
+    throw new Error('Logto callback: missing code or state mismatch')
+  }
+  await exchange(
+    new URLSearchParams({
+      grant_type: 'authorization_code',
+      code,
+      redirect_uri: REDIRECT_URI,
+      client_id: appId,
+      code_verifier: expected.verifier
+    })
+  )
+}
+
+/** Return a valid access token, refreshing if near expiry. `undefined` if signed out. */
+export async function getAccessToken(): Promise<string | undefined> {
+  if (!session) return undefined
+  if (session.accessToken && Date.now() < session.expiresAt - 60_000) return session.accessToken
+  try {
+    await refresh()
+    return session?.accessToken
+  } catch {
+    session = null
+    await persist()
+    emit()
+    return undefined
+  }
+}
+
+export async function logout(): Promise<void> {
+  session = null
+  await persist()
+  emit()
+}
+
+export function getState(): AuthState {
+  return {
+    configured: isConfigured(),
+    isAuthenticated: Boolean(session),
+    claims: session?.claims ?? null
+  }
+}
+
+/** Register the single listener (main broadcasts changes to the renderer). */
+export function onChange(cb: Listener): void {
+  listener = cb
+}
+
+function emit(): void {
+  listener?.(getState(), session?.accessToken)
+}
+
+/** Restore a persisted session on startup (silent refresh). Safe when unconfigured. */
+export async function init(): Promise<void> {
+  if (!isConfigured()) return
+  try {
+    const blob = await readFile(sessionFile())
+    const plain = safeStorage.isEncryptionAvailable()
+      ? safeStorage.decryptString(blob)
+      : blob.toString('utf8')
+    const parsed = JSON.parse(plain) as { refreshToken?: string; claims?: AuthClaims | null }
+    if (parsed.refreshToken) {
+      session = {
+        accessToken: '',
+        refreshToken: parsed.refreshToken,
+        expiresAt: 0,
+        claims: parsed.claims ?? null
+      }
+      await refresh().catch(() => {
+        session = null
+      })
+    }
+  } catch {
+    /* no stored session */
+  }
+}

--- a/src/main/env.d.ts
+++ b/src/main/env.d.ts
@@ -1,0 +1,15 @@
+/// <reference types="electron-vite/node" />
+
+/**
+ * Main-process env vars (electron-vite exposes only `MAIN_VITE_`-prefixed keys
+ * on `import.meta.env`). Augments the base ImportMetaEnv from electron-vite/node.
+ * Logto config is read here, not in the renderer — the OAuth flow runs in main.
+ */
+interface ImportMetaEnv {
+  /** Logto tenant endpoint, e.g. https://xxxx.logto.app */
+  readonly MAIN_VITE_LOGTO_ENDPOINT?: string
+  /** Logto "Native app" application ID (public client, PKCE). */
+  readonly MAIN_VITE_LOGTO_APP_ID?: string
+  /** Optional API resource indicator the access token should be scoped to. */
+  readonly MAIN_VITE_LOGTO_RESOURCE?: string
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -4,7 +4,36 @@ import { electronApp, optimizer, is } from '@electron-toolkit/utils'
 import icon from '../../resources/icon.png?asset'
 import { initDb } from './db'
 import { memoryService } from './services/memory-service'
+import * as auth from './auth/logto'
 import { IPC } from '../shared/ipc'
+
+// Register `neeme://` as the OAuth callback scheme. In dev (electron launched
+// with a script arg) we must pass execPath + the project dir so the OS routes
+// the deep link back to this instance.
+if (process.defaultApp && process.argv.length >= 2) {
+  app.setAsDefaultProtocolClient('neeme', process.execPath, [join(__dirname, '../..')])
+} else {
+  app.setAsDefaultProtocolClient('neeme')
+}
+
+// Single-instance lock so Windows/Linux deep links reach the already-running app.
+if (!app.requestSingleInstanceLock()) {
+  app.quit()
+}
+app.on('second-instance', (_event, argv) => {
+  const url = argv.find((a) => a.startsWith('neeme://'))
+  if (url) auth.handleCallback(url).catch((e) => console.error('auth callback failed', e))
+  const win = BrowserWindow.getAllWindows()[0]
+  if (win) {
+    if (win.isMinimized()) win.restore()
+    win.focus()
+  }
+})
+// macOS delivers the deep link via open-url.
+app.on('open-url', (event, url) => {
+  event.preventDefault()
+  auth.handleCallback(url).catch((e) => console.error('auth callback failed', e))
+})
 
 function createWindow(): void {
   // Create the browser window.
@@ -59,6 +88,19 @@ app.whenReady().then(async () => {
   await initDb()
   ipcMain.handle(IPC.memoryList, () => memoryService.list())
   ipcMain.handle(IPC.memoryAdd, (_event, content: string) => memoryService.add(content))
+
+  // Auth (Logto) — broadcast changes to renderers, restore any saved session,
+  // then expose login/logout/token over IPC. Inert until Logto env is configured.
+  auth.onChange((state, accessToken) => {
+    for (const win of BrowserWindow.getAllWindows()) {
+      win.webContents.send(IPC.authChanged, { state, accessToken })
+    }
+  })
+  await auth.init()
+  ipcMain.handle(IPC.authLogin, () => auth.startLogin())
+  ipcMain.handle(IPC.authLogout, () => auth.logout())
+  ipcMain.handle(IPC.authGetToken, () => auth.getAccessToken())
+  ipcMain.handle(IPC.authGetState, () => auth.getState())
 
   createWindow()
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1,12 +1,26 @@
-import { contextBridge, ipcRenderer } from 'electron'
+import { contextBridge, ipcRenderer, type IpcRendererEvent } from 'electron'
 import { electronAPI } from '@electron-toolkit/preload'
-import { IPC, type NeemeApi } from '../shared/ipc'
+import { IPC, type AuthState, type NeemeApi } from '../shared/ipc'
 
 // Custom APIs for renderer — the only data surface the renderer can reach.
 const api: NeemeApi = {
   memory: {
     list: () => ipcRenderer.invoke(IPC.memoryList),
     add: (content: string) => ipcRenderer.invoke(IPC.memoryAdd, content)
+  },
+  auth: {
+    login: () => ipcRenderer.invoke(IPC.authLogin),
+    logout: () => ipcRenderer.invoke(IPC.authLogout),
+    getAccessToken: () => ipcRenderer.invoke(IPC.authGetToken),
+    getState: () => ipcRenderer.invoke(IPC.authGetState),
+    onChanged: (cb) => {
+      const handler = (
+        _e: IpcRendererEvent,
+        payload: { state: AuthState; accessToken?: string }
+      ): void => cb(payload.state, payload.accessToken)
+      ipcRenderer.on(IPC.authChanged, handler)
+      return () => ipcRenderer.removeListener(IPC.authChanged, handler)
+    }
   }
 }
 

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react'
 import ApiStatus from './components/ApiStatus'
+import { useAuth } from './hooks/useAuth'
 import {
   addNote,
   getRecent,
@@ -37,6 +38,8 @@ function App(): React.JSX.Element {
   // Item detail overlay
   const [detail, setDetail] = useState<ItemDetail | null>(null)
   const [detailBusy, setDetailBusy] = useState(false)
+
+  const auth = useAuth()
 
   async function refreshRecent(): Promise<void> {
     setRecent((await unwrap(getRecent({ query: { limit: 20 } }))).items)
@@ -128,11 +131,36 @@ function App(): React.JSX.Element {
   return (
     <div className="min-h-screen bg-neutral-950 text-neutral-100 p-8">
       <div className="mx-auto flex max-w-xl flex-col gap-6">
-        <header>
-          <h1 className="text-2xl font-semibold tracking-tight">neeme</h1>
-          <p className="text-sm text-neutral-400">
-            Capture a memory or a file, then search across everything.
-          </p>
+        <header className="flex items-start justify-between gap-3">
+          <div>
+            <h1 className="text-2xl font-semibold tracking-tight">neeme</h1>
+            <p className="text-sm text-neutral-400">
+              Capture a memory or a file, then search across everything.
+            </p>
+          </div>
+          {/* Auth control — only shown once Logto is configured (auth is deferred,
+              so unconfigured installs show nothing here). */}
+          {auth.state.configured &&
+            (auth.state.isAuthenticated ? (
+              <div className="flex shrink-0 items-center gap-2 text-xs">
+                <span className="text-neutral-400">
+                  {auth.state.claims?.email ?? auth.state.claims?.name ?? 'signed in'}
+                </span>
+                <button
+                  onClick={auth.logout}
+                  className="rounded-md border border-neutral-700 px-2 py-1 transition-colors hover:bg-neutral-800"
+                >
+                  Sign out
+                </button>
+              </div>
+            ) : (
+              <button
+                onClick={auth.login}
+                className="shrink-0 rounded-md bg-indigo-500 px-3 py-1.5 text-xs font-medium text-white transition-colors hover:bg-indigo-400"
+              >
+                Sign in
+              </button>
+            ))}
         </header>
 
         <ApiStatus />

--- a/src/renderer/src/hooks/useAuth.ts
+++ b/src/renderer/src/hooks/useAuth.ts
@@ -1,0 +1,41 @@
+import { useEffect, useState } from 'react'
+import { setToken, clearToken } from '../../../shared/api/token-store'
+import type { AuthState } from '../../../shared/ipc'
+
+const EMPTY: AuthState = { configured: false, isAuthenticated: false, claims: null }
+
+/**
+ * Bridges the renderer to the main-process Logto flow. On mount it hydrates the
+ * API client's token (via `token-store`) and the auth state from main, then
+ * subscribes to changes (login / refresh / logout) so the bearer token the HTTP
+ * client attaches stays current. Login/logout just delegate to main over IPC.
+ */
+export function useAuth(): { state: AuthState; login: () => void; logout: () => void } {
+  const [state, setState] = useState<AuthState>(EMPTY)
+
+  useEffect(() => {
+    let active = true
+    window.api.auth.getState().then((s) => active && setState(s))
+    window.api.auth.getAccessToken().then((t) => {
+      if (!active) return
+      if (t) setToken(t)
+      else clearToken()
+    })
+    const unsubscribe = window.api.auth.onChanged((s, accessToken) => {
+      if (!active) return
+      setState(s)
+      if (accessToken) setToken(accessToken)
+      else if (!s.isAuthenticated) clearToken()
+    })
+    return () => {
+      active = false
+      unsubscribe()
+    }
+  }, [])
+
+  return {
+    state,
+    login: () => void window.api.auth.login().catch((e) => console.error('login failed', e)),
+    logout: () => void window.api.auth.logout().catch((e) => console.error('logout failed', e))
+  }
+}

--- a/src/shared/api/runtime.ts
+++ b/src/shared/api/runtime.ts
@@ -1,4 +1,5 @@
 import type { CreateClientConfig } from './generated/client.gen'
+import { getToken } from './token-store'
 
 /**
  * Runtime configuration for the generated Neeme API client.
@@ -12,16 +13,9 @@ export const createClientConfig: CreateClientConfig = (config) => ({
   ...config,
   // Base URL from env; defaults to the local `neeme serve` address.
   baseUrl: import.meta.env.VITE_NEEME_API_URL ?? 'http://localhost:8000',
-  // Auth seam: returns the bearer token once auth exists. `undefined` today
-  // means no Authorization header is attached — wired now, no rework later.
-  auth: () => getAuthToken()
+  // Auth seam: hey-api calls `auth` per request, so the token can be hydrated
+  // lazily. `token-store` holds the bearer in memory, populated over IPC from the
+  // main-process Logto flow (`src/main/auth/logto.ts`). `undefined` today (no
+  // login) means no Authorization header — the local-first app stays unauthenticated.
+  auth: () => getToken()
 })
-
-/**
- * Placeholder token source. Returns `undefined` until auth/identity is built.
- * When tokens land, read from wherever they're stored (e.g. an in-memory store
- * hydrated over IPC from Electron `safeStorage`) and return the bearer string.
- */
-function getAuthToken(): string | undefined {
-  return undefined
-}

--- a/src/shared/api/token-store.ts
+++ b/src/shared/api/token-store.ts
@@ -1,0 +1,28 @@
+/**
+ * In-memory bearer-token holder for the API client's auth seam.
+ *
+ * No Electron/Node imports — this module works unchanged in the renderer, in
+ * React Native / Expo, and in tests. The renderer hydrates it over IPC from the
+ * main process, which runs the Logto OIDC flow and holds the real tokens in the
+ * OS keychain (`safeStorage`). The generated HTTP client reads `getToken()`
+ * lazily per request via `runtime.ts`, so a late `setToken()` (login / refresh)
+ * takes effect with no client re-init.
+ *
+ * Today, with no Logto config, nothing calls `setToken()`, so `getToken()`
+ * returns `undefined` and no Authorization header is attached — the app works
+ * fully unauthenticated (local-first; auth is deferred behind sync, see
+ * docs/adr/0002-authentication.md).
+ */
+let current: string | undefined
+
+export function getToken(): string | undefined {
+  return current
+}
+
+export function setToken(token: string | undefined): void {
+  current = token
+}
+
+export function clearToken(): void {
+  current = undefined
+}

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -12,8 +12,30 @@ export interface Memory {
 
 export const IPC = {
   memoryList: 'memory:list',
-  memoryAdd: 'memory:add'
+  memoryAdd: 'memory:add',
+  // Auth (Logto OIDC flow lives in main; see src/main/auth/logto.ts)
+  authLogin: 'auth:login',
+  authLogout: 'auth:logout',
+  authGetToken: 'auth:get-token',
+  authGetState: 'auth:get-state',
+  /** main → renderer event: auth state / token changed (login, refresh, logout). */
+  authChanged: 'auth:changed'
 } as const
+
+/** Identity claims decoded from the id_token (display only). */
+export interface AuthClaims {
+  sub: string
+  email?: string
+  name?: string
+  picture?: string
+}
+
+/** Auth state surfaced to the renderer. `configured` is false until Logto env is set. */
+export interface AuthState {
+  configured: boolean
+  isAuthenticated: boolean
+  claims: AuthClaims | null
+}
 
 /** The API surface exposed on `window.api`. */
 export interface MemoryApi {
@@ -21,6 +43,20 @@ export interface MemoryApi {
   add: (content: string) => Promise<Memory>
 }
 
+export interface AuthApi {
+  /** Open the system browser to sign in (OIDC + PKCE). */
+  login: () => Promise<void>
+  /** Clear the local session. */
+  logout: () => Promise<void>
+  /** Current access token (refreshed if near expiry), or undefined if signed out. */
+  getAccessToken: () => Promise<string | undefined>
+  /** Snapshot of auth state. */
+  getState: () => Promise<AuthState>
+  /** Subscribe to auth changes; returns an unsubscribe fn. */
+  onChanged: (cb: (state: AuthState, accessToken?: string) => void) => () => void
+}
+
 export interface NeemeApi {
   memory: MemoryApi
+  auth: AuthApi
 }


### PR DESCRIPTION
Follow-up to #5 (which merged before this commit landed). Adds the **Logto auth scaffold** — wired end-to-end but **dormant until configured** (auth is deferred behind sync per ADR 0002; the local-first app needs no login).

- `src/main/auth/logto.ts` — OIDC Authorization Code + PKCE in the system browser, `neeme://callback`, token exchange + refresh, refresh token sealed via `safeStorage`. Inert without `MAIN_VITE_LOGTO_ENDPOINT`/`_APP_ID`.
- `src/main/index.ts` — `neeme://` protocol registration, single-instance lock + deep-link handling, auth IPC handlers + change broadcast.
- `src/shared/api/{token-store,runtime}.ts` — in-memory bearer seam (renderer-safe; client reads it lazily per request).
- `src/shared/ipc.ts` + preload — `window.api.auth.{login,logout,getAccessToken,getState,onChanged}`.
- `src/renderer/.../useAuth.ts` + App header — hydrate token from main; Sign in/out shown only when configured.
- `docs/auth-logto-setup.md` — how to turn it on.

Flow runs in **main**, so no renderer CSP changes and tokens stay out of the renderer except the short-lived access token. Verified: typecheck (node + web) clean, app boots inert with no Logto env.

🤖 Generated with [Claude Code](https://claude.com/claude-code)