### PR TITLE
feat(renderer): global search icon top-right on Today + task detail

### DIFF
--- a/src/renderer/src/neeme/NeemeApp.tsx
+++ b/src/renderer/src/neeme/NeemeApp.tsx
@@ -71,7 +71,9 @@ export default function NeemeApp(): JSX.Element {
   const [backlog, setBacklog] = useState<BacklogItem[]>(BACKLOG)
   const [feedRecording, setFeedRecording] = useState(false)
   const [addRecording, setAddRecording] = useState(false)
-  const [searching, setSearching] = useState(false)
+  // global = "search everything" (header magnifier); task = "dig deeper" scoped to the
+  // open task (its footer). Only task-mode carries the task's context into the overlay.
+  const [searchMode, setSearchMode] = useState<'global' | 'task' | null>(null)
 
   useEffect(() => {
     const el = document.documentElement
@@ -178,10 +180,11 @@ export default function NeemeApp(): JSX.Element {
   const waiting =
     tasks.filter((x) => !x.done && x.status === 'drafted').length +
     backlog.filter((b) => b.fresh).length
-  const openSearch = (): void => {
+  const openGlobalSearch = (): void => {
     setOverlay(null)
-    setSearching(true)
+    setSearchMode('global')
   }
+  const openTaskSearch = (): void => setSearchMode('task')
   // a memory kept from search → added to the open task's context pool
   const addContextToTask = (memId: string): void => {
     if (!openTask) return
@@ -209,7 +212,7 @@ export default function NeemeApp(): JSX.Element {
                 onAdd={() => setOverlay('add')}
                 onPlan={() => setOverlay('plan')}
                 onTomorrow={beginNewDay}
-                onSearch={openSearch}
+                onSearch={openGlobalSearch}
                 onWeather={() => setOverlay('plan')}
               />
             ) : (
@@ -227,7 +230,8 @@ export default function NeemeApp(): JSX.Element {
                 onBack={() => setOpenId(null)}
                 onToggle={toggleTask}
                 onUpdate={updateTask}
-                onDig={openSearch}
+                onDig={openTaskSearch}
+                onSearch={openGlobalSearch}
               />
             )}
 
@@ -262,12 +266,12 @@ export default function NeemeApp(): JSX.Element {
               />
             )}
 
-            {searching && (
+            {searchMode && (
               <SearchOverlay
-                contextTitle={openTask ? openTask.title : null}
-                keptIds={openTask ? openTask.ctx : []}
-                onKeep={openTask ? addContextToTask : null}
-                onClose={() => setSearching(false)}
+                contextTitle={searchMode === 'task' && openTask ? openTask.title : null}
+                keptIds={searchMode === 'task' && openTask ? openTask.ctx : []}
+                onKeep={searchMode === 'task' && openTask ? addContextToTask : null}
+                onClose={() => setSearchMode(null)}
               />
             )}
           </div>

--- a/src/renderer/src/neeme/task.tsx
+++ b/src/renderer/src/neeme/task.tsx
@@ -262,7 +262,8 @@ export function TaskDetail({
   onBack,
   onToggle,
   onUpdate,
-  onDig
+  onDig,
+  onSearch
 }: {
   task: Task
   index: number
@@ -270,6 +271,7 @@ export function TaskDetail({
   onToggle: (id: string) => void
   onUpdate?: (id: string, patch: Partial<Task>) => void
   onDig: () => void
+  onSearch: () => void
 }): JSX.Element {
   const [pinned, setPinned] = useState<Set<string>>(new Set(task.pinned || []))
   const [swept, setSwept] = useState<Set<string>>(new Set())
@@ -349,8 +351,8 @@ export function TaskDetail({
           <div className="push-kicker">{(task.when || 'Today').toUpperCase()}</div>
           <div className="push-ttl">{task.title}</div>
         </div>
-        <button className="hdr-btn" aria-label="More">
-          <NIcon name="dots" size={18} />
+        <button className="hdr-btn" aria-label="Search your memory" onClick={onSearch}>
+          <NIcon name="search" size={18} />
         </button>
       </div>
 

--- a/src/renderer/src/neeme/today.tsx
+++ b/src/renderer/src/neeme/today.tsx
@@ -48,11 +48,11 @@ function AppHeader({
         </div>
       </div>
       <div className="hdr-r">
-        <button className="hdr-btn" aria-label="Search your memory" onClick={onSearch}>
-          <NIcon name="search" size={18} />
-        </button>
         <button className="hdr-btn" aria-label="Plan tomorrow" onClick={onTomorrow}>
           <NIcon name="dayNext" size={18} />
+        </button>
+        <button className="hdr-btn" aria-label="Search your memory" onClick={onSearch}>
+          <NIcon name="search" size={18} />
         </button>
       </div>
     </header>


### PR DESCRIPTION
Follow-up to #9 (which is already merged). One small consistency fix that missed the #9 merge window — re-based onto current `main` (post-#10).

- The **top-right magnifier opens global search** ("search everything you've fed me") on **both** the Today header and the task-detail header.
- Task detail: the dead **"More" (dots)** button is replaced by the search icon.
- Today header: reordered so **search sits top-right** on both screens.
- The task-detail footer **"Dig deeper in your memory"** stays **task-scoped** (keeps results into that task). Encoded as `searchMode: 'global' | 'task'` so only task-mode carries the task's context into the overlay.

Renderer-only; no overlap with #10's main-process changes. Verified: typecheck, eslint, electron-vite build (42 modules).

🤖 Generated with [Claude Code](https://claude.com/claude-code)