### PR TITLE
docs: agent guide (CLAUDE.md) + sync loop (INBOX + routine config)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,7 @@ out
 
 # Claude Code local worktrees/session data
 .claude/
+
+# Generated agent-sync brief (rewritten each routine run; local scratchpad — read it
+# to compose the paste you seed each agent with). The routine config is tracked.
+docs/agent-sync/SYNC-BRIEF.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,66 @@
+# neeme-desktop — agent guide
+
+Neeme is an all-TypeScript, **on-device-first** personal-memory desktop app (Electron):
+capture multi-modal input → surface it (semantic search + a daily focus list) to get
+things done. This repo is the product. (The Python `neeme` repo is legacy.)
+
+## Before you start (coordination)
+
+Two agents work this repo in parallel. **Lanes:** backend/pipeline = `src/main/**` +
+`src/shared/**`; frontend/UI = `src/renderer/**`. Before starting a task or rebasing:
+
+1. Read **`docs/agent-sync/INBOX.md`** (directives for you — a `@all hold` overrides
+   everything), **`docs/agent-sync/SYNC-BRIEF.md`** (branches, merge order, live conflicts),
+   and **`docs/INTEGRATION.md`** (the backend⇄UI contract + swap map).
+2. **Contract changes land in `src/shared` first** — types are the boundary; the compiler
+   enforces agreement there. Update `docs/INTEGRATION.md` in the same change.
+3. Stay in your lane unless the contract says otherwise. Don't edit the other lane's files
+   beyond what a shared-type change forces.
+
+## Architecture (process model)
+
+```
+renderer (sandboxed, no node) → preload (contextBridge) → main (thin router) → utilityProcess (DB + pipeline/todos + native)
+```
+
+- **Main is a router, not a Node server** — no business logic, DB, or network servers in it.
+  New data capabilities go in the worker (`src/main/worker`, `src/main/services`), exposed
+  over IPC. Heavy/native work (libSQL, transformers.js) lives in the utilityProcess.
+- The renderer only ever touches `window.api.*`. See **`docs/SECURITY.md`**.
+
+## Security invariants (non-negotiable)
+
+Never set `sandbox:false`, `nodeIntegration:true`, `contextIsolation:false`, or
+`webSecurity:false`. Never expose Node/`ipcRenderer` on `window` — only scoped methods via
+`contextBridge`. Validate inputs at the IPC boundary. Full checklist: `docs/SECURITY.md`.
+
+## The contract
+
+- `src/shared/views.ts` — the **view model** the UI renders (`Memory`/`Task`/`BacklogItem`/
+  `FedItem`/`MatchHit`). `src/shared/ipc.ts` — the `window.api.*` surface + channels.
+- The worker projects its data model (`Item`/`Todo`/…) → the view model in
+  `src/main/services/project.ts`. That's the one place the **AI-gap** lives.
+- **"Wire real, plain":** structural data is served for real; AI-generated fields
+  (`brief`/`draft`/`note`, `gathering`→`drafted`) come back `null`/empty until the LLM layer
+  lands, and the UI degrades gracefully.
+
+## Verify before you PR
+
+```bash
+pnpm typecheck   # tsc node + web — must be green
+pnpm build       # electron-vite: main + worker, preload, renderer
+pnpm lint        # eslint; your changed files must be clean
+```
+
+- Pre-existing eslint debt lives in `src/shared/api/generated/**` (hey-api output) — not yours.
+- **No Electron runtime in CI/agents** → worker behavior (native `onnxruntime-node`, model
+  download, libSQL vector search) needs a live `pnpm dev` smoke test before merge.
+- Offline/dev fallback: `NEEME_EMBEDDER=hash pnpm dev` (skips the real model).
+
+## Stack & conventions
+
+- libSQL (`@libsql/client`) + Drizzle ORM; native vector search (`vector32`, `vector_distance_cos`).
+- Embeddings: transformers.js (MiniLM, 384-dim) behind the `Embedder` seam in `src/main/pipeline/embed.ts`.
+- Auth: Logto OIDC + PKCE in the system browser (ADR 0002), inert until configured.
+- Git: branch off `main`; commit/push only when asked; PRs get a smoke-test note for worker changes.
+- Decisions of record: `docs/adr/0001` (sync/processing), `0002` (auth), `0003` (all-TS on-device pipeline).

--- a/docs/agent-sync/INBOX.md
+++ b/docs/agent-sync/INBOX.md
@@ -1,0 +1,17 @@
+# Agent inbox — human → agent directives
+
+The other half of the loop: `SYNC-BRIEF.md` reports status *to* the human (auto-generated);
+this file carries directives *from* the human. Every agent reads it at the top of a run
+(see `CLAUDE.md`). **Tracked on purpose** — it has to reach agents in other worktrees.
+
+**Convention**
+- Newest on top. One line each: `@tag   directive`.
+- Tags: `@all` · `@backend` (`src/main`, `src/shared`, pipeline/worker) ·
+  `@frontend` (`src/renderer`, UI) · or a branch name (`@tray`, `@embedder`) for one PR.
+- **Delete a line once it's handled.** Keep this a whiteboard, not a log.
+
+---
+
+@all   #14 (contract) is in `main` — pull `main` fresh before starting new work.
+@embedder   #12 rebased on #14 + green; awaiting human force-push & live smoke test.
+@tray   rebase #13 on #14: re-add `UiApi`/`ui` + `traySetBadge` onto the new `ipc.ts`/`preload` (clean append).

--- a/docs/agent-sync/ROUTINE.md
+++ b/docs/agent-sync/ROUTINE.md
@@ -1,0 +1,54 @@
+# `sync-my-agents` routine config
+
+Paste these into the Claude Routine fields. The goal: a brief two agents can read
+in 10 seconds, generated fast. Terse > thorough — it answers one question per
+branch ("am I safe, what's my next move?"), nothing more.
+
+## Description
+
+> Scan open PRs/branches in this repo and flag where two agents are about to
+> collide (shared files, the IPC/DB contract, migrations). Emit a one-screen brief
+> with the merge order and a one-line next move per branch.
+
+## Instructions
+
+```
+Read-only. Output must fit on one screen (~20 lines). Speed > completeness.
+
+1. git fetch -p; gh pr list --state open --json number,title,headRefName
+2. Per open PR: git diff --name-only origin/main...<headRef>  (names only — do NOT read diffs)
+3. A collision = two PRs share a file. Only open a file if the shared file is in the
+   contract hotset: src/shared/**, src/main/index.ts, src/preload/**,
+   src/main/services/pipeline-service.ts, src/main/db/schema.ts. Otherwise just name it.
+4. Skip planning docs unless a hotset overlap is ambiguous on names alone.
+5. Write docs/agent-sync/SYNC-BRIEF.md in EXACTLY this shape — no prose sections:
+
+   # Sync — <date>
+   **Merge order:** #A → #B → #C
+
+   **Per branch — do this now:**
+   - #N <branch>: <ready to merge | rebase on #X then <1 clause how> | blocked: <why>>
+   - ...
+
+   **⚠ Real conflicts:** <file (#X×#Y)>, ... — everything else auto-merges.
+
+   If nothing is actionable, write one line: "All clear, no overlaps." Stop.
+```
+
+## Settings
+
+- **Model:** Haiku 4.5 is fine at this reduced scope (no diff/doc reading). Bump to
+  Sonnet only if you later want it to reason about *semantic* (non-file-overlap)
+  conflicts.
+- **Worktree:** off — it runs from the main checkout and reads siblings via
+  `git worktree list` / `gh pr`.
+- **Permissions:** Ask. It's read-only except the single `SYNC-BRIEF.md` write.
+
+## Why the first version was slow + verbose
+
+It read every PR's full diff and all planning docs, then wrote a paragraph per
+collision (~110 lines). The fixes above: `--name-only` overlaps + a contract-hotset
+rule (only open the 1–2 files that matter), and a hard output cap. Same intelligence,
+a fraction of the time and length — and less prose means fewer small guesses
+(the long version misnamed a dependency).
+```


### PR DESCRIPTION
Coordination scaffolding so two agents stay aligned without trading plan files.

## What

- **`CLAUDE.md`** (root) — standing agent guide, link-heavy to stay small in context:
  lanes (backend = `src/main`+`src/shared`, frontend = `src/renderer`), the
  read-before-you-start rule, process model + security invariants (→ `SECURITY.md`),
  the shared contract + "wire real, plain" (→ `INTEGRATION.md`), verify commands, ADRs.
- **`docs/agent-sync/INBOX.md`** — human→agent directives (tracked, so it crosses
  worktrees). Tag by lane, newest on top, delete a line once handled.
- **`docs/agent-sync/ROUTINE.md`** — the `sync-my-agents` routine config, tightened to
  emit a one-screen brief (merge order + one-line-per-branch) instead of a ~110-line report.
- **`.gitignore`** — ignores the generated `SYNC-BRIEF.md` (local scratchpad).

## The loop

```
status  ↓  SYNC-BRIEF.md  (auto-generated by the routine, gitignored — human reads it)
directives ↑  INBOX.md     (human writes, tracked — agents read it at top of run)
```

Solves the "auto agents don't stop mid-task" problem: the sync point is the task
boundary, and both files are short enough to read/seed there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)