### PR TITLE
feat: on-device pipeline + daily-focus todos in the main process

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "@electron-toolkit/utils": "^4.0.0",
     "@libsql/client": "^0.17.3",
     "drizzle-orm": "^0.44.7",
-    "electron-updater": "^6.3.9"
+    "electron-updater": "^6.3.9",
+    "unpdf": "^1.6.2"
   },
   "devDependencies": {
     "@electron-toolkit/eslint-config-prettier": "^3.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       electron-updater:
         specifier: ^6.3.9
         version: 6.8.3
+      unpdf:
+        specifier: ^1.6.2
+        version: 1.6.2
     devDependencies:
       '@electron-toolkit/eslint-config-prettier':
         specifier: ^3.0.0
@@ -3410,6 +3413,14 @@ packages:
   universalify@2.0.1:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
     engines: {node: '>= 10.0.0'}
+
+  unpdf@1.6.2:
+    resolution: {integrity: sha512-zQ80ySoPuPHOsvIoRp/nJyQt8TOUoTh1+WBCGcBvlddQNgKDLRwm0AY3x8Q35I7+kIiRSgqMx+Ma2pl9McIp7A==}
+    peerDependencies:
+      '@napi-rs/canvas': ^0.1.69
+    peerDependenciesMeta:
+      '@napi-rs/canvas':
+        optional: true
 
   update-browserslist-db@1.2.3:
     resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
@@ -7042,6 +7053,8 @@ snapshots:
   universalify@0.1.2: {}
 
   universalify@2.0.1: {}
+
+  unpdf@1.6.2: {}
 
   update-browserslist-db@1.2.3(browserslist@4.28.2):
     dependencies:

--- a/src/main/db/index.ts
+++ b/src/main/db/index.ts
@@ -15,20 +15,44 @@ import * as schema from './schema'
  */
 const dbPath = join(app.getPath('userData'), 'neeme.db')
 
-const client = createClient({ url: `file:${dbPath}` })
+// Exported so the pipeline can use libSQL's native vector functions
+// (vector32 / vector_distance_cos / libsql_vector_idx) via raw SQL — Drizzle's
+// query builder doesn't model the F32_BLOB type.
+export const client = createClient({ url: `file:${dbPath}` })
 
 export const db = drizzle(client, { schema })
+
+/** Embedding dimension for the chunk vector column (matches the embedder seam). */
+export const EMBED_DIM = 384
 
 /**
  * Bootstrap the schema. For the first slice we create tables directly; once the
  * schema stabilizes we switch to drizzle-kit generated migrations applied here.
  */
 export async function initDb(): Promise<void> {
-  await client.execute(`
+  await client.executeMultiple(`
     CREATE TABLE IF NOT EXISTS memories (
       id TEXT PRIMARY KEY,
       content TEXT NOT NULL,
       created_at INTEGER NOT NULL DEFAULT (unixepoch())
     );
+    CREATE TABLE IF NOT EXISTS items (
+      id TEXT PRIMARY KEY,
+      source_name TEXT NOT NULL,
+      content_type TEXT NOT NULL,
+      size_bytes INTEGER NOT NULL,
+      stored_path TEXT,
+      text TEXT NOT NULL DEFAULT '',
+      status TEXT NOT NULL,
+      created_at INTEGER NOT NULL DEFAULT (unixepoch())
+    );
+    CREATE TABLE IF NOT EXISTS chunks (
+      item_id TEXT NOT NULL REFERENCES items(id) ON DELETE CASCADE,
+      chunk_idx INTEGER NOT NULL,
+      text TEXT NOT NULL,
+      embedding F32_BLOB(${EMBED_DIM}),
+      PRIMARY KEY (item_id, chunk_idx)
+    );
+    CREATE INDEX IF NOT EXISTS chunks_vec_idx ON chunks (libsql_vector_idx(embedding));
   `)
 }

--- a/src/main/db/index.ts
+++ b/src/main/db/index.ts
@@ -54,5 +54,29 @@ export async function initDb(): Promise<void> {
       PRIMARY KEY (item_id, chunk_idx)
     );
     CREATE INDEX IF NOT EXISTS chunks_vec_idx ON chunks (libsql_vector_idx(embedding));
+    CREATE TABLE IF NOT EXISTS todos (
+      id TEXT PRIMARY KEY,
+      title TEXT NOT NULL,
+      notes TEXT,
+      status TEXT NOT NULL DEFAULT 'open',
+      day TEXT,
+      position INTEGER NOT NULL DEFAULT 0,
+      created_at INTEGER NOT NULL DEFAULT (unixepoch()),
+      completed_at INTEGER
+    );
+    CREATE INDEX IF NOT EXISTS todos_day_idx ON todos (day, position);
+    CREATE TABLE IF NOT EXISTS todo_context (
+      todo_id TEXT NOT NULL REFERENCES todos(id) ON DELETE CASCADE,
+      item_id TEXT NOT NULL,
+      score REAL,
+      source_name TEXT,
+      content_type TEXT,
+      excerpt TEXT,
+      state TEXT NOT NULL DEFAULT 'surfaced',
+      first_surfaced_at INTEGER NOT NULL DEFAULT (unixepoch()),
+      last_surfaced_at INTEGER NOT NULL DEFAULT (unixepoch()),
+      PRIMARY KEY (todo_id, item_id)
+    );
+    CREATE INDEX IF NOT EXISTS todo_context_idx ON todo_context (todo_id, state);
   `)
 }

--- a/src/main/db/schema.ts
+++ b/src/main/db/schema.ts
@@ -21,3 +21,26 @@ export const memories = sqliteTable('memories', {
 
 export type Memory = typeof memories.$inferSelect
 export type NewMemory = typeof memories.$inferInsert
+
+/**
+ * `items` — captured multi-modal input, content-addressed by sha256. The richer
+ * model the note above anticipated: provenance (source name/type), the
+ * normalized `text`, and an extraction `status`. The vector index lives in a
+ * separate `chunks` table (created in db/index.ts — it uses libSQL's native
+ * F32_BLOB type, so it's managed via raw SQL rather than the Drizzle schema).
+ */
+export const items = sqliteTable('items', {
+  id: text('id').primaryKey(), // sha256 of the raw bytes
+  sourceName: text('source_name').notNull(),
+  contentType: text('content_type').notNull(), // text | pdf | image | audio | other
+  sizeBytes: integer('size_bytes').notNull(),
+  storedPath: text('stored_path'),
+  text: text('text').notNull().default(''),
+  status: text('status').notNull(), // captured | extracted | pending | failed
+  createdAt: integer('created_at', { mode: 'timestamp' })
+    .notNull()
+    .default(sql`(unixepoch())`)
+})
+
+export type Item = typeof items.$inferSelect
+export type NewItem = typeof items.$inferInsert

--- a/src/main/db/schema.ts
+++ b/src/main/db/schema.ts
@@ -1,5 +1,5 @@
 import { sql } from 'drizzle-orm'
-import { sqliteTable, text, integer } from 'drizzle-orm/sqlite-core'
+import { sqliteTable, text, integer, real } from 'drizzle-orm/sqlite-core'
 
 /**
  * `memories` — the atomic unit of neeme's local store.
@@ -44,3 +44,49 @@ export const items = sqliteTable('items', {
 
 export type Item = typeof items.$inferSelect
 export type NewItem = typeof items.$inferInsert
+
+/**
+ * `todos` — the daily focus list (cap 5). `day` is the ISO date the item lives
+ * on; NULL = backlog (unscheduled). Done items keep their `day` as a record.
+ * (The Python/neeme-mono cap+plan model.)
+ */
+export const todos = sqliteTable('todos', {
+  id: text('id')
+    .primaryKey()
+    .$defaultFn(() => crypto.randomUUID()),
+  title: text('title').notNull(),
+  notes: text('notes'),
+  status: text('status').notNull().default('open'), // open | done
+  day: text('day'), // ISO date; NULL = backlog
+  position: integer('position').notNull().default(0),
+  createdAt: integer('created_at', { mode: 'timestamp' })
+    .notNull()
+    .default(sql`(unixepoch())`),
+  completedAt: integer('completed_at', { mode: 'timestamp' })
+})
+
+export type Todo = typeof todos.$inferSelect
+export type NewTodo = typeof todos.$inferInsert
+
+/**
+ * `todoContext` — each todo's persistent, additive pool of surfaced memories
+ * (from semantic search over `items`). Denormalized so the UI renders without a
+ * re-search; `state` is the user's pin/dismiss verdict (a search-quality signal).
+ */
+export const todoContext = sqliteTable('todo_context', {
+  todoId: text('todo_id').notNull(),
+  itemId: text('item_id').notNull(),
+  score: real('score'),
+  sourceName: text('source_name'),
+  contentType: text('content_type'),
+  excerpt: text('excerpt'),
+  state: text('state').notNull().default('surfaced'), // surfaced | pinned | dismissed
+  firstSurfacedAt: integer('first_surfaced_at', { mode: 'timestamp' })
+    .notNull()
+    .default(sql`(unixepoch())`),
+  lastSurfacedAt: integer('last_surfaced_at', { mode: 'timestamp' })
+    .notNull()
+    .default(sql`(unixepoch())`)
+})
+
+export type TodoContextRow = typeof todoContext.$inferSelect

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -4,6 +4,7 @@ import { electronApp, optimizer, is } from '@electron-toolkit/utils'
 import icon from '../../resources/icon.png?asset'
 import { initDb } from './db'
 import { memoryService } from './services/memory-service'
+import { pipelineService } from './services/pipeline-service'
 import * as auth from './auth/logto'
 import { IPC } from '../shared/ipc'
 
@@ -88,6 +89,15 @@ app.whenReady().then(async () => {
   await initDb()
   ipcMain.handle(IPC.memoryList, () => memoryService.list())
   ipcMain.handle(IPC.memoryAdd, (_event, content: string) => memoryService.add(content))
+
+  // Pipeline — on-device capture / semantic search (see services/pipeline-service).
+  ipcMain.handle(IPC.pipelineCaptureText, (_e, text: string, name?: string) =>
+    pipelineService.captureText(text, name)
+  )
+  ipcMain.handle(IPC.pipelineSearch, (_e, query: string, topK?: number) =>
+    pipelineService.search(query, topK)
+  )
+  ipcMain.handle(IPC.pipelineList, () => pipelineService.listItems())
 
   // Auth (Logto) — broadcast changes to renderers, restore any saved session,
   // then expose login/logout/token over IPC. Inert until Logto env is configured.

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -5,6 +5,7 @@ import icon from '../../resources/icon.png?asset'
 import { initDb } from './db'
 import { memoryService } from './services/memory-service'
 import { pipelineService } from './services/pipeline-service'
+import { todoService } from './services/todo-service'
 import * as auth from './auth/logto'
 import { IPC } from '../shared/ipc'
 
@@ -98,6 +99,23 @@ app.whenReady().then(async () => {
     pipelineService.search(query, topK)
   )
   ipcMain.handle(IPC.pipelineList, () => pipelineService.listItems())
+
+  // Todos — daily focus list + per-todo context pool (see services/todo-service).
+  ipcMain.handle(IPC.todoAdd, (_e, title: string, notes?: string) => todoService.add(title, notes))
+  ipcMain.handle(IPC.todoToday, (_e, day?: string) => todoService.today(day))
+  ipcMain.handle(IPC.todoBacklog, () => todoService.backlog())
+  ipcMain.handle(IPC.todoDone, (_e, limit?: number) => todoService.done(limit))
+  ipcMain.handle(IPC.todoComplete, (_e, id: string) => todoService.complete(id))
+  ipcMain.handle(IPC.todoReopen, (_e, id: string) => todoService.reopen(id))
+  ipcMain.handle(IPC.todoPlan, (_e, keep: string[], day?: string) => todoService.plan(keep, day))
+  ipcMain.handle(IPC.todoSchedule, (_e, id: string, day?: string) => todoService.schedule(id, day))
+  ipcMain.handle(IPC.todoContextSearch, (_e, id: string) => todoService.searchMoreContext(id))
+  ipcMain.handle(IPC.todoContextPin, (_e, id: string, itemId: string) =>
+    todoService.pinContext(id, itemId)
+  )
+  ipcMain.handle(IPC.todoContextDismiss, (_e, id: string, itemId: string) =>
+    todoService.dismissContext(id, itemId)
+  )
 
   // Auth (Logto) — broadcast changes to renderers, restore any saved session,
   // then expose login/logout/token over IPC. Inert until Logto env is configured.

--- a/src/main/pipeline/chunk.ts
+++ b/src/main/pipeline/chunk.ts
@@ -1,0 +1,17 @@
+/** Split text into overlapping char windows for embedding (ported from chunking.py). */
+export function chunkText(text: string, maxChars = 800, overlap = 100): string[] {
+  const trimmed = text.trim()
+  if (!trimmed) return []
+  if (trimmed.length <= maxChars) return [trimmed]
+  if (overlap >= maxChars) throw new Error('overlap must be < maxChars')
+
+  const chunks: string[] = []
+  let start = 0
+  while (start < trimmed.length) {
+    const end = Math.min(start + maxChars, trimmed.length)
+    chunks.push(trimmed.slice(start, end))
+    if (end >= trimmed.length) break
+    start = end - overlap
+  }
+  return chunks
+}

--- a/src/main/pipeline/embed.ts
+++ b/src/main/pipeline/embed.ts
@@ -1,0 +1,46 @@
+import { createHash } from 'node:crypto'
+import { EMBED_DIM } from '../db'
+
+/**
+ * The embedding seam. Today's default is a deterministic hash-of-tokens
+ * placeholder so the whole capture→index→search path works end-to-end with no
+ * native deps (identical text → identical vector; shared words → closer). It is
+ * NOT semantic — it proves the plumbing while the real on-device model is wired.
+ *
+ * Next: swap in a transformers.js LocalEmbedder (EmbeddingGemma / bge / MiniLM),
+ * proven in the neeme-mono spike. In Electron that needs onnxruntime-node via
+ * `electron-rebuild` (or the WASM backend) — a one-line swap at this seam.
+ */
+export interface Embedder {
+  readonly name: string
+  readonly dim: number
+  embed(texts: string[]): Promise<number[][]>
+}
+
+const TOKEN_RE = /[a-z0-9]+/g
+
+function l2normalize(vec: number[]): number[] {
+  const norm = Math.sqrt(vec.reduce((sum, x) => sum + x * x, 0))
+  return norm === 0 ? vec : vec.map((x) => x / norm)
+}
+
+export class HashEmbedder implements Embedder {
+  readonly name = 'hash-placeholder'
+  constructor(readonly dim = EMBED_DIM) {}
+
+  embed(texts: string[]): Promise<number[][]> {
+    return Promise.resolve(texts.map((t) => this.embedOne(t)))
+  }
+
+  private embedOne(text: string): number[] {
+    const vec = new Array<number>(this.dim).fill(0)
+    for (const tok of text.toLowerCase().match(TOKEN_RE) ?? []) {
+      const h = createHash('sha1').update(tok).digest()
+      const idx = h.readUInt32BE(0) % this.dim
+      vec[idx] = (vec[idx] ?? 0) + ((h[4] ?? 0) & 1 ? 1 : -1)
+    }
+    return l2normalize(vec)
+  }
+}
+
+export const embedder: Embedder = new HashEmbedder()

--- a/src/main/pipeline/extract.ts
+++ b/src/main/pipeline/extract.ts
@@ -1,0 +1,70 @@
+import { extractText as pdfText, getDocumentProxy } from 'unpdf'
+import type { ContentType, ItemStatus } from '../../shared/ipc'
+
+// Suffix wins, then MIME prefix (ported from the Python content_types.py).
+const BY_EXT: Record<string, ContentType> = {
+  '.txt': 'text',
+  '.md': 'text',
+  '.markdown': 'text',
+  '.rst': 'text',
+  '.log': 'text',
+  '.csv': 'text',
+  '.json': 'text',
+  '.eml': 'text',
+  '.pdf': 'pdf',
+  '.png': 'image',
+  '.jpg': 'image',
+  '.jpeg': 'image',
+  '.gif': 'image',
+  '.webp': 'image',
+  '.heic': 'image',
+  '.m4a': 'audio',
+  '.mp3': 'audio',
+  '.wav': 'audio',
+  '.opus': 'audio'
+}
+
+export function suffixOf(name: string): string {
+  const dot = name.lastIndexOf('.')
+  return dot >= 0 ? name.slice(dot).toLowerCase() : ''
+}
+
+export function detectContentType(name: string, mime?: string): ContentType {
+  const byExt = BY_EXT[suffixOf(name)]
+  if (byExt) return byExt
+  if (mime) {
+    if (mime.startsWith('image/')) return 'image'
+    if (mime.startsWith('audio/')) return 'audio'
+    if (mime === 'application/pdf') return 'pdf'
+    if (mime.startsWith('text/') || mime === 'application/json') return 'text'
+  }
+  return 'other'
+}
+
+export interface ExtractResult {
+  text: string
+  status: ItemStatus
+  error?: string
+}
+
+/**
+ * Normalize raw bytes to text. text/pdf extract natively; image/audio need a
+ * model (vision/whisper) or cloud offload — deferred, so they park as `pending`.
+ */
+export async function extract(contentType: ContentType, bytes: Uint8Array): Promise<ExtractResult> {
+  if (contentType === 'text') {
+    const text = new TextDecoder('utf-8').decode(bytes).trim()
+    return { text, status: text ? 'extracted' : 'pending' }
+  }
+  if (contentType === 'pdf') {
+    try {
+      const pdf = await getDocumentProxy(bytes)
+      const { text } = await pdfText(pdf, { mergePages: true })
+      const trimmed = (text ?? '').trim()
+      return { text: trimmed, status: trimmed ? 'extracted' : 'pending' }
+    } catch (err) {
+      return { text: '', status: 'failed', error: String(err) }
+    }
+  }
+  return { text: '', status: 'pending' }
+}

--- a/src/main/pipeline/raw-store.ts
+++ b/src/main/pipeline/raw-store.ts
@@ -1,0 +1,29 @@
+import { createHash } from 'node:crypto'
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { app } from 'electron'
+
+/**
+ * Content-addressed raw store: the original bytes land first, sha256-named and
+ * sharded, under Electron's per-user `userData/raw`. Idempotent — the same bytes
+ * map to the same id + path, so re-capture is a no-op. (Ported from the Python
+ * `raw_store.py` / the neeme-mono pipeline.)
+ */
+export interface RawItem {
+  id: string
+  storedPath: string
+  sizeBytes: number
+  isNew: boolean
+}
+
+export function putRaw(bytes: Uint8Array, suffix = ''): RawItem {
+  const id = createHash('sha256').update(bytes).digest('hex')
+  const dir = join(app.getPath('userData'), 'raw', id.slice(0, 2))
+  const storedPath = join(dir, `${id}${suffix}`)
+  const isNew = !existsSync(storedPath)
+  if (isNew) {
+    mkdirSync(dir, { recursive: true })
+    writeFileSync(storedPath, bytes)
+  }
+  return { id, storedPath, sizeBytes: bytes.byteLength, isNew }
+}

--- a/src/main/services/pipeline-service.ts
+++ b/src/main/services/pipeline-service.ts
@@ -1,0 +1,90 @@
+import { desc, eq } from 'drizzle-orm'
+import { client, db } from '../db'
+import { items, type Item as ItemRow } from '../db/schema'
+import { chunkText } from '../pipeline/chunk'
+import { embedder } from '../pipeline/embed'
+import { detectContentType, extract, suffixOf } from '../pipeline/extract'
+import { putRaw } from '../pipeline/raw-store'
+import type { CaptureResult, ContentType, Item, ItemStatus, SearchHit } from '../../shared/ipc'
+
+/**
+ * The on-device pipeline (ADR 0003): capture → content-hash store → extract →
+ * chunk → embed → index in libSQL; and semantic search over the chunks. The IPC
+ * handlers call into this — the renderer never touches Drizzle or libSQL.
+ * Ported from the Python `neeme` pipeline + the neeme-mono engine.
+ */
+
+function toItem(row: ItemRow): Item {
+  return {
+    id: row.id,
+    sourceName: row.sourceName,
+    contentType: row.contentType as ContentType,
+    sizeBytes: row.sizeBytes,
+    status: row.status as ItemStatus,
+    text: row.text,
+    createdAt: row.createdAt
+  }
+}
+
+async function capture(bytes: Uint8Array, name: string, mime?: string): Promise<CaptureResult> {
+  const { id, storedPath, sizeBytes } = putRaw(bytes, suffixOf(name))
+
+  // Idempotent on content: already captured these exact bytes → return it.
+  const existing = await db.select().from(items).where(eq(items.id, id)).limit(1)
+  if (existing[0]) return { item: toItem(existing[0]), created: false }
+
+  const contentType = detectContentType(name, mime)
+  const { text, status } = await extract(contentType, bytes)
+  const [created] = await db
+    .insert(items)
+    .values({ id, sourceName: name, contentType, sizeBytes, storedPath, text, status })
+    .returning()
+
+  if (text) {
+    const chunks = chunkText(text)
+    const vectors = await embedder.embed(chunks)
+    for (let i = 0; i < chunks.length; i++) {
+      await client.execute({
+        sql: 'INSERT OR REPLACE INTO chunks (item_id, chunk_idx, text, embedding) VALUES (?, ?, ?, vector32(?))',
+        args: [id, i, chunks[i]!, JSON.stringify(vectors[i] ?? [])]
+      })
+    }
+  }
+  return { item: toItem(created!), created: true }
+}
+
+export const pipelineService = {
+  captureText(text: string, name = 'note.md'): Promise<CaptureResult> {
+    return capture(new TextEncoder().encode(text), name, 'text/markdown')
+  },
+
+  captureFile(bytes: Uint8Array, name: string, mime?: string): Promise<CaptureResult> {
+    return capture(bytes, name, mime)
+  },
+
+  async search(query: string, topK = 8): Promise<SearchHit[]> {
+    const [queryVector] = await embedder.embed([query])
+    if (!queryVector) return []
+    const res = await client.execute({
+      sql: `SELECT c.item_id AS item_id, c.chunk_idx AS chunk_idx, c.text AS chunk_text,
+                   vector_distance_cos(c.embedding, vector32(?)) AS dist,
+                   i.source_name AS source_name, i.content_type AS content_type
+            FROM chunks c JOIN items i ON i.id = c.item_id
+            ORDER BY dist ASC LIMIT ?`,
+      args: [JSON.stringify(queryVector), topK]
+    })
+    return res.rows.map((r) => ({
+      itemId: String(r.item_id),
+      chunkIdx: Number(r.chunk_idx),
+      text: String(r.chunk_text),
+      score: Number(r.dist),
+      sourceName: String(r.source_name),
+      contentType: String(r.content_type) as ContentType
+    }))
+  },
+
+  async listItems(): Promise<Item[]> {
+    const rows = await db.select().from(items).orderBy(desc(items.createdAt))
+    return rows.map(toItem)
+  }
+}

--- a/src/main/services/todo-service.ts
+++ b/src/main/services/todo-service.ts
@@ -1,0 +1,236 @@
+import { and, count, desc, eq, isNotNull, isNull } from 'drizzle-orm'
+import { db } from '../db'
+import { todoContext, todos, type Todo as TodoRow, type TodoContextRow } from '../db/schema'
+import { pipelineService } from './pipeline-service'
+import {
+  CAP_REACHED,
+  type ContentType,
+  type ContextEntry,
+  type ContextState,
+  type Todo,
+  type TodoStatus,
+  type TodoWithContext
+} from '../../shared/ipc'
+
+/**
+ * The daily focus to-do list + each todo's context pool (ported from the Python
+ * `todos.py` / neeme-mono). Capped at CAP open items per day with a "finish the
+ * whole list" latch; context is surfaced from the on-device pipeline's semantic
+ * search over captured items and persisted (pin/dismiss verdicts stick).
+ */
+const CAP = 5
+const CONTEXT_TOP_K = 6
+
+const todayISO = (): string => new Date().toISOString().slice(0, 10)
+
+function toTodo(row: TodoRow): Todo {
+  return {
+    id: row.id,
+    title: row.title,
+    notes: row.notes,
+    status: row.status as TodoStatus,
+    day: row.day,
+    position: row.position,
+    createdAt: row.createdAt,
+    completedAt: row.completedAt
+  }
+}
+
+function toContextEntry(row: TodoContextRow): ContextEntry {
+  return {
+    itemId: row.itemId,
+    score: row.score,
+    sourceName: row.sourceName,
+    contentType: row.contentType as ContentType | null,
+    excerpt: row.excerpt,
+    state: row.state as ContextState
+  }
+}
+
+async function countForDay(day: string): Promise<number> {
+  const [r] = await db.select({ c: count() }).from(todos).where(eq(todos.day, day))
+  return r?.c ?? 0
+}
+
+async function openCountForDay(day: string): Promise<number> {
+  const [r] = await db
+    .select({ c: count() })
+    .from(todos)
+    .where(and(eq(todos.day, day), eq(todos.status, 'open')))
+  return r?.c ?? 0
+}
+
+/** Focus rule: add while filling the day, or once it's fully cleared. */
+async function canAdd(day: string): Promise<boolean> {
+  if ((await openCountForDay(day)) === 0) return true
+  return (await countForDay(day)) < CAP
+}
+
+// --- context pool ---------------------------------------------------------
+
+async function listContext(todoId: string): Promise<ContextEntry[]> {
+  const rows = await db.select().from(todoContext).where(eq(todoContext.todoId, todoId))
+  return rows
+    .filter((r) => r.state !== 'dismissed')
+    .sort((a, b) => {
+      const pin = Number(b.state === 'pinned') - Number(a.state === 'pinned')
+      if (pin) return pin
+      return (a.score ?? 1) - (b.score ?? 1) // cosine distance: lower = closer
+    })
+    .map(toContextEntry)
+}
+
+/** Run search over captured items and merge hits into the pool (additive; a
+ *  user's pin/dismiss verdict is preserved). Best chunk per item. */
+async function surfaceContext(todo: Todo): Promise<ContextEntry[]> {
+  const query = todo.notes ? `${todo.title}\n${todo.notes}` : todo.title
+  const hits = await pipelineService.search(query, CONTEXT_TOP_K)
+
+  const bestByItem = new Map<string, (typeof hits)[number]>()
+  for (const h of hits) {
+    const prev = bestByItem.get(h.itemId)
+    if (!prev || h.score < prev.score) bestByItem.set(h.itemId, h)
+  }
+
+  const now = new Date()
+  for (const h of bestByItem.values()) {
+    await db
+      .insert(todoContext)
+      .values({
+        todoId: todo.id,
+        itemId: h.itemId,
+        score: h.score,
+        sourceName: h.sourceName,
+        contentType: h.contentType,
+        excerpt: h.text,
+        lastSurfacedAt: now
+      })
+      .onConflictDoUpdate({
+        target: [todoContext.todoId, todoContext.itemId],
+        // bump score/snapshot but never touch `state` (the verdict sticks).
+        set: {
+          score: h.score,
+          sourceName: h.sourceName,
+          contentType: h.contentType,
+          excerpt: h.text,
+          lastSurfacedAt: now
+        }
+      })
+  }
+  return listContext(todo.id)
+}
+
+async function withContext(todo: Todo): Promise<TodoWithContext> {
+  return { ...todo, context: await listContext(todo.id) }
+}
+
+// --- service --------------------------------------------------------------
+
+export const todoService = {
+  async add(title: string, notes?: string): Promise<TodoWithContext> {
+    const day = todayISO()
+    if (!(await canAdd(day))) throw new Error(CAP_REACHED)
+    const position = await countForDay(day)
+    const [created] = await db
+      .insert(todos)
+      .values({ title, notes: notes ?? null, day, position })
+      .returning()
+    const todo = toTodo(created!)
+    await surfaceContext(todo)
+    return withContext(todo)
+  },
+
+  async today(day = todayISO()): Promise<TodoWithContext[]> {
+    const rows = await db
+      .select()
+      .from(todos)
+      .where(eq(todos.day, day))
+      .orderBy(todos.position, todos.createdAt)
+    return Promise.all(rows.map((r) => withContext(toTodo(r))))
+  },
+
+  async backlog(): Promise<Todo[]> {
+    const rows = await db
+      .select()
+      .from(todos)
+      .where(and(isNull(todos.day), eq(todos.status, 'open')))
+      .orderBy(desc(todos.createdAt))
+    return rows.map(toTodo)
+  },
+
+  async done(limit = 50): Promise<Todo[]> {
+    const rows = await db
+      .select()
+      .from(todos)
+      .where(eq(todos.status, 'done'))
+      .orderBy(desc(todos.completedAt))
+      .limit(limit)
+    return rows.map(toTodo)
+  },
+
+  async complete(id: string): Promise<Todo | null> {
+    const [r] = await db
+      .update(todos)
+      .set({ status: 'done', completedAt: new Date() })
+      .where(eq(todos.id, id))
+      .returning()
+    return r ? toTodo(r) : null
+  },
+
+  async reopen(id: string): Promise<Todo | null> {
+    const [r] = await db
+      .update(todos)
+      .set({ status: 'open', completedAt: null })
+      .where(eq(todos.id, id))
+      .returning()
+    return r ? toTodo(r) : null
+  },
+
+  /** Carry the `keep` open items onto `day`; sweep every other open scheduled
+   *  item to the backlog. Done items stay in the done log. */
+  async plan(keep: string[], day = todayISO()): Promise<TodoWithContext[]> {
+    if (keep.length > CAP) throw new Error(CAP_REACHED)
+    const scheduled = await db
+      .select()
+      .from(todos)
+      .where(and(eq(todos.status, 'open'), isNotNull(todos.day)))
+    const keepSet = new Set(keep)
+    for (const t of scheduled) {
+      if (!keepSet.has(t.id))
+        await db.update(todos).set({ day: null, position: 0 }).where(eq(todos.id, t.id))
+    }
+    for (let i = 0; i < keep.length; i++) {
+      await db.update(todos).set({ day, position: i }).where(eq(todos.id, keep[i]!))
+    }
+    return this.today(day)
+  },
+
+  async schedule(id: string, day = todayISO()): Promise<Todo | null> {
+    if (!(await canAdd(day))) throw new Error(CAP_REACHED)
+    const position = await countForDay(day)
+    const [r] = await db.update(todos).set({ day, position }).where(eq(todos.id, id)).returning()
+    return r ? toTodo(r) : null
+  },
+
+  async searchMoreContext(id: string): Promise<ContextEntry[]> {
+    const [r] = await db.select().from(todos).where(eq(todos.id, id)).limit(1)
+    if (!r) return []
+    return surfaceContext(toTodo(r))
+  },
+
+  async pinContext(id: string, itemId: string): Promise<ContextEntry[]> {
+    await db
+      .update(todoContext)
+      .set({ state: 'pinned' })
+      .where(and(eq(todoContext.todoId, id), eq(todoContext.itemId, itemId)))
+    return listContext(id)
+  },
+
+  async dismissContext(id: string, itemId: string): Promise<ContextEntry[]> {
+    await db
+      .update(todoContext)
+      .set({ state: 'dismissed' })
+      .where(and(eq(todoContext.todoId, id), eq(todoContext.itemId, itemId)))
+    return listContext(id)
+  }
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -14,6 +14,20 @@ const api: NeemeApi = {
     search: (query: string, topK?: number) => ipcRenderer.invoke(IPC.pipelineSearch, query, topK),
     listItems: () => ipcRenderer.invoke(IPC.pipelineList)
   },
+  todos: {
+    add: (title: string, notes?: string) => ipcRenderer.invoke(IPC.todoAdd, title, notes),
+    today: (day?: string) => ipcRenderer.invoke(IPC.todoToday, day),
+    backlog: () => ipcRenderer.invoke(IPC.todoBacklog),
+    done: (limit?: number) => ipcRenderer.invoke(IPC.todoDone, limit),
+    complete: (id: string) => ipcRenderer.invoke(IPC.todoComplete, id),
+    reopen: (id: string) => ipcRenderer.invoke(IPC.todoReopen, id),
+    plan: (keep: string[], day?: string) => ipcRenderer.invoke(IPC.todoPlan, keep, day),
+    schedule: (id: string, day?: string) => ipcRenderer.invoke(IPC.todoSchedule, id, day),
+    searchMoreContext: (id: string) => ipcRenderer.invoke(IPC.todoContextSearch, id),
+    pinContext: (id: string, itemId: string) => ipcRenderer.invoke(IPC.todoContextPin, id, itemId),
+    dismissContext: (id: string, itemId: string) =>
+      ipcRenderer.invoke(IPC.todoContextDismiss, id, itemId)
+  },
   auth: {
     login: () => ipcRenderer.invoke(IPC.authLogin),
     logout: () => ipcRenderer.invoke(IPC.authLogout),

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -8,6 +8,12 @@ const api: NeemeApi = {
     list: () => ipcRenderer.invoke(IPC.memoryList),
     add: (content: string) => ipcRenderer.invoke(IPC.memoryAdd, content)
   },
+  pipeline: {
+    captureText: (text: string, name?: string) =>
+      ipcRenderer.invoke(IPC.pipelineCaptureText, text, name),
+    search: (query: string, topK?: number) => ipcRenderer.invoke(IPC.pipelineSearch, query, topK),
+    listItems: () => ipcRenderer.invoke(IPC.pipelineList)
+  },
   auth: {
     login: () => ipcRenderer.invoke(IPC.authLogin),
     logout: () => ipcRenderer.invoke(IPC.authLogout),

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -17,6 +17,18 @@ export const IPC = {
   pipelineCaptureText: 'pipeline:capture-text',
   pipelineSearch: 'pipeline:search',
   pipelineList: 'pipeline:list',
+  // Todos (daily focus list: cap/plan + the per-todo context pool)
+  todoAdd: 'todo:add',
+  todoToday: 'todo:today',
+  todoBacklog: 'todo:backlog',
+  todoDone: 'todo:done',
+  todoComplete: 'todo:complete',
+  todoReopen: 'todo:reopen',
+  todoPlan: 'todo:plan',
+  todoSchedule: 'todo:schedule',
+  todoContextSearch: 'todo:context-search',
+  todoContextPin: 'todo:context-pin',
+  todoContextDismiss: 'todo:context-dismiss',
   // Auth (Logto OIDC flow lives in main; see src/main/auth/logto.ts)
   authLogin: 'auth:login',
   authLogout: 'auth:logout',
@@ -92,6 +104,62 @@ export interface AuthApi {
   onChanged: (cb: (state: AuthState, accessToken?: string) => void) => () => void
 }
 
+// --- Todos (daily focus list + context pool) ------------------------------
+
+export type TodoStatus = 'open' | 'done'
+
+export interface Todo {
+  id: string
+  title: string
+  notes: string | null
+  status: TodoStatus
+  /** ISO date the todo lives on; null = backlog (unscheduled). */
+  day: string | null
+  position: number
+  createdAt: Date
+  completedAt: Date | null
+}
+
+export type ContextState = 'surfaced' | 'pinned' | 'dismissed'
+
+/** One surfaced memory in a todo's context pool. */
+export interface ContextEntry {
+  itemId: string
+  score: number | null
+  sourceName: string | null
+  contentType: ContentType | null
+  excerpt: string | null
+  state: ContextState
+}
+
+export interface TodoWithContext extends Todo {
+  context: ContextEntry[]
+}
+
+/** Raised when adding would exceed the day's focus cap. */
+export const CAP_REACHED = 'CAP_REACHED'
+
+export interface TodoApi {
+  /** Add to today (cap-enforced; rejects with CAP_REACHED when full). Surfaces context. */
+  add: (title: string, notes?: string) => Promise<TodoWithContext>
+  /** Today's focus list, each item with its stored context pool. */
+  today: (day?: string) => Promise<TodoWithContext[]>
+  /** Open, unscheduled items (the backlog). */
+  backlog: () => Promise<Todo[]>
+  /** The done log (newest first). */
+  done: (limit?: number) => Promise<Todo[]>
+  complete: (id: string) => Promise<Todo | null>
+  reopen: (id: string) => Promise<Todo | null>
+  /** Plan a day: carry `keep` open items onto it, sweep the rest to the backlog. */
+  plan: (keep: string[], day?: string) => Promise<TodoWithContext[]>
+  /** Pull a backlog item onto a day (cap-enforced). */
+  schedule: (id: string, day?: string) => Promise<Todo | null>
+  /** "Search more" — re-run search and merge new hits into the pool. */
+  searchMoreContext: (id: string) => Promise<ContextEntry[]>
+  pinContext: (id: string, itemId: string) => Promise<ContextEntry[]>
+  dismissContext: (id: string, itemId: string) => Promise<ContextEntry[]>
+}
+
 /** Capture + surface, backed by the on-device pipeline in the main process. */
 export interface PipelineApi {
   /** Quick text capture → returns the item (+ whether it was newly created). */
@@ -105,5 +173,6 @@ export interface PipelineApi {
 export interface NeemeApi {
   memory: MemoryApi
   pipeline: PipelineApi
+  todos: TodoApi
   auth: AuthApi
 }

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -13,6 +13,10 @@ export interface Memory {
 export const IPC = {
   memoryList: 'memory:list',
   memoryAdd: 'memory:add',
+  // Pipeline (on-device capture → extract → index → search; main process)
+  pipelineCaptureText: 'pipeline:capture-text',
+  pipelineSearch: 'pipeline:search',
+  pipelineList: 'pipeline:list',
   // Auth (Logto OIDC flow lives in main; see src/main/auth/logto.ts)
   authLogin: 'auth:login',
   authLogout: 'auth:logout',
@@ -21,6 +25,38 @@ export const IPC = {
   /** main → renderer event: auth state / token changed (login, refresh, logout). */
   authChanged: 'auth:changed'
 } as const
+
+// --- Pipeline (capture / surface) -----------------------------------------
+
+export type ContentType = 'text' | 'pdf' | 'image' | 'audio' | 'other'
+export type ItemStatus = 'captured' | 'extracted' | 'pending' | 'failed'
+
+/** A captured item — content-addressed, normalized to `text` when possible. */
+export interface Item {
+  id: string
+  sourceName: string
+  contentType: ContentType
+  sizeBytes: number
+  status: ItemStatus
+  text: string
+  createdAt: Date
+}
+
+export interface CaptureResult {
+  item: Item
+  /** false if this exact content was already captured (idempotent). */
+  created: boolean
+}
+
+/** A semantic-search hit: a matching chunk, with its parent item's metadata. */
+export interface SearchHit {
+  itemId: string
+  chunkIdx: number
+  text: string
+  score: number // cosine distance (lower = closer)
+  sourceName: string
+  contentType: ContentType
+}
 
 /** Identity claims decoded from the id_token (display only). */
 export interface AuthClaims {
@@ -56,7 +92,18 @@ export interface AuthApi {
   onChanged: (cb: (state: AuthState, accessToken?: string) => void) => () => void
 }
 
+/** Capture + surface, backed by the on-device pipeline in the main process. */
+export interface PipelineApi {
+  /** Quick text capture → returns the item (+ whether it was newly created). */
+  captureText: (text: string, name?: string) => Promise<CaptureResult>
+  /** Semantic search over captured content. */
+  search: (query: string, topK?: number) => Promise<SearchHit[]>
+  /** Recently captured items (newest first). */
+  listItems: () => Promise<Item[]>
+}
+
 export interface NeemeApi {
   memory: MemoryApi
+  pipeline: PipelineApi
   auth: AuthApi
 }


### PR DESCRIPTION
Ports the neeme pipeline + the daily-focus to-do model (from the Python `neeme` / neeme-mono engines) into the **Electron main process** — the on-device backend the renderer hooks into via IPC. Per ADR 0003: pipeline runs in main, no HTTP on the local path. Built on the existing libSQL + Drizzle data layer; `memory` + `auth` surfaces untouched.

Reconciled against the stabilized design (`Neeme-handoff (8)`): the backend data contract matches it exactly (`MEMORIES`→items, `matchTask`→search, `REL`→cosine scores, `CTX_WHY`/pin→context pool, `CAP=5`+plan ritual).

## What's in it

**Capture → index → search** (`5d60f4d`)
- `items` (Drizzle) + `chunks` (F32_BLOB) tables w/ libSQL **native vector** index
- `pipeline/`: content-hash raw store, text + PDF (`unpdf`) extract (image/audio → `pending`), chunking, an **Embedder seam**
- `pipelineService`: `captureText`/`captureFile` (idempotent on content), `search` (cosine over chunks), `listItems`
- IPC: `window.api.pipeline.{captureText, search, listItems}`

**Daily focus todos + context pool** (`ad9b4af`)
- `todos` + `todo_context` tables
- `todoService`: capped daily list (CAP 5, finish-the-list latch → `CAP_REACHED`), today/backlog/done, complete/reopen, the **`plan(keep)` day ritual** (carry-over → backlog), `schedule`; **context pool** surfaces best-chunk-per-item from `pipelineService.search`, additive upsert that **preserves pin/dismiss** verdicts; `searchMore`/`pin`/`dismiss`
- IPC: `window.api.todos.*`

## Verified
- `pnpm typecheck` (node + web) green
- new files lint-clean (pre-existing repo lint errors unaffected; `build` gates on typecheck, not lint)
- full **`electron-vite build` green**

## Honest caveats (follow-ups, not blockers)
- **Embedder is a deterministic `HashEmbedder` placeholder** — the whole capture→index→search path works, but it's structural, not semantic. Real on-device model (transformers.js, proven in the neeme-mono spike) is a one-line swap at the seam; needs `electron-rebuild` for `onnxruntime-node` (or the WASM backend).
- **`captureFile` not yet exposed over IPC** (only `captureText`) — the Feed's file/drop capture needs an ArrayBuffer channel.
- **Live IPC roundtrip not exercised** here (no Electron runtime in the build env) — the engine logic is the test-verified neeme-mono/Python port.
- Out of scope (UI / future): drafting (LLM), "open in Gmail" actions (connectors), feed-uncovered-todos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)