### PR TITLE
feat(renderer): memory search, waiting badge, richer celebrate (design v4)

### DIFF
--- a/src/renderer/src/neeme/NeemeApp.tsx
+++ b/src/renderer/src/neeme/NeemeApp.tsx
@@ -7,8 +7,11 @@
 //      frameless-window + tray integration is a later main-process step). The app
 //      is a single centred column on the matcha wallpaper, "the same size as mobile".
 //   2. The design-time TweaksPanel (a variation explorer) is dropped. Its chosen
-//      defaults — dark / matcha / stack / cozy / ambient-on — are applied to <html>,
+//      defaults — dark / apricot / stack / cozy / ambient-on — are applied to <html>,
 //      and the header's "Plan tomorrow" button still triggers the new-day ritual.
+//   3. The prototype's menu-bar/tray search + badge live on the header here: the
+//      "waiting" badge sits on the header mark, and global search replaces the (then
+//      meaningless) "On device" pill.
 import { useEffect, useMemo, useRef, useState } from 'react'
 import type { JSX } from 'react'
 import { TodayView, BottomNav } from './today'
@@ -17,6 +20,7 @@ import { FeedView } from './feed'
 import { AddSheet } from './add'
 import { PlanRitual } from './plan'
 import { AllDone } from './celebrate'
+import { SearchOverlay } from './search'
 import { SEED_TASKS, REL, BACKLOG } from './data'
 import type { BacklogItem, Task } from './data'
 import type { NeemeMarkState } from './types'
@@ -27,12 +31,29 @@ const CAP = 5
 // The product defaults the design landed on (formerly the TweaksPanel defaults).
 const TWEAKS = {
   theme: 'dark',
-  accent: 'matcha', // matcha is the CSS :root default, so no var override needed
+  accent: 'apricot',
   todayLayout: 'stack',
   captureStyle: 'drop',
   density: 'cozy',
   ambient: true
 } as const
+
+// accent palettes from the design (oklch). matcha is the CSS :root default; any
+// other accent (apricot is the current default) sets the --accent* vars on <html>.
+const ACCENTS: Record<string, { solid: string; ink: string; deep: string }> = {
+  matcha: {
+    solid: 'oklch(0.80 0.13 142)',
+    ink: 'oklch(0.90 0.09 142)',
+    deep: 'oklch(0.62 0.13 142)'
+  },
+  apricot: {
+    solid: 'oklch(0.80 0.12 64)',
+    ink: 'oklch(0.90 0.09 64)',
+    deep: 'oklch(0.64 0.12 64)'
+  },
+  rose: { solid: 'oklch(0.76 0.12 18)', ink: 'oklch(0.87 0.09 18)', deep: 'oklch(0.60 0.12 18)' },
+  iris: { solid: 'oklch(0.74 0.12 280)', ink: 'oklch(0.86 0.10 280)', deep: 'oklch(0.58 0.13 280)' }
+}
 
 function seedTasks(): Task[] {
   return SEED_TASKS.map((t) => ({ ...t, relMap: REL[t.id] || {} }))
@@ -50,12 +71,17 @@ export default function NeemeApp(): JSX.Element {
   const [backlog, setBacklog] = useState<BacklogItem[]>(BACKLOG)
   const [feedRecording, setFeedRecording] = useState(false)
   const [addRecording, setAddRecording] = useState(false)
+  const [searching, setSearching] = useState(false)
 
   useEffect(() => {
     const el = document.documentElement
     el.setAttribute('data-theme', TWEAKS.theme)
     el.setAttribute('data-density', TWEAKS.density)
     el.setAttribute('data-ambient', TWEAKS.ambient ? 'on' : 'off')
+    const a = ACCENTS[TWEAKS.accent] || ACCENTS.matcha
+    el.style.setProperty('--accent', a.solid)
+    el.style.setProperty('--accent-ink', a.ink)
+    el.style.setProperty('--accent-deep', a.deep)
   }, [])
 
   const cheer = (): void => {
@@ -148,6 +174,20 @@ export default function NeemeApp(): JSX.Element {
   // a stable carried-over count for the fresh-day meta line
   const carriedCount = useMemo(() => yesterday.filter((x) => !x.done).length, [yesterday])
 
+  // things waiting on you: drafts ready to act + freshly-uncovered backlog to-dos
+  const waiting =
+    tasks.filter((x) => !x.done && x.status === 'drafted').length +
+    backlog.filter((b) => b.fresh).length
+  const openSearch = (): void => {
+    setOverlay(null)
+    setSearching(true)
+  }
+  // a memory kept from search → added to the open task's context pool
+  const addContextToTask = (memId: string): void => {
+    if (!openTask) return
+    updateTask(openTask.id, { ctx: [...new Set([...(openTask.ctx || []), memId])] })
+  }
+
   return (
     <div className="desk">
       <div className="desk-wall" />
@@ -163,11 +203,13 @@ export default function NeemeApp(): JSX.Element {
                 planned={planned}
                 carriedCount={carriedCount}
                 backlogCount={backlog.length}
+                badge={waiting}
                 onOpen={setOpenId}
                 onToggle={toggleTask}
                 onAdd={() => setOverlay('add')}
                 onPlan={() => setOverlay('plan')}
                 onTomorrow={beginNewDay}
+                onSearch={openSearch}
                 onWeather={() => setOverlay('plan')}
               />
             ) : (
@@ -185,6 +227,7 @@ export default function NeemeApp(): JSX.Element {
                 onBack={() => setOpenId(null)}
                 onToggle={toggleTask}
                 onUpdate={updateTask}
+                onDig={openSearch}
               />
             )}
 
@@ -210,11 +253,21 @@ export default function NeemeApp(): JSX.Element {
             {allDone && showWin && (
               <AllDone
                 count={tasks.length}
+                titles={tasks.map((x) => x.title)}
                 onClose={() => setShowWin(false)}
                 onPlan={() => {
                   setShowWin(false)
                   beginNewDay()
                 }}
+              />
+            )}
+
+            {searching && (
+              <SearchOverlay
+                contextTitle={openTask ? openTask.title : null}
+                keptIds={openTask ? openTask.ctx : []}
+                onKeep={openTask ? addContextToTask : null}
+                onClose={() => setSearching(false)}
               />
             )}
           </div>

--- a/src/renderer/src/neeme/celebrate.tsx
+++ b/src/renderer/src/neeme/celebrate.tsx
@@ -15,7 +15,7 @@ interface ConfPiece {
 // Randomised confetti scatter. Lives at module scope (not in render) so the
 // random draw is pure-by-the-rules; fed once through a useState lazy initializer.
 function makeConfetti(): ConfPiece[] {
-  return Array.from({ length: 18 }).map(() => ({
+  return Array.from({ length: 20 }).map(() => ({
     x: (Math.random() * 2 - 1) * 150,
     d: Math.random() * 0.5,
     r: (Math.random() * 2 - 1) * 320,
@@ -26,17 +26,20 @@ function makeConfetti(): ConfPiece[] {
 
 export function AllDone({
   count = 5,
+  titles = [],
   onPlan,
   onClose
 }: {
   count?: number
+  titles?: string[]
   onPlan: () => void
   onClose: () => void
 }): JSX.Element {
   const [conf] = useState(makeConfetti)
-  const shards = [0, 1, 2, 3, 4].map((i) => {
-    const ang = ((-90 + i * 72) * Math.PI) / 180
-    return { sx: Math.cos(ang) * 64, sy: Math.sin(ang) * 64 }
+  const items: Array<string | number> = (titles.length ? titles : [0, 1, 2, 3, 4]).slice(0, 5)
+  const shards = items.map((title, i) => {
+    const ang = ((-90 + i * (360 / items.length)) * Math.PI) / 180
+    return { title, sx: Math.cos(ang) * 150, sy: Math.sin(ang) * 92 }
   })
   return (
     <div className="win">
@@ -51,11 +54,18 @@ export function AllDone({
                 {
                   '--sx': s.sx + 'px',
                   '--sy': s.sy + 'px',
-                  animationDelay: i * 0.05 + 's'
+                  animationDelay: i * 0.08 + 's'
                 } as CSSProperties
               }
             >
-              <NeemeMark state="done" fill={9} size={22} />
+              <span className="win-shard-chip">
+                <NIcon name="check" size={11} stroke={2.6} />
+                {typeof s.title === 'string' && (
+                  <span className="win-shard-t">
+                    {s.title.length > 18 ? s.title.slice(0, 17) + '…' : s.title}
+                  </span>
+                )}
+              </span>
             </span>
           ))}
           <span className="win-big">
@@ -70,7 +80,7 @@ export function AllDone({
                   '--cx': c.x + 'px',
                   '--cr': c.r + 'deg',
                   '--cs': c.s,
-                  animationDelay: 0.55 + c.d + 's',
+                  animationDelay: 0.7 + c.d + 's',
                   animationDuration: c.dur + 's'
                 } as CSSProperties
               }
@@ -83,7 +93,7 @@ export function AllDone({
         </div>
         <div className="win-actions">
           <button className="btn primary" onClick={onPlan}>
-            <NIcon name="today" size={16} /> Plan tomorrow
+            <NIcon name="dayNext" size={16} /> Plan tomorrow
           </button>
           <button className="btn ghost" onClick={onClose}>
             Bask a moment

--- a/src/renderer/src/neeme/icons.tsx
+++ b/src/renderer/src/neeme/icons.tsx
@@ -132,7 +132,15 @@ const NM_PATHS: Record<string, ReactNode> = {
   ),
   sweep: (
     <>
-      <path d="M16.5 3.5l4 4M14 6l4 4-7.5 7.5-4-4zM6.5 13.5L4 20l6.5-2.5" />
+      <path d="M20 4l-8 8" />
+      <path d="M12 12l-6.5 3 1.5 5.5 6.5-3z" />
+      <path d="M7 15.7l1.3 4.6M10 14.3l1.3 4.6" />
+    </>
+  ),
+  copy: (
+    <>
+      <rect x="8.5" y="8.5" width="11" height="11" rx="2.3" />
+      <path d="M5.5 15.5A1.5 1.5 0 0 1 4 14V5.5A1.5 1.5 0 0 1 5.5 4H14a1.5 1.5 0 0 1 1.5 1.5" />
     </>
   ),
   search: (

--- a/src/renderer/src/neeme/neeme.css
+++ b/src/renderer/src/neeme/neeme.css
@@ -1,6 +1,6 @@
 /* ============================================================================
    Neeme — a personal-memory companion.  (mneme · the muse of memory)
-   Visual system extends "Mr. Matcha": warm-dark, matcha accent, hairlines,
+   Visual system extends "Mr. Matcha": warm-dark, accent, hairlines,
    Hanken Grotesk + JetBrains Mono. Animation-forward & personable.
 
    Ported from the Claude Design handoff bundle (neeme-desktop.html). The desktop
@@ -976,7 +976,7 @@ html[data-ambient='off'] .task.pop {
   position: relative;
   z-index: 2;
   color: var(--accent-ink);
-  animation: nm-bigbloom 0.65s var(--ease-spring) 0.42s both;
+  animation: nm-bigbloom 0.6s var(--ease-spring) 0.62s both;
 }
 @keyframes nm-bigbloom {
   0% {
@@ -991,20 +991,38 @@ html[data-ambient='off'] .task.pop {
 .win-shard {
   position: absolute;
   z-index: 1;
+  animation: nm-converge 0.8s var(--ease-out) both;
+}
+.win-shard-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 10px 5px 8px;
+  border-radius: 999px;
+  border: 1px solid var(--accent-line);
+  background: var(--surface-2);
+  color: var(--ink);
+  font-size: 11px;
+  font-weight: 550;
+  white-space: nowrap;
+  box-shadow: var(--shadow-soft);
+}
+.win-shard-chip svg {
   color: var(--accent-ink);
-  animation: nm-converge 0.6s var(--ease-out) both;
+  flex: 0 0 auto;
 }
 @keyframes nm-converge {
   0% {
     opacity: 0;
-    transform: translate(var(--sx), var(--sy)) scale(0.6);
+    transform: translate(var(--sx), var(--sy)) scale(0.85);
   }
-  40% {
+  35% {
     opacity: 1;
+    transform: translate(calc(var(--sx) * 0.55), calc(var(--sy) * 0.55)) scale(1);
   }
   100% {
     opacity: 0;
-    transform: translate(0, 0) scale(0.3);
+    transform: translate(0, 0) scale(0.2);
   }
 }
 .win-conf {
@@ -1061,6 +1079,286 @@ html[data-ambient='off'] .win-shard {
 }
 html[data-ambient='off'] .win-big {
   animation: none;
+}
+
+/* badge on the Neeme mark (tray + header) — things waiting on you */
+.hdr-mark,
+.tray-peek-mark {
+  position: relative;
+  display: inline-flex;
+  flex: 0 0 auto;
+}
+.nm-badge {
+  position: absolute;
+  top: -5px;
+  right: -6px;
+  min-width: 17px;
+  height: 17px;
+  padding: 0 4px;
+  border-radius: 999px;
+  background: var(--accent);
+  color: #0a0a0b;
+  font-family: var(--mono);
+  font-size: 10px;
+  font-weight: 600;
+  line-height: 17px;
+  text-align: center;
+  box-shadow: 0 0 0 2px var(--bg);
+  display: inline-block;
+}
+.tray-btn {
+  position: relative;
+}
+.tray-count {
+  display: inline-block;
+  min-width: 15px;
+  height: 15px;
+  line-height: 15px;
+  padding: 0 4px;
+  border-radius: 5px;
+  background: var(--accent);
+  color: #0a0a0b;
+  font-family: var(--mono);
+  font-size: 9.5px;
+  font-weight: 600;
+  text-align: center;
+}
+.nm-badge.dot {
+  top: -2px;
+  right: -2px;
+  min-width: 9px;
+  width: 9px;
+  height: 9px;
+  padding: 0;
+  border-radius: 50%;
+  box-shadow:
+    0 0 0 2px color-mix(in oklch, var(--bg) 52%, transparent),
+    0 0 7px -1px var(--accent);
+}
+.mb-iconbtn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 22px;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  border-radius: 6px;
+  transition: background 0.15s;
+}
+.mb-iconbtn:hover {
+  background: var(--surface-3);
+}
+
+/* ── Dig deeper: universal memory search ── */
+.search-ov {
+  position: absolute;
+  inset: 0;
+  z-index: 60;
+  background: var(--bg);
+  display: flex;
+  flex-direction: column;
+  animation: nm-push 0.32s var(--ease-out) both;
+}
+.search-top {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 14px 10px 12px;
+  border-bottom: 1px solid var(--hairline);
+}
+.search-field {
+  flex: 1 1 auto;
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  height: 42px;
+  padding: 0 12px;
+  border-radius: 13px;
+  border: 1px solid var(--accent-line);
+  background: var(--surface-2);
+}
+.search-field > svg:first-child {
+  color: var(--accent-ink);
+  flex: 0 0 auto;
+}
+.search-input {
+  flex: 1 1 auto;
+  min-width: 0;
+  border: 0;
+  background: transparent;
+  outline: none;
+  color: var(--ink);
+  font-family: var(--sans);
+  font-size: 15px;
+}
+.search-input::placeholder {
+  color: var(--ink-3);
+}
+.search-clear {
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  border-radius: 7px;
+  border: 0;
+  background: var(--surface-3);
+  color: var(--ink-2);
+  display: grid;
+  place-items: center;
+  cursor: pointer;
+}
+.search-clear:hover {
+  background: var(--hairline);
+  color: var(--ink);
+}
+.search-scope {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  padding: 11px 16px 4px;
+  font-size: 12.5px;
+  color: var(--ink-2);
+}
+.search-scope b {
+  color: var(--accent-ink);
+  font-weight: 600;
+}
+.search-body {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 8px 14px 16px;
+}
+.search-suggest {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding: 6px 2px 10px;
+}
+.search-meta {
+  font-family: var(--mono);
+  font-size: 9.5px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--ink-3);
+  margin: 6px 2px 10px;
+  min-height: 16px;
+  display: flex;
+  align-items: center;
+}
+.sr {
+  display: flex;
+  gap: 12px;
+  align-items: flex-start;
+  padding: 11px 4px;
+  border-bottom: 1px solid var(--hairline);
+  animation: nm-rowin 0.35s var(--ease-out) both;
+}
+.sr-thumb {
+  flex: 0 0 auto;
+  width: 40px;
+  height: 40px;
+  border-radius: 10px;
+  display: grid;
+  place-items: center;
+  color: var(--ink-2);
+  border: 1px solid var(--hairline);
+  background: var(--surface-3);
+}
+.sr-thumb.img {
+  background:
+    repeating-linear-gradient(45deg, var(--accent-soft) 0 5px, transparent 5px 11px),
+    var(--surface-2);
+}
+.sr-main {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+.sr-kind {
+  font-family: var(--mono);
+  font-size: 8.5px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--ink-3);
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.sr-kind .dot {
+  width: 3px;
+  height: 3px;
+  border-radius: 50%;
+  background: var(--ink-3);
+}
+.sr-t {
+  font-size: 13.5px;
+  font-weight: 550;
+  line-height: 1.3;
+  margin-top: 3px;
+  letter-spacing: -0.01em;
+  text-wrap: pretty;
+}
+.sr-snip {
+  font-size: 12px;
+  line-height: 1.45;
+  color: var(--ink-2);
+  margin-top: 3px;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+.sr-keep {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  height: 30px;
+  padding: 0 11px;
+  border-radius: 9px;
+  border: 1px solid var(--hairline);
+  background: var(--surface);
+  color: var(--ink-2);
+  font-family: var(--mono);
+  font-size: 9.5px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: all 0.15s;
+  margin-top: 2px;
+}
+.sr-keep:hover {
+  border-color: var(--accent-line);
+  color: var(--accent-ink);
+  background: var(--accent-faint);
+}
+.sr-keep.on {
+  border-color: var(--accent-line);
+  color: var(--accent-ink);
+  background: var(--accent-soft);
+  cursor: default;
+}
+.search-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: 7px;
+  padding: 40px 24px;
+}
+.search-empty-t {
+  font-size: 15px;
+  font-weight: 600;
+  margin-top: 4px;
+}
+.search-empty-s {
+  font-size: 12.5px;
+  color: var(--ink-2);
+  line-height: 1.5;
+  max-width: 240px;
 }
 
 /* ───────────────────────── fresh-day (unplanned) entry ───────────────────────── */
@@ -2359,6 +2657,7 @@ html[data-ambient='off'] .vrec-wave span {
   font-size: 9.5px;
   letter-spacing: 0.08em;
   text-transform: uppercase;
+  white-space: nowrap;
   padding: 4px 9px;
   border-radius: 999px;
   border: 1px solid var(--hairline);
@@ -2418,6 +2717,65 @@ html[data-ambient='off'] .vrec-wave span {
   gap: 10px;
   padding: 13px 14px 10px;
 }
+.draft-hd.as-toggle {
+  width: 100%;
+  border: 0;
+  background: none;
+  cursor: pointer;
+  text-align: left;
+}
+.draft-collapse {
+  flex: 0 0 auto;
+  color: var(--ink-3);
+  display: inline-flex;
+  align-items: center;
+  margin-left: 2px;
+}
+.draft-hd.as-toggle:hover .draft-collapse {
+  color: var(--accent-ink);
+}
+.draft-strip {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  margin-bottom: 16px;
+  padding: 12px 13px;
+  border: 1px solid var(--accent-line);
+  border-radius: 14px;
+  cursor: pointer;
+  transition: all 0.16s var(--ease-out);
+  background: linear-gradient(120deg, var(--accent-faint), transparent 70%), var(--surface-2);
+  animation: nm-rowin 0.3s var(--ease-out) both;
+}
+.draft-strip:hover {
+  background: linear-gradient(120deg, var(--accent-soft), transparent 70%), var(--surface-2);
+}
+.draft-strip-ico {
+  flex: 0 0 auto;
+  width: 30px;
+  height: 30px;
+  border-radius: 8px;
+  display: grid;
+  place-items: center;
+  color: var(--accent-ink);
+  border: 1px solid var(--accent-line);
+  background: var(--surface-2);
+}
+.draft-strip-tx {
+  flex: 1 1 auto;
+  min-width: 0;
+  font-size: 12.5px;
+  color: var(--ink-2);
+}
+.draft-strip-tx b {
+  color: var(--ink);
+  font-weight: 600;
+}
+.draft-strip-cv {
+  flex: 0 0 auto;
+  color: var(--ink-3);
+}
 .draft-hd .nm {
   flex: 0 0 auto;
 }
@@ -2471,17 +2829,13 @@ html[data-ambient='off'] .vrec-wave span {
   flex: 0 0 auto;
   display: inline-flex;
   align-items: center;
-  gap: 5px;
-  height: 28px;
-  padding: 0 10px;
-  border-radius: 8px;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border-radius: 9px;
   border: 1px solid var(--hairline);
   background: var(--surface);
   color: var(--ink-2);
-  font-family: var(--mono);
-  font-size: 9px;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
   cursor: pointer;
   transition: all 0.15s;
 }
@@ -3071,23 +3425,18 @@ html[data-ambient='off'] .kept-chip.fresh {
   justify-content: space-between;
   width: 100%;
   gap: 10px;
-  padding: 12px 13px;
-  margin: 4px 0 11px;
-  border: 1px solid var(--hairline);
-  border-radius: 14px;
-  background: var(--surface);
-  color: var(--ink-2);
+  padding: 6px 2px;
+  margin: 2px 0 11px;
+  border: 0;
+  border-radius: 0;
+  background: none;
+  color: var(--accent-ink);
   cursor: pointer;
-  transition: all 0.16s var(--ease-out);
+  transition: color 0.16s var(--ease-out);
   text-align: left;
 }
-.pool-review:hover {
-  border-color: var(--accent-line);
-  color: var(--ink);
-  background: var(--accent-faint);
-}
-.pool-review.has-new {
-  border-color: var(--accent-line);
+.pool-review:hover .pr-r {
+  color: var(--accent-ink);
 }
 .pool-review .pr-l {
   display: flex;
@@ -3095,6 +3444,7 @@ html[data-ambient='off'] .kept-chip.fresh {
   gap: 11px;
   min-width: 0;
   font-size: 12.5px;
+  font-weight: 550;
 }
 .pool-review .pr-r {
   display: flex;
@@ -3246,19 +3596,15 @@ html[data-ambient='off'] .mem.fresh::after {
   width: 48px;
   height: 48px;
   padding: 0;
-  border-radius: 14px;
-  border: 1px solid var(--accent-line);
-  background:
-    radial-gradient(120% 120% at 30% 25%, var(--accent-faint), transparent 65%), var(--surface);
+  border: 0;
+  background: transparent;
   display: grid;
   place-items: center;
   cursor: pointer;
-  transition: all 0.16s var(--ease-out);
+  transition: transform 0.16s var(--ease-out);
 }
 .dt-ask:hover {
-  background:
-    radial-gradient(120% 120% at 30% 25%, var(--accent-soft), transparent 65%), var(--surface);
-  transform: translateY(-1px);
+  transform: translateY(-1px) scale(1.06);
 }
 /* Dig deeper — the universal "search your life" bar */
 .dt-dig {
@@ -3817,7 +4163,7 @@ html[data-ambient='off'] .mem.fresh::after {
 /* ───────────────────────── desktop surface — fills the real window ─────────────────────────
    The prototype simulated a macOS menu bar + tray popover; here the app fills the actual
    Electron window. The single-column app (intentionally "the same size as mobile") is centered
-   on the matcha wallpaper and stretches full-height, so it reads as a real desktop surface now
+   on the wallpaper and stretches full-height, so it reads as a real desktop surface now
    and ports cleanly to a small frameless/tray window later. */
 .desk {
   position: relative;

--- a/src/renderer/src/neeme/search.tsx
+++ b/src/renderer/src/neeme/search.tsx
@@ -1,0 +1,173 @@
+// search.tsx — "Dig deeper": a universal search across everything you've fed Neeme.
+import { useEffect, useRef, useState } from 'react'
+import type { JSX } from 'react'
+import { NIcon } from './icons'
+import { kindIcon } from './iconKind'
+import { NeemeMark, NeemeSay, Dots } from './mark'
+import { MEMORIES } from './data'
+
+function memSearch(q: string): string[] {
+  const ids = Object.keys(MEMORIES)
+  const words = q
+    .toLowerCase()
+    .split(/[^a-z0-9']+/)
+    .filter((w) => w.length > 1)
+  if (!words.length) return ids
+  return ids
+    .map((id) => {
+      const m = MEMORIES[id]
+      const hay = (m.title + ' ' + m.snip + ' ' + m.kind + ' ' + (m.src || '')).toLowerCase()
+      let s = 0
+      for (const w of words) if (hay.includes(w)) s += 1
+      return { id, s }
+    })
+    .filter((x) => x.s > 0)
+    .sort((a, b) => b.s - a.s)
+    .map((x) => x.id)
+}
+
+const SEARCH_SUGGEST = ['cabin weekend', "mom's birthday", 'Q3 numbers', 'dentist', 'book club']
+
+export function SearchOverlay({
+  contextTitle,
+  keptIds,
+  onKeep,
+  onClose
+}: {
+  contextTitle?: string | null
+  keptIds?: string[]
+  onKeep?: ((id: string) => void) | null
+  onClose: () => void
+}): JSX.Element {
+  const [q, setQ] = useState('')
+  const [settledQ, setSettledQ] = useState('')
+  const [kept, setKept] = useState<Set<string>>(new Set(keptIds || []))
+  const inputRef = useRef<HTMLInputElement>(null)
+  useEffect(() => {
+    inputRef.current && inputRef.current.focus()
+  }, [])
+
+  // a beat of "Neeme is searching" when the query settles. We debounce the input
+  // into `settledQ` — the only setState lives inside the timeout, so it never fires
+  // synchronously in the effect body — and derive `thinking` from the gap.
+  useEffect(() => {
+    if (q === settledQ) return undefined
+    const id = setTimeout(() => setSettledQ(q), q.trim() ? 650 : 0)
+    return () => clearTimeout(id)
+  }, [q, settledQ])
+
+  const thinking = q.trim() !== '' && settledQ !== q
+  const results = q.trim() ? memSearch(q) : Object.keys(MEMORIES).slice(0, 6)
+  const keep = (id: string): void => {
+    setKept((s) => new Set(s).add(id))
+    onKeep && onKeep(id)
+  }
+
+  return (
+    <div className="search-ov">
+      <div className="search-top">
+        <button className="push-back" onClick={onClose} aria-label="Close search">
+          <NIcon name="back" size={18} />
+        </button>
+        <div className="search-field">
+          <NIcon name="search" size={17} />
+          <input
+            ref={inputRef}
+            className="search-input"
+            value={q}
+            placeholder="Search everything you've fed me…"
+            onChange={(e) => setQ(e.target.value)}
+          />
+          {q && (
+            <button className="search-clear" aria-label="Clear" onClick={() => setQ('')}>
+              <NIcon name="close" size={14} />
+            </button>
+          )}
+        </div>
+      </div>
+
+      {contextTitle && (
+        <div className="search-scope">
+          <NeemeMark state={thinking ? 'thinking' : 'idle'} size={18} />
+          <span>
+            Looking across your memory for <b>“{contextTitle}”</b>
+          </span>
+        </div>
+      )}
+
+      <div className="search-body">
+        {!q && (
+          <div className="search-suggest">
+            {SEARCH_SUGGEST.map((s) => (
+              <button key={s} className="sugg-chip" onClick={() => setQ(s)}>
+                {s}
+              </button>
+            ))}
+          </div>
+        )}
+        <div className="search-meta">
+          {thinking ? (
+            <NeemeSay state="thinking" size={18}>
+              Searching
+              <Dots />
+            </NeemeSay>
+          ) : q ? (
+            `${results.length} result${results.length === 1 ? '' : 's'} in your memory`
+          ) : (
+            'Recently fed'
+          )}
+        </div>
+
+        {!thinking &&
+          results.map((id, i) => {
+            const m = MEMORIES[id]
+            const isImg = m.kind === 'photo' || m.kind === 'screenshot' || m.kind === 'image'
+            const isKept = kept.has(id)
+            return (
+              <div className="sr" key={id} style={{ animationDelay: `${Math.min(i, 8) * 0.03}s` }}>
+                <div className={'sr-thumb' + (isImg ? ' img' : '')}>
+                  {!isImg && <NIcon name={kindIcon(m.kind)} size={17} />}
+                </div>
+                <div className="sr-main">
+                  <div className="sr-kind">
+                    {m.kind}
+                    <span className="dot" />
+                    {m.when}
+                  </div>
+                  <div className="sr-t">{m.title}</div>
+                  <div className="sr-snip">{m.snip}</div>
+                </div>
+                {onKeep && (
+                  <button
+                    className={'sr-keep' + (isKept ? ' on' : '')}
+                    disabled={isKept}
+                    onClick={() => keep(id)}
+                  >
+                    {isKept ? (
+                      <>
+                        <NIcon name="check" size={13} /> Kept
+                      </>
+                    ) : (
+                      <>
+                        <NIcon name="pin" size={13} /> Keep
+                      </>
+                    )}
+                  </button>
+                )}
+              </div>
+            )
+          })}
+
+        {!thinking && q && results.length === 0 && (
+          <div className="search-empty">
+            <NeemeMark state="idle" size={30} />
+            <div className="search-empty-t">Nothing on that yet</div>
+            <div className="search-empty-s">
+              Try fewer words — or feed me more and it&apos;ll be here next time.
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/neeme/task.tsx
+++ b/src/renderer/src/neeme/task.tsx
@@ -120,8 +120,12 @@ function MemoryCard({
             >
               <NIcon name={pinned ? 'pinFill' : 'pin'} size={15} />
             </button>
-            <button className="mem-act sweep" aria-label="Dismiss" onClick={stop(onSweep)}>
-              <NIcon name="close" size={15} />
+            <button
+              className="mem-act sweep"
+              aria-label="Sweep from this task"
+              onClick={stop(onSweep)}
+            >
+              <NIcon name="sweep" size={15} />
             </button>
           </div>
         </div>
@@ -155,9 +159,25 @@ function DraftCard({
 }): JSX.Element {
   const [used, setUsed] = useState(false)
   const [copied, setCopied] = useState(false)
+  const [collapsed, setCollapsed] = useState(false)
+
+  if (collapsed) {
+    return (
+      <button className="draft-strip" onClick={() => setCollapsed(false)}>
+        <span className="draft-strip-ico">
+          <NIcon name={typeIcon || 'sparkle'} size={15} />
+        </span>
+        <span className="draft-strip-tx">
+          <b>{typeLabel || 'A first draft'}</b> · tap to reopen
+        </span>
+        <NIcon name="chevDown" size={14} className="draft-strip-cv" />
+      </button>
+    )
+  }
+
   return (
     <div className="draft">
-      <div className="draft-hd">
+      <button className="draft-hd as-toggle" onClick={() => setCollapsed(true)}>
         <NeemeMark state="idle" size={24} />
         <div className="draft-hd-main">
           <div className="draft-hd-t">I took a crack at it</div>
@@ -165,17 +185,23 @@ function DraftCard({
             <NIcon name={typeIcon || 'sparkle'} size={11} /> {typeLabel || 'A first draft'}
           </div>
         </div>
-        <button
+        <span
           className="draft-copy"
-          aria-label="Copy"
-          onClick={() => {
+          role="button"
+          tabIndex={0}
+          aria-label={copied ? 'Copied' : 'Copy draft'}
+          onClick={(e) => {
+            e.stopPropagation()
             setCopied(true)
             setTimeout(() => setCopied(false), 1400)
           }}
         >
-          <NIcon name={copied ? 'check' : 'file'} size={14} /> {copied ? 'Copied' : 'Copy'}
-        </button>
-      </div>
+          <NIcon name={copied ? 'check' : 'copy'} size={16} />
+        </span>
+        <span className="draft-collapse">
+          <NIcon name="chevUp" size={14} />
+        </span>
+      </button>
       <div className="draft-paper">
         {draft.map((p, i) => (
           <p key={i}>{renderBold(p)}</p>
@@ -235,18 +261,18 @@ export function TaskDetail({
   task,
   onBack,
   onToggle,
-  onUpdate
+  onUpdate,
+  onDig
 }: {
   task: Task
   index: number
   onBack: () => void
   onToggle: (id: string) => void
   onUpdate?: (id: string, patch: Partial<Task>) => void
+  onDig: () => void
 }): JSX.Element {
   const [pinned, setPinned] = useState<Set<string>>(new Set(task.pinned || []))
   const [swept, setSwept] = useState<Set<string>>(new Set())
-  const [extra, setExtra] = useState<string[]>([])
-  const [searching, setSearching] = useState(false)
   const [drafting, setDrafting] = useState(false)
   const [draft, setDraft] = useState<string[] | null>(task.draft || null)
   const [open, setOpen] = useState(false)
@@ -275,8 +301,9 @@ export function TaskDetail({
     })
   }
 
-  const baseIds = (task.ctx || []).filter((id) => !swept.has(id))
-  const allIds = [...baseIds, ...extra.filter((id) => !swept.has(id))]
+  // context is just the task's saved ctx (minus what's been swept this session);
+  // "dig deeper" now adds memories via the app-level SearchOverlay → task.ctx.
+  const allIds = (task.ctx || []).filter((id) => !swept.has(id))
   const sorted = allIds.slice().sort((a, b) => {
     const pa = pinned.has(a) ? 1 : 0
     const pb = pinned.has(b) ? 1 : 0
@@ -294,19 +321,6 @@ export function TaskDetail({
     if (!pinned.has(id)) markFresh([id])
   }
   const sweep = (id: string): void => setSwept((s) => new Set(s).add(id))
-
-  const searchMore = (): void => {
-    setSearching(true)
-    setTimeout(() => {
-      const have = new Set([...allIds])
-      const pool = Object.keys(MEMORIES).filter((id) => !have.has(id))
-      const add = pool.sort(() => Math.random() - 0.5).slice(0, 2)
-      setExtra((e) => [...e, ...add])
-      setSearching(false)
-      setOpen(true)
-      markFresh(add)
-    }, 1400)
-  }
 
   const tryDraft = (): void => {
     setDrafting(true)
@@ -414,16 +428,6 @@ export function TaskDetail({
         {/* context Neeme gathered */}
         {!done && (
           <>
-            <div className="pool-hd">
-              <div className="pool-hd-l">
-                <span className="ctx-orb" />
-                <span className="pool-hd-t">Sources</span>
-              </div>
-              <span className="pool-hd-meta">
-                {keptCount} kept · {suggIds.length} more
-              </span>
-            </div>
-
             {keptCount > 0 ? (
               <>
                 <button
@@ -488,27 +492,18 @@ export function TaskDetail({
             {suggIds.length > 0 && (
               <>
                 <button
-                  className={
-                    'pool-review' + (open ? ' open' : '') + (freshSugg > 0 ? ' has-new' : '')
-                  }
+                  className={'pool-group-hd as-toggle' + (open ? ' open' : '')}
                   onClick={() => setOpen((o) => !o)}
                 >
-                  <span className="pr-l">
-                    <span className="pool-cloud sm">
-                      {Array.from({ length: Math.min(suggIds.length, 6) }).map((_, i) => (
-                        <span key={i} className={'pc' + (i < freshSugg ? ' fresh' : '')} />
-                      ))}
-                    </span>
-                    {open ? (
-                      <span>More I found — keep or sweep</span>
-                    ) : freshSugg > 0 ? (
-                      <span className="shimmer-text">{freshSugg} just surfaced — take a look</span>
-                    ) : (
-                      <span>{suggIds.length} more I think relate</span>
-                    )}
-                  </span>
-                  <span className="pr-r">
-                    {open ? 'Tuck away' : 'Review'} <NIcon name="chevDown" size={14} />
+                  <NIcon name="layers" size={11} />
+                  {freshSugg > 0 && !open ? (
+                    <span className="shimmer-text">{freshSugg} just surfaced</span>
+                  ) : (
+                    <span>{suggIds.length} more memories</span>
+                  )}
+                  <span className="ln" />
+                  <span className="kept-toggle">
+                    {open ? 'Tuck away' : 'Review'} <NIcon name="chevDown" size={13} />
                   </span>
                 </button>
                 {open &&
@@ -559,19 +554,10 @@ export function TaskDetail({
         >
           <NeemeMark state="idle" size={26} />
         </button>
-        <button className="dt-dig" onClick={searchMore} disabled={searching}>
-          {searching ? (
-            <NeemeSay state="thinking" size={20}>
-              Searching your memory
-              <Dots />
-            </NeemeSay>
-          ) : (
-            <>
-              <NIcon name="search" size={17} />
-              <span className="dt-dig-tx">Dig deeper in your memory</span>
-              <NIcon name="arrowRight" size={15} />
-            </>
-          )}
+        <button className="dt-dig" onClick={onDig}>
+          <NIcon name="search" size={17} />
+          <span className="dt-dig-tx">Dig deeper in your memory</span>
+          <NIcon name="arrowRight" size={15} />
         </button>
       </div>
 

--- a/src/renderer/src/neeme/today.tsx
+++ b/src/renderer/src/neeme/today.tsx
@@ -26,24 +26,31 @@ function dateLabel(): string {
 
 function AppHeader({
   neemeState,
+  badge,
+  onSearch,
   onTomorrow
 }: {
   neemeState: NeemeMarkState
+  badge: number
+  onSearch: () => void
   onTomorrow: () => void
 }): JSX.Element {
   return (
     <header className="hdr">
       <div className="hdr-l">
-        <NeemeMark state={neemeState} size={38} />
+        <span className="hdr-mark">
+          <NeemeMark state={neemeState} size={38} />
+          {badge > 0 && <span className="nm-badge">{badge}</span>}
+        </span>
         <div className="hdr-greet">
           <span className="hdr-hi">{greeting()}</span>
           <span className="hdr-date">{dateLabel()}</span>
         </div>
       </div>
       <div className="hdr-r">
-        <span className="priv-pill">
-          <NIcon name="lock" size={11} /> On device
-        </span>
+        <button className="hdr-btn" aria-label="Search your memory" onClick={onSearch}>
+          <NIcon name="search" size={18} />
+        </button>
         <button className="hdr-btn" aria-label="Plan tomorrow" onClick={onTomorrow}>
           <NIcon name="dayNext" size={18} />
         </button>
@@ -151,7 +158,6 @@ function TaskCard({
             <>
               {task.note && <NeemeNote kind={task.noteKind || 'gathered'}>{task.note}</NeemeNote>}
               <div className="ctx-strip">
-                <span className="ctx-orb" />
                 {ctxN > 0 && <CtxThumbs memIds={task.ctx} />}
                 <span className="ctx-txt">{ctxLabel}</span>
                 <span className="ctx-go">
@@ -189,11 +195,13 @@ interface TodayViewProps {
   planned: boolean
   carriedCount: number
   backlogCount: number
+  badge: number
   onOpen: (id: string) => void
   onToggle: (id: string) => void
   onAdd: () => void
   onPlan: () => void
   onTomorrow: () => void
+  onSearch: () => void
   onWeather: () => void
   neemeState: NeemeMarkState
 }
@@ -205,10 +213,12 @@ export function TodayView({
   planned,
   carriedCount,
   backlogCount,
+  badge,
   onOpen,
   onToggle,
   onPlan,
   onTomorrow,
+  onSearch,
   onWeather,
   neemeState
 }: TodayViewProps): JSX.Element {
@@ -220,7 +230,12 @@ export function TodayView({
     return (
       <div className="view">
         <div className="scroll">
-          <AppHeader neemeState={neemeState} onTomorrow={onPlan} />
+          <AppHeader
+            neemeState={neemeState}
+            badge={badge}
+            onSearch={onSearch}
+            onTomorrow={onPlan}
+          />
           <div className="dayzero">
             <NeemeMark state="idle" size={66} />
             <div className="dayzero-h">A fresh day</div>
@@ -243,7 +258,12 @@ export function TodayView({
   return (
     <div className="view">
       <div className="scroll">
-        <AppHeader neemeState={neemeState} onTomorrow={onTomorrow} />
+        <AppHeader
+          neemeState={neemeState}
+          badge={badge}
+          onSearch={onSearch}
+          onTomorrow={onTomorrow}
+        />
         <MemoryWeather
           count={tasks.reduce((a, t) => a + (t.ctx ? t.ctx.length : 0), 0)}
           onOpen={onWeather}


### PR DESCRIPTION
Third Claude Design handoff drop, applied on top of the alpha UI (PR #8, now on `main`).

## What's new
- **Universal memory search** — `search.tsx` adds a "Dig deeper" `SearchOverlay` over everything fed to Neeme (live substring rank, a brief "searching" beat, suggestion chips, per-result **Keep**, empty state). The task detail's **Dig deeper** button opens it scoped to the task ("Looking across your memory for …"); keeping a result adds that memory to the task's context. A header **search button** opens it globally.
- **Waiting badge** on the header Neeme mark — count of `drafted, not-done tasks + freshly-uncovered backlog items`.
- **Task detail polish** — `DraftCard` collapses to a strip and reopens; broom **sweep** icon; icon-only **copy**; the Sources section loses its header and the suggested toggle is now a slim "{n} more memories" disclosure.
- **Richer celebrate** — the all-done payoff flings the actual task *titles* (as check-chips) into the assembling diamond.

## Product decisions (confirmed with the user)
- **Default accent → apricot** (the new design source's default; `ACCENTS` map + effect on `<html>`, matcha stays the CSS `:root` fallback).
- **The "On device" header pill is replaced by the global search button.** The prototype's menu-bar (search icon + tray badge) is dropped in the fill-the-window layout, so search lives in the header and the badge sits on the header mark.

## Still deferred (separate PR)
Frameless, mobile-sized window + **system-tray pop-out** in the main process; backend/local-libSQL data wiring; local font bundling for offline-first.

## Verification
`typecheck` (node + web), `eslint`, and `electron-vite build` all pass (42 renderer modules).

🤖 Generated with [Claude Code](https://claude.com/claude-code)