### PR TITLE
docs(adr): AI model, OCR/ASR, repo structure (0004–0006)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -60,8 +60,8 @@ AI layer** once a model is chosen. Everything else parallelizes around that.
 Each is written up as an ADR — settle (ratify) each before starting the items it gates.
 
 1. **AI model (gates #3):** → [ADR 0004](adr/0004-ai-drafting-model.md)
-   _(accepted direction: `Drafter` seam, **cloud-first** (BYO-key) to ship the UX, on-device
-   benchmarked fast-follow for the latency/privacy win; device-breadth deferred)_.
+   _(accepted: **cloud (BYO-key) behind a `Drafter` seam** to ship; on-device LLM is an
+   optional parked spike, not a committed path)_.
 2. **OCR / ASR (gates #5):** on-device vs cloud → [ADR 0005](adr/0005-image-audio-extraction.md)
    _(proposed: on-device default, macOS-native fast path, cloud as later offload)_.
 3. **Repo structure (gates #14):** flat vs monorepo → [ADR 0006](adr/0006-repo-structure.md)

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -57,15 +57,14 @@ AI layer** once a model is chosen. Everything else parallelizes around that.
 
 ## ⚠️ Decisions that gate work
 
-ADR-worthy; settle each before starting the items it gates.
+Each is written up as an ADR — settle (ratify) each before starting the items it gates.
 
-1. **AI model (gates #3):** on-device LLM (llama.cpp / small local model) vs cloud API vs hybrid.
-   The on-device-first ↔ capability trade-off.
-2. **OCR / ASR (gates #5):** on-device (tesseract / whisper.cpp) vs cloud. Same trade-off.
-3. **Repo structure (gates #14):** adding an RN/Expo app in-repo turns this into a multi-app
-   repo — decide the layout now (turborepo/pnpm workspaces with `desktop` + `mobile` + a shared
-   `packages/contract` lifted from `src/shared`, vs a looser sibling). Cheaper to choose before
-   the Expo scaffold than to restructure after.
+1. **AI model (gates #3):** on-device LLM vs cloud vs hybrid → [ADR 0004](adr/0004-ai-drafting-model.md)
+   _(proposed: seam + hybrid, local default + cloud offload by BYO-key)_.
+2. **OCR / ASR (gates #5):** on-device vs cloud → [ADR 0005](adr/0005-image-audio-extraction.md)
+   _(proposed: on-device default, macOS-native fast path, cloud as later offload)_.
+3. **Repo structure (gates #14):** flat vs monorepo → [ADR 0006](adr/0006-repo-structure.md)
+   _(accepted: stay flat now, migrate to a workspace monorepo when the Expo app starts)_.
 
 **Native-packaging note (#13):** `onnxruntime-node` ships per-platform prebuilt binaries. macOS
 is the happy path; the Windows build is a deliberate canary to see _how_ it breaks. Fallback if

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -59,8 +59,9 @@ AI layer** once a model is chosen. Everything else parallelizes around that.
 
 Each is written up as an ADR — settle (ratify) each before starting the items it gates.
 
-1. **AI model (gates #3):** on-device LLM vs cloud vs hybrid → [ADR 0004](adr/0004-ai-drafting-model.md)
-   _(proposed: seam + hybrid, local default + cloud offload by BYO-key)_.
+1. **AI model (gates #3):** → [ADR 0004](adr/0004-ai-drafting-model.md)
+   _(accepted direction: `Drafter` seam, **cloud-first** (BYO-key) to ship the UX, on-device
+   benchmarked fast-follow for the latency/privacy win; device-breadth deferred)_.
 2. **OCR / ASR (gates #5):** on-device vs cloud → [ADR 0005](adr/0005-image-audio-extraction.md)
    _(proposed: on-device default, macOS-native fast path, cloud as later offload)_.
 3. **Repo structure (gates #14):** flat vs monorepo → [ADR 0006](adr/0006-repo-structure.md)

--- a/docs/adr/0004-ai-drafting-model.md
+++ b/docs/adr/0004-ai-drafting-model.md
@@ -1,114 +1,71 @@
 # ADR 0004 — AI drafting / chat model (the "AI-gap" layer)
 
-**Status:** Accepted direction — `Drafter` seam; **cloud-first to ship the experience, on-device as the benchmarked fast-follow** (the latency/privacy win). Device-breadth deferred. Open: managed-vs-BYO key, local model choice (below).
+**Status:** Accepted — **cloud (BYO-key) behind a `Drafter` seam.** On-device LLM is an _optional future spike_, not a committed path. Only open question: managed-key vs BYO-key.
 **Date:** 2026-06-01
 **Context owners:** jlee (+ Claude)
-**Related:** fills the AI-gap left by the contract convergence (`docs/INTEGRATION.md`); extends [[0003-all-typescript-on-device-pipeline]] (cloud = offload); touches [[0002-authentication]] (only if we host a managed key)
+**Related:** fills the AI-gap left by the contract convergence (`docs/INTEGRATION.md`); narrows [[0003-all-typescript-on-device-pipeline]] (cloud LLM was already its carve-out); touches [[0002-authentication]] (only if we host a managed key)
 
 ## Problem
 
-"Wire real, plain" shipped the structural data and left every AI-generated field `null`:
-`Task.brief`/`draft`/`note`, the `gathering→drafted` status, `BacklogItem.conf`, the
-per-context "why" strings, feed-inferred `UncoveredTodo`s, and "Ask Nimi" chat. This ADR
-decides **what generates that text**, and **in what order we build it**.
+"Wire real, plain" left every AI-generated field `null`: `Task.brief`/`draft`/`note`, the
+`gathering→drafted` status, `BacklogItem.conf`, the per-context "why" strings, feed-inferred
+`UncoveredTodo`s, and "Ask Nimi" chat. This ADR decides **what generates that text.**
 
-The honest tension: Nimi is a **personal-memory** app, so drafting prompts carry the user's
-private content, and on-device-first (0003) is the spine — which argues for a local model.
-But for _speed to ship the experience_, a local LLM is the slowest possible start (native
-addon, multi-GB download, packaging), while cloud is an HTTPS call. The resolution is a
-**seam** that lets us start fast and graduate, not pick one forever.
+The decision is shipping-first. On-device LLM is appealing (latency, privacy, 0003's spine)
+but it's the _slowest possible start_ — native addon, multi-GB model, packaging, device
+variance — and the goal right now is to **get Nimi into people's hands.** So: cloud now,
+local as a curiosity spike later.
 
 ## Options considered
 
 Legend: ✅ strong · ⚠️ caveats · ❌ poor
 
-| Option                                                                   | Draft quality           | Offline             | Privacy                      | $ to us                 | Ships in Electron          |
-| ------------------------------------------------------------------------ | ----------------------- | ------------------- | ---------------------------- | ----------------------- | -------------------------- |
-| A. Cloud frontier API only (we hold the key)                             | ✅                      | ❌                  | ⚠️ sends memory to 3rd party | ❌ per-token, we eat it | ✅ trivial                 |
-| B. On-device small LLM only (`node-llama-cpp`, Llama-3.2-3B/Qwen2.5/Phi) | ⚠️ ceiling              | ✅                  | ✅                           | ✅ free                 | ⚠️ native addon + GB model |
-| C. Seam: cloud first, on-device fast-follow _(recommended)_              | ✅ now → ✅ local later | ✅ once local lands | ✅ (cloud opt-in/keyed)      | ✅ BYO-key              | ✅                         |
-| D. BYO-key, provider-agnostic (user supplies Claude/OpenAI/local)        | ✅                      | ⚠️                  | ✅ user's choice             | ✅ zero                 | ✅                         |
+| Option                                          | Quality    | Speed to ship               | $ to us      | Privacy                |
+| ----------------------------------------------- | ---------- | --------------------------- | ------------ | ---------------------- |
+| A. Cloud, we hold the key                       | ✅         | ✅                          | ❌ per-token | ⚠️                     |
+| B. Cloud, **BYO-key**, behind a seam _(chosen)_ | ✅         | ✅ HTTPS call               | ✅ zero      | ✅ user opts in + keys |
+| C. On-device small LLM                          | ⚠️ ceiling | ❌ weeks of native-ML setup | ✅           | ✅                     |
 
-### Notes
-
-- **A** — fastest to _ship_, but offline-breaking, we pay per user, and routes private memory
-  to a vendor by default. Right as _phase 1 behind a seam_, wrong as the permanent only-path.
-- **B** — purest 0003 fit and the latency end-goal, but the _slowest start_: a 3B model is
-  mediocre at long drafts, multi-GB download + device variance is real, and it's weeks of
-  native-ML yak-shaving before the first drafted reply.
-- **C + D (recommended)** — a `Drafter` seam (mirrors the `Embedder` seam) with BYO-key so we
-  eat no token cost. Ship the cloud impl first to validate the UX; slot the local impl in
-  later behind the same interface. Exactly 0003's "cloud = offload for the big chat LLM,"
-  just sequenced for dev speed.
+**B** wins on every axis that matters for shipping: frontier quality immediately, an HTTPS
+call (no native deps), no token cost on us pre-revenue, and the user opts in with their own
+key. The **seam** (mirrors `Embedder`'s `NIMI_EMBEDDER`) means a local impl could drop in
+later with zero caller changes — so choosing cloud now forecloses nothing.
 
 ## Recommendation
 
-Build a **`Drafter` seam** (like `Embedder`) and **sequence cloud → local**:
+**Build a `Drafter` seam and ship the cloud impl (BYO-key, default Claude).**
 
-**Phase 1 — cloud, BYO-key (ship the experience, fast).** Wire `brief`/`draft`/Ask-Nimi
-through a cloud provider (default Claude) the user keys. An HTTPS call — hours, not weeks; no
-native addon, no model download, frontier quality immediately. This validates the product UX.
-BYO-key = zero token cost on us pre-revenue; opt-in with a clear "this sends the relevant
-memories to <provider>" consent. No device-capability question → **v1 ships everywhere.**
+- Wire `brief`/`draft`/Ask-Nimi through it; opt-in, with a clear "this sends the relevant
+  memories to <provider>" consent.
+- The projection layer (`src/main/services/project.ts`) already isolates every AI-gap field,
+  so the UI degrades gracefully when AI is off or unkeyed.
+- No device-capability question → **v1 ships everywhere.**
 
-**Phase 2 — on-device, benchmarked fast-follow (the latency/privacy win).** Add a local impl
-(`node-llama-cpp`, lazy model cached in userData like the embedder) behind the _same_ seam,
-**measured against the cloud output as the quality + latency bar**. Per-capability graduation:
-short/structured generations (`note`/`noteKind`, `brief`, `BacklogItem.conf`,
-feed→`UncoveredTodo`) move local first — cheap, latency-sensitive, easiest to clear the bar;
-long-form `draft` + Ask-Nimi stay cloud until/unless local is good enough. Best case "all
-local," worst case "long drafts stay cloud."
+### Sidequest (optional, unscheduled): on-device LLM spike
 
-The projection layer (`src/main/services/project.ts`) isolates every AI-gap field, so the UI
-degrades gracefully whenever AI is off or unkeyed.
-
-### Why this order
-
-Ease-of-dev + speed-to-begin is the axis that matters to _start_, and on it cloud wins
-decisively: an API call vs a native addon + multi-GB download + packaging matrix. The **seam**
-keeps it non-throwaway — local drops in later with zero caller changes (same pattern as
-`NIMI_EMBEDDER`), and the cloud output becomes the **benchmark** for local. On-device
-latency/privacy (0003's driver — skipping the record→upload→process→respond loop) is a
-_runtime_ optimization applied once the experience is proven worth it.
-
-### v1 scope — defer the device problem
-
-Cloud-first has no device-capability question, so v1 just ships. When on-device lands later,
-"device too weak to run local" is handled **free** by the graceful-null state we already built
-("wire real, plain"). Min-spec probes, device tiers, quantized models — all a **success
-problem**: if we ever have so many users that some can't run local, we'll have earned the
-right to solve it. Not now.
-
-### No chatty hybrid
-
-When local lands, keep each capability end-to-end on **one** side. A split that ferries
-embeddings/intermediate state across the network re-adds the very round-trip latency on-device
-is meant to kill — a capability is fully local or fully cloud, never half mid-pipeline.
+If/when curiosity or a privacy/latency need warrants it, run a _time-boxed spike_ behind the
+same seam: a small model via `node-llama-cpp` (lazy-downloaded, cached like the embedder),
+benchmarked against the cloud output as the quality bar, on capable hardware only. It's a
+sidequest — not a roadmap commitment, not a launch blocker. If a device can't run it, the
+graceful-null state already covers that for free.
 
 ## Consequences
 
-- **Easier:** the experience ships in days, not weeks; no native-ML packaging to _start_;
-  privacy stays honest (cloud opt-in + keyed; local later); the seam keeps model + provider
-  swappable.
-- **Harder:** eventually two impls to maintain; `node-llama-cpp` enters the packaging matrix
-  when phase 2 starts (we already carry `onnxruntime-node`); a settings surface for the key +
-  provider; prompt-injection hygiene once memory content feeds prompts.
+- **Easier:** the experience ships in days; no native-ML packaging; the seam keeps provider +
+  (future) local model swappable.
+- **Harder:** a cloud dependency for the AI features (the rest of the app stays fully local +
+  offline); a settings surface for the key; prompt-injection hygiene once memory feeds prompts.
 
-## Open questions
+## Open question
 
-- **Managed key (we proxy — simplest UX, but cost + an auth need → re-opens [[0002]]) vs
-  strict BYO-key (zero cost, more friction)? — the phase-1 fork to decide first.**
-- Which local model + the per-capability bar for phase 2 (the thing to actually benchmark).
-- Streaming "Ask Nimi" over IPC — chunked events on the existing `window.api` seam.
-- Does `gathering`/`drafted` status become real only when the Drafter runs, or do we infer
-  `gathering` structurally (open + empty context)?
+- **Managed key (we proxy — smoother UX, but cost + an auth need → re-opens [[0002]]) vs
+  strict BYO-key (zero cost, no accounts, more setup friction)?** Lean BYO-key for v1 (cheap,
+  no auth); revisit managed-key only if a frictionless consumer launch demands it.
 
 ## Action items
 
 1. [ ] Define the `Drafter` interface + a `NIMI_DRAFTER` env seam (mirror `embed.ts`).
-2. [ ] Decide managed-key vs BYO-key (phase 1's one real fork).
-3. [ ] **Phase 1:** wire the cloud impl (BYO-key, Claude) feeding `brief` + `draft` for one
-       task end-to-end through the seam → validate the UX.
+2. [ ] Decide managed-key vs BYO-key (the one fork).
+3. [ ] Wire the cloud impl (BYO-key, Claude) feeding `brief` + `draft` for one task end-to-end.
 4. [ ] Settings: provider + key + the consent copy.
-5. [ ] **Phase 2 (later):** on-device impl behind the same seam, benchmarked per-capability
-       against the cloud output.
+5. [ ] _(Sidequest, optional)_ on-device spike behind the same seam, benchmarked vs cloud.

--- a/docs/adr/0004-ai-drafting-model.md
+++ b/docs/adr/0004-ai-drafting-model.md
@@ -1,0 +1,85 @@
+# ADR 0004 — AI drafting / chat model (the "AI-gap" layer)
+
+**Status:** Proposed (recommends a provider seam + hybrid: on-device default, cloud offload by BYO-key)
+**Date:** 2026-06-01
+**Context owners:** jlee (+ Claude)
+**Related:** fills the AI-gap left by the contract convergence (`docs/INTEGRATION.md`); extends [[0003-all-typescript-on-device-pipeline]] (cloud = offload); touches [[0002-authentication]] (only if we host a managed key)
+
+## Problem
+
+"Wire real, plain" shipped the structural data and left every AI-generated field `null`:
+`Task.brief`/`draft`/`note`, the `gathering→drafted` status, `BacklogItem.conf`, the
+per-context "why" strings, feed-inferred `UncoveredTodo`s, and "Ask Nimi" chat. This ADR
+decides **what generates that text** — and how it squares with on-device-first.
+
+The honest tension: Nimi is a **personal-memory** app, so drafting prompts carry the user's
+private content (emails, notes, calendar). And on-device-first (0003) is the spine. But
+small local models draft markedly worse than frontier cloud models — and 0003 already
+carved out "big chat LLM" as a legitimate **cloud-offload** case.
+
+## Options considered
+
+Legend: ✅ strong · ⚠️ caveats · ❌ poor
+
+| Option                                                                   | Draft quality      | Offline     | Privacy                      | $ to us                 | Ships in Electron          |
+| ------------------------------------------------------------------------ | ------------------ | ----------- | ---------------------------- | ----------------------- | -------------------------- |
+| A. Cloud frontier API only (we hold the key)                             | ✅                 | ❌          | ⚠️ sends memory to 3rd party | ❌ per-token, we eat it | ✅ trivial                 |
+| B. On-device small LLM only (`node-llama-cpp`, Llama-3.2-3B/Qwen2.5/Phi) | ⚠️ ceiling         | ✅          | ✅                           | ✅ free                 | ⚠️ native addon + GB model |
+| C. Hybrid behind a seam: local default, cloud offload _(recommended)_    | ✅ when it matters | ✅ degraded | ✅ by default                | ✅ user-keyed           | ✅                         |
+| D. BYO-key, provider-agnostic (user supplies Claude/OpenAI/local)        | ✅                 | ⚠️          | ✅ user's choice             | ✅ zero                 | ✅                         |
+
+### Notes
+
+- **A** — fastest to ship the magic, but it breaks the offline promise, makes us pay per
+  user, and routes private memory to a vendor by default. Fine as _an_ option, wrong as the
+  _only_ one for this app.
+- **B** — purest 0003 fit, but a 3B-class model writes mediocre replies and a multi-GB
+  download + device variance is real. Great for the _cheap_ generations (status, short
+  briefs, todo inference), not for the headline draft.
+- **C + D (recommended together)** — mirror the **Embedder seam** that already worked: a
+  `Drafter` interface with a local impl (default: private, free, offline, good enough for
+  structured/short output) and a cloud impl the user enables **with their own key** (BYO)
+  for quality-sensitive drafting + "Ask Nimi". This is exactly 0003's "cloud = offload for
+  the big chat LLM," and BYO-key means we don't eat token cost pre-revenue.
+
+## Recommendation
+
+**Build a `Drafter` seam (like `Embedder`) and ship hybrid:**
+
+- **Local default** (`node-llama-cpp`, small instruct model, lazy-downloaded + cached in
+  userData like the embedder) handles the always-on, privacy-sensitive, cheap generations:
+  task `note`/`noteKind`, `brief` summaries over the context pool, `BacklogItem.conf`, and
+  feed→`UncoveredTodo` inference.
+- **Cloud offload, opt-in + BYO-key** (default provider: Claude) for the quality bar:
+  long `draft` bodies and the "Ask Nimi" conversation. Off by default; enabling it shows a
+  clear "this sends the relevant memories to <provider>" consent.
+- The projection layer (`src/main/services/project.ts`) already isolates every AI-gap field
+  — the Drafter feeds exactly those, so the UI keeps degrading gracefully when AI is off.
+
+Pragmatic v1: wire the **cloud BYO-key path first** (fastest route to the actual experience;
+local-LLM packaging is heavy), with the seam in place so the local impl is a fast-follow.
+
+## Consequences
+
+- **Easier:** the magic ships; privacy story is honest (local default, cloud opt-in); no
+  per-token cost on us; the seam keeps model choice swappable.
+- **Harder:** two code paths to maintain; `node-llama-cpp` is another native addon in the
+  packaging matrix (we already carry `onnxruntime-node`); a settings surface for the key +
+  the local/cloud toggle; prompt-injection hygiene once memory content feeds prompts.
+
+## Open questions
+
+- Which local model (size vs quality vs download) — and do we even ship local in v1 or
+  seam-only + cloud-first?
+- Managed key (we proxy, simplest UX, but cost + an auth need → re-opens [[0002]]) vs strict
+  BYO-key (zero cost, more friction)?
+- Streaming "Ask Nimi" over IPC — chunked events on the existing `window.api` seam.
+- Does `gathering`/`drafted` status become real only when the Drafter runs, or do we infer
+  `gathering` structurally (open + empty context)?
+
+## Action items
+
+1. [ ] Define the `Drafter` interface + a `NIMI_DRAFTER` env seam (mirror `embed.ts`).
+2. [ ] Wire one path end-to-end (cloud BYO-key) feeding `brief` + `draft` for one task.
+3. [ ] Settings: provider + key + local/cloud toggle + the consent copy.
+4. [ ] Decide local model + lazy-download story (or defer local to a follow-up).

--- a/docs/adr/0004-ai-drafting-model.md
+++ b/docs/adr/0004-ai-drafting-model.md
@@ -1,6 +1,6 @@
 # ADR 0004 — AI drafting / chat model (the "AI-gap" layer)
 
-**Status:** Accepted direction — **on-device happy path, benchmark-gated; cloud as the measured worst-case cutover** (per-capability). Open: local model choice, managed-vs-BYO key (below).
+**Status:** Accepted direction — `Drafter` seam; **cloud-first to ship the experience, on-device as the benchmarked fast-follow** (the latency/privacy win). Device-breadth deferred. Open: managed-vs-BYO key, local model choice (below).
 **Date:** 2026-06-01
 **Context owners:** jlee (+ Claude)
 **Related:** fills the AI-gap left by the contract convergence (`docs/INTEGRATION.md`); extends [[0003-all-typescript-on-device-pipeline]] (cloud = offload); touches [[0002-authentication]] (only if we host a managed key)
@@ -10,110 +10,95 @@
 "Wire real, plain" shipped the structural data and left every AI-generated field `null`:
 `Task.brief`/`draft`/`note`, the `gathering→drafted` status, `BacklogItem.conf`, the
 per-context "why" strings, feed-inferred `UncoveredTodo`s, and "Ask Nimi" chat. This ADR
-decides **what generates that text** — and how it squares with on-device-first.
+decides **what generates that text**, and **in what order we build it**.
 
 The honest tension: Nimi is a **personal-memory** app, so drafting prompts carry the user's
-private content (emails, notes, calendar). And on-device-first (0003) is the spine. But
-small local models draft markedly worse than frontier cloud models — and 0003 already
-carved out "big chat LLM" as a legitimate **cloud-offload** case.
+private content, and on-device-first (0003) is the spine — which argues for a local model.
+But for _speed to ship the experience_, a local LLM is the slowest possible start (native
+addon, multi-GB download, packaging), while cloud is an HTTPS call. The resolution is a
+**seam** that lets us start fast and graduate, not pick one forever.
 
 ## Options considered
 
 Legend: ✅ strong · ⚠️ caveats · ❌ poor
 
-| Option                                                                   | Draft quality      | Offline     | Privacy                      | $ to us                 | Ships in Electron          |
-| ------------------------------------------------------------------------ | ------------------ | ----------- | ---------------------------- | ----------------------- | -------------------------- |
-| A. Cloud frontier API only (we hold the key)                             | ✅                 | ❌          | ⚠️ sends memory to 3rd party | ❌ per-token, we eat it | ✅ trivial                 |
-| B. On-device small LLM only (`node-llama-cpp`, Llama-3.2-3B/Qwen2.5/Phi) | ⚠️ ceiling         | ✅          | ✅                           | ✅ free                 | ⚠️ native addon + GB model |
-| C. Hybrid behind a seam: local default, cloud offload _(recommended)_    | ✅ when it matters | ✅ degraded | ✅ by default                | ✅ user-keyed           | ✅                         |
-| D. BYO-key, provider-agnostic (user supplies Claude/OpenAI/local)        | ✅                 | ⚠️          | ✅ user's choice             | ✅ zero                 | ✅                         |
+| Option                                                                   | Draft quality           | Offline             | Privacy                      | $ to us                 | Ships in Electron          |
+| ------------------------------------------------------------------------ | ----------------------- | ------------------- | ---------------------------- | ----------------------- | -------------------------- |
+| A. Cloud frontier API only (we hold the key)                             | ✅                      | ❌                  | ⚠️ sends memory to 3rd party | ❌ per-token, we eat it | ✅ trivial                 |
+| B. On-device small LLM only (`node-llama-cpp`, Llama-3.2-3B/Qwen2.5/Phi) | ⚠️ ceiling              | ✅                  | ✅                           | ✅ free                 | ⚠️ native addon + GB model |
+| C. Seam: cloud first, on-device fast-follow _(recommended)_              | ✅ now → ✅ local later | ✅ once local lands | ✅ (cloud opt-in/keyed)      | ✅ BYO-key              | ✅                         |
+| D. BYO-key, provider-agnostic (user supplies Claude/OpenAI/local)        | ✅                      | ⚠️                  | ✅ user's choice             | ✅ zero                 | ✅                         |
 
 ### Notes
 
-- **A** — fastest to ship the magic, but it breaks the offline promise, makes us pay per
-  user, and routes private memory to a vendor by default. Fine as _an_ option, wrong as the
-  _only_ one for this app.
-- **B** — purest 0003 fit, but a 3B-class model writes mediocre replies and a multi-GB
-  download + device variance is real. Great for the _cheap_ generations (status, short
-  briefs, todo inference), not for the headline draft.
-- **C + D (recommended together)** — mirror the **Embedder seam** that already worked: a
-  `Drafter` interface with a local impl (default: private, free, offline, good enough for
-  structured/short output) and a cloud impl the user enables **with their own key** (BYO)
-  for quality-sensitive drafting + "Ask Nimi". This is exactly 0003's "cloud = offload for
-  the big chat LLM," and BYO-key means we don't eat token cost pre-revenue.
+- **A** — fastest to _ship_, but offline-breaking, we pay per user, and routes private memory
+  to a vendor by default. Right as _phase 1 behind a seam_, wrong as the permanent only-path.
+- **B** — purest 0003 fit and the latency end-goal, but the _slowest start_: a 3B model is
+  mediocre at long drafts, multi-GB download + device variance is real, and it's weeks of
+  native-ML yak-shaving before the first drafted reply.
+- **C + D (recommended)** — a `Drafter` seam (mirrors the `Embedder` seam) with BYO-key so we
+  eat no token cost. Ship the cloud impl first to validate the UX; slot the local impl in
+  later behind the same interface. Exactly 0003's "cloud = offload for the big chat LLM,"
+  just sequenced for dev speed.
 
 ## Recommendation
 
-**Build a `Drafter` seam (like `Embedder`) and ship hybrid:**
+Build a **`Drafter` seam** (like `Embedder`) and **sequence cloud → local**:
 
-- **Local default** (`node-llama-cpp`, small instruct model, lazy-downloaded + cached in
-  userData like the embedder) handles the always-on, privacy-sensitive, cheap generations:
-  task `note`/`noteKind`, `brief` summaries over the context pool, `BacklogItem.conf`, and
-  feed→`UncoveredTodo` inference.
-- **Cloud offload, opt-in + BYO-key** (default provider: Claude) for the quality bar:
-  long `draft` bodies and the "Ask Nimi" conversation. Off by default; enabling it shows a
-  clear "this sends the relevant memories to <provider>" consent.
-- The projection layer (`src/main/services/project.ts`) already isolates every AI-gap field
-  — the Drafter feeds exactly those, so the UI keeps degrading gracefully when AI is off.
+**Phase 1 — cloud, BYO-key (ship the experience, fast).** Wire `brief`/`draft`/Ask-Nimi
+through a cloud provider (default Claude) the user keys. An HTTPS call — hours, not weeks; no
+native addon, no model download, frontier quality immediately. This validates the product UX.
+BYO-key = zero token cost on us pre-revenue; opt-in with a clear "this sends the relevant
+memories to <provider>" consent. No device-capability question → **v1 ships everywhere.**
 
-### Sequencing — happy path first, measure, cut over only if needed
+**Phase 2 — on-device, benchmarked fast-follow (the latency/privacy win).** Add a local impl
+(`node-llama-cpp`, lazy model cached in userData like the embedder) behind the _same_ seam,
+**measured against the cloud output as the quality + latency bar**. Per-capability graduation:
+short/structured generations (`note`/`noteKind`, `brief`, `BacklogItem.conf`,
+feed→`UncoveredTodo`) move local first — cheap, latency-sensitive, easiest to clear the bar;
+long-form `draft` + Ask-Nimi stay cloud until/unless local is good enough. Best case "all
+local," worst case "long drafts stay cloud."
 
-The call (consistent with 0003's "spike + measure before committing"): **build the on-device
-path first and benchmark it.** Local is not just the principled default — it's _quicker_ for
-the common case (no network round-trip; 0003's speed/latency/offline driver). Only build the
-cloud path and cut over **where the numbers say local isn't good enough** — and that cutover
-is **per-capability, not wholesale**.
+The projection layer (`src/main/services/project.ts`) isolates every AI-gap field, so the UI
+degrades gracefully whenever AI is off or unkeyed.
 
-**The "good enough" bar (define before building):** acceptable draft quality on real tasks
-(reply-to-email, one-pager brief) + a latency target on the **v1 target device** (Apple
-Silicon — get it working _there_ first). Low-end/weak-hardware viability is the capability
-probe's job _later_, not a launch gate. Measure each capability against it.
+### Why this order
 
-Likely outcome by capability (to be confirmed by benchmark, not assumed):
+Ease-of-dev + speed-to-begin is the axis that matters to _start_, and on it cloud wins
+decisively: an API call vs a native addon + multi-GB download + packaging matrix. The **seam**
+keeps it non-throwaway — local drops in later with zero caller changes (same pattern as
+`NIMI_EMBEDDER`), and the cloud output becomes the **benchmark** for local. On-device
+latency/privacy (0003's driver — skipping the record→upload→process→respond loop) is a
+_runtime_ optimization applied once the experience is proven worth it.
 
-- **Cheap/structured — stays local:** `note`/`noteKind`, `brief` over the context pool,
-  `BacklogItem.conf`, feed→`UncoveredTodo` inference. Short, templated, latency-sensitive.
-- **Long-form `draft` + "Ask Nimi" — the most likely to fail the bar** → the first/only
-  capability that cuts over to cloud offload (opt-in, BYO-key) if local can't clear it.
+### v1 scope — defer the device problem
 
-So: ship local, benchmark, and let the bar — per capability — decide what (if anything)
-graduates to cloud. Worst case is "long drafts go cloud"; best case is "all local."
+Cloud-first has no device-capability question, so v1 just ships. When on-device lands later,
+"device too weak to run local" is handled **free** by the graceful-null state we already built
+("wire real, plain"). Min-spec probes, device tiers, quantized models — all a **success
+problem**: if we ever have so many users that some can't run local, we'll have earned the
+right to solve it. Not now.
 
-### Device capability gate + v1 scope
+### No chatty hybrid
 
-Local inference is hardware-bound and not every device clears the bar. Two rules:
-
-- **v1: get it working _somewhere_, not everywhere.** Target capable hardware first (the
-  Apple-Silicon dev machine) and ship the local path there. Broadening device reach
-  (quantized/smaller models, tiers, weak-Intel/Windows) is a later concern, **not a launch
-  blocker** — don't let universal coverage gate getting the loop working at all.
-- **Runtime capability probe.** On first use, check the device against a **minimum spec**
-  (arch / RAM / accelerator, or a quick timed warm-up inference). Clears it → local Drafter
-  on. Below it → fall back to cloud (opt-in) or simply the **graceful-null state the UI
-  already handles** ("wire real, plain": no draft, neutral status). The "device too weak"
-  path is _free_ — it's the degrade path we already built, not new work.
-
-**No chatty hybrid.** Keep each capability end-to-end on **one** side. A split that ferries
-embeddings / intermediate state back and forth over the network reintroduces exactly the
-round-trip latency on-device is meant to kill — so a capability is _fully_ local or _fully_
-cloud, never half-and-half mid-pipeline. (This is the latency win you're really after: skip
-the record→upload→process→respond loop, not just the upload.)
+When local lands, keep each capability end-to-end on **one** side. A split that ferries
+embeddings/intermediate state across the network re-adds the very round-trip latency on-device
+is meant to kill — a capability is fully local or fully cloud, never half mid-pipeline.
 
 ## Consequences
 
-- **Easier:** the magic ships; privacy story is honest (local default, cloud opt-in); no
-  per-token cost on us; the seam keeps model choice swappable.
-- **Harder:** two code paths to maintain; `node-llama-cpp` is another native addon in the
-  packaging matrix (we already carry `onnxruntime-node`); a settings surface for the key +
-  the local/cloud toggle; prompt-injection hygiene once memory content feeds prompts.
+- **Easier:** the experience ships in days, not weeks; no native-ML packaging to _start_;
+  privacy stays honest (cloud opt-in + keyed; local later); the seam keeps model + provider
+  swappable.
+- **Harder:** eventually two impls to maintain; `node-llama-cpp` enters the packaging matrix
+  when phase 2 starts (we already carry `onnxruntime-node`); a settings surface for the key +
+  provider; prompt-injection hygiene once memory content feeds prompts.
 
 ## Open questions
 
-- Which local model (size vs quality vs download), and what's the per-capability bar that
-  triggers a cloud cutover? (Decided: local ships first and gets benchmarked — this is the
-  one to actually measure.)
-- Managed key (we proxy, simplest UX, but cost + an auth need → re-opens [[0002]]) vs strict
-  BYO-key (zero cost, more friction)?
+- **Managed key (we proxy — simplest UX, but cost + an auth need → re-opens [[0002]]) vs
+  strict BYO-key (zero cost, more friction)? — the phase-1 fork to decide first.**
+- Which local model + the per-capability bar for phase 2 (the thing to actually benchmark).
 - Streaming "Ask Nimi" over IPC — chunked events on the existing `window.api` seam.
 - Does `gathering`/`drafted` status become real only when the Drafter runs, or do we infer
   `gathering` structurally (open + empty context)?
@@ -121,11 +106,9 @@ the record→upload→process→respond loop, not just the upload.)
 ## Action items
 
 1. [ ] Define the `Drafter` interface + a `NIMI_DRAFTER` env seam (mirror `embed.ts`).
-2. [ ] Set the "good enough" bar on the **v1 target** (Apple Silicon): real-task quality + latency.
-3. [ ] Build the **on-device** Drafter first (`node-llama-cpp`, lazy model) → benchmark
-       `brief` + `draft` against the bar, per capability. Get it working _there_ before
-       worrying about device breadth.
-4. [ ] Add a runtime **capability probe** (min-spec / timed warm-up) → enable local only when
-       cleared; below it, fall back to cloud (opt-in) or the existing graceful-null state.
-5. [ ] Only for capabilities that miss the bar: add the cloud offload (opt-in, BYO-key) +
-       the consent/settings surface, and cut those over.
+2. [ ] Decide managed-key vs BYO-key (phase 1's one real fork).
+3. [ ] **Phase 1:** wire the cloud impl (BYO-key, Claude) feeding `brief` + `draft` for one
+       task end-to-end through the seam → validate the UX.
+4. [ ] Settings: provider + key + the consent copy.
+5. [ ] **Phase 2 (later):** on-device impl behind the same seam, benchmarked per-capability
+       against the cloud output.

--- a/docs/adr/0004-ai-drafting-model.md
+++ b/docs/adr/0004-ai-drafting-model.md
@@ -65,8 +65,9 @@ cloud path and cut over **where the numbers say local isn't good enough** — an
 is **per-capability, not wholesale**.
 
 **The "good enough" bar (define before building):** acceptable draft quality on real tasks
-(reply-to-email, one-pager brief) + a latency target on a **low-end device**, not just Apple
-Silicon. Measure each capability against it.
+(reply-to-email, one-pager brief) + a latency target on the **v1 target device** (Apple
+Silicon — get it working _there_ first). Low-end/weak-hardware viability is the capability
+probe's job _later_, not a launch gate. Measure each capability against it.
 
 Likely outcome by capability (to be confirmed by benchmark, not assumed):
 
@@ -77,6 +78,26 @@ Likely outcome by capability (to be confirmed by benchmark, not assumed):
 
 So: ship local, benchmark, and let the bar — per capability — decide what (if anything)
 graduates to cloud. Worst case is "long drafts go cloud"; best case is "all local."
+
+### Device capability gate + v1 scope
+
+Local inference is hardware-bound and not every device clears the bar. Two rules:
+
+- **v1: get it working _somewhere_, not everywhere.** Target capable hardware first (the
+  Apple-Silicon dev machine) and ship the local path there. Broadening device reach
+  (quantized/smaller models, tiers, weak-Intel/Windows) is a later concern, **not a launch
+  blocker** — don't let universal coverage gate getting the loop working at all.
+- **Runtime capability probe.** On first use, check the device against a **minimum spec**
+  (arch / RAM / accelerator, or a quick timed warm-up inference). Clears it → local Drafter
+  on. Below it → fall back to cloud (opt-in) or simply the **graceful-null state the UI
+  already handles** ("wire real, plain": no draft, neutral status). The "device too weak"
+  path is _free_ — it's the degrade path we already built, not new work.
+
+**No chatty hybrid.** Keep each capability end-to-end on **one** side. A split that ferries
+embeddings / intermediate state back and forth over the network reintroduces exactly the
+round-trip latency on-device is meant to kill — so a capability is _fully_ local or _fully_
+cloud, never half-and-half mid-pipeline. (This is the latency win you're really after: skip
+the record→upload→process→respond loop, not just the upload.)
 
 ## Consequences
 
@@ -100,8 +121,11 @@ graduates to cloud. Worst case is "long drafts go cloud"; best case is "all loca
 ## Action items
 
 1. [ ] Define the `Drafter` interface + a `NIMI_DRAFTER` env seam (mirror `embed.ts`).
-2. [ ] Set the "good enough" bar: real-task quality + a latency target on a low-end device.
+2. [ ] Set the "good enough" bar on the **v1 target** (Apple Silicon): real-task quality + latency.
 3. [ ] Build the **on-device** Drafter first (`node-llama-cpp`, lazy model) → benchmark
-       `brief` + `draft` against the bar, per capability.
-4. [ ] Only for capabilities that miss the bar: add the cloud offload (opt-in, BYO-key) +
+       `brief` + `draft` against the bar, per capability. Get it working _there_ before
+       worrying about device breadth.
+4. [ ] Add a runtime **capability probe** (min-spec / timed warm-up) → enable local only when
+       cleared; below it, fall back to cloud (opt-in) or the existing graceful-null state.
+5. [ ] Only for capabilities that miss the bar: add the cloud offload (opt-in, BYO-key) +
        the consent/settings surface, and cut those over.

--- a/docs/adr/0004-ai-drafting-model.md
+++ b/docs/adr/0004-ai-drafting-model.md
@@ -1,6 +1,6 @@
 # ADR 0004 — AI drafting / chat model (the "AI-gap" layer)
 
-**Status:** Proposed (recommends a provider seam + hybrid: on-device default, cloud offload by BYO-key)
+**Status:** Accepted direction — **on-device happy path, benchmark-gated; cloud as the measured worst-case cutover** (per-capability). Open: local model choice, managed-vs-BYO key (below).
 **Date:** 2026-06-01
 **Context owners:** jlee (+ Claude)
 **Related:** fills the AI-gap left by the contract convergence (`docs/INTEGRATION.md`); extends [[0003-all-typescript-on-device-pipeline]] (cloud = offload); touches [[0002-authentication]] (only if we host a managed key)
@@ -56,8 +56,27 @@ Legend: ✅ strong · ⚠️ caveats · ❌ poor
 - The projection layer (`src/main/services/project.ts`) already isolates every AI-gap field
   — the Drafter feeds exactly those, so the UI keeps degrading gracefully when AI is off.
 
-Pragmatic v1: wire the **cloud BYO-key path first** (fastest route to the actual experience;
-local-LLM packaging is heavy), with the seam in place so the local impl is a fast-follow.
+### Sequencing — happy path first, measure, cut over only if needed
+
+The call (consistent with 0003's "spike + measure before committing"): **build the on-device
+path first and benchmark it.** Local is not just the principled default — it's _quicker_ for
+the common case (no network round-trip; 0003's speed/latency/offline driver). Only build the
+cloud path and cut over **where the numbers say local isn't good enough** — and that cutover
+is **per-capability, not wholesale**.
+
+**The "good enough" bar (define before building):** acceptable draft quality on real tasks
+(reply-to-email, one-pager brief) + a latency target on a **low-end device**, not just Apple
+Silicon. Measure each capability against it.
+
+Likely outcome by capability (to be confirmed by benchmark, not assumed):
+
+- **Cheap/structured — stays local:** `note`/`noteKind`, `brief` over the context pool,
+  `BacklogItem.conf`, feed→`UncoveredTodo` inference. Short, templated, latency-sensitive.
+- **Long-form `draft` + "Ask Nimi" — the most likely to fail the bar** → the first/only
+  capability that cuts over to cloud offload (opt-in, BYO-key) if local can't clear it.
+
+So: ship local, benchmark, and let the bar — per capability — decide what (if anything)
+graduates to cloud. Worst case is "long drafts go cloud"; best case is "all local."
 
 ## Consequences
 
@@ -69,8 +88,9 @@ local-LLM packaging is heavy), with the seam in place so the local impl is a fas
 
 ## Open questions
 
-- Which local model (size vs quality vs download) — and do we even ship local in v1 or
-  seam-only + cloud-first?
+- Which local model (size vs quality vs download), and what's the per-capability bar that
+  triggers a cloud cutover? (Decided: local ships first and gets benchmarked — this is the
+  one to actually measure.)
 - Managed key (we proxy, simplest UX, but cost + an auth need → re-opens [[0002]]) vs strict
   BYO-key (zero cost, more friction)?
 - Streaming "Ask Nimi" over IPC — chunked events on the existing `window.api` seam.
@@ -80,6 +100,8 @@ local-LLM packaging is heavy), with the seam in place so the local impl is a fas
 ## Action items
 
 1. [ ] Define the `Drafter` interface + a `NIMI_DRAFTER` env seam (mirror `embed.ts`).
-2. [ ] Wire one path end-to-end (cloud BYO-key) feeding `brief` + `draft` for one task.
-3. [ ] Settings: provider + key + local/cloud toggle + the consent copy.
-4. [ ] Decide local model + lazy-download story (or defer local to a follow-up).
+2. [ ] Set the "good enough" bar: real-task quality + a latency target on a low-end device.
+3. [ ] Build the **on-device** Drafter first (`node-llama-cpp`, lazy model) → benchmark
+       `brief` + `draft` against the bar, per capability.
+4. [ ] Only for capabilities that miss the bar: add the cloud offload (opt-in, BYO-key) +
+       the consent/settings surface, and cut those over.

--- a/docs/adr/0005-image-audio-extraction.md
+++ b/docs/adr/0005-image-audio-extraction.md
@@ -56,6 +56,11 @@ Legend: ✅ strong · ⚠️ caveats · ❌ poor
 This keeps the most privacy-sensitive captures (photos, voice) **on the device** by default,
 exactly the on-device-first intent of 0003, while leaving a quality escape hatch.
 
+Same **measure-first** rule as 0004: ship on-device, benchmark against a quality bar (clean
+screenshot OCR accuracy, clear-speech WER, latency on a low-end device), and cut a capability
+to cloud only where it misses. On-device OCR/ASR is mature, so the bar should clear easily —
+unlike drafting, this is the case least likely to ever need the cloud fallback.
+
 ## Consequences
 
 - **Easier:** image/audio become first-class searchable memories; feed `pending → done`

--- a/docs/adr/0005-image-audio-extraction.md
+++ b/docs/adr/0005-image-audio-extraction.md
@@ -1,0 +1,80 @@
+# ADR 0005 — Image + audio extraction (OCR / ASR)
+
+**Status:** Proposed (recommends on-device default — tesseract.js / whisper — with a macOS-native fast path and cloud as later offload)
+**Date:** 2026-06-01
+**Context owners:** jlee (+ Claude)
+**Related:** extends [[0003-all-typescript-on-device-pipeline]] (capability→TS mapping); unblocks roadmap #5; feeds the same capture→chunk→embed→index path
+
+## Problem
+
+The pipeline extracts text from `text` and `pdf` items (via `unpdf`). **Images** (screenshots,
+photos) and **audio** (voice memos) are captured but not turned into text — so they can't be
+chunked, embedded, or searched, and they show as `pending` in the feed forever. This ADR
+decides how to extract: OCR for images, ASR (transcription) for audio.
+
+Unlike the drafting LLM (0004), on-device OCR/ASR is **mature and small**, and the privacy
+case is strong (photos and voice are the most sensitive captures). So the on-device-first
+default is easier to defend here than it was for drafting.
+
+## Options considered
+
+Legend: ✅ strong · ⚠️ caveats · ❌ poor
+
+| Option                                                                                                  | Quality                | Offline | Privacy | Cross-platform | Notes                                                      |
+| ------------------------------------------------------------------------------------------------------- | ---------------------- | ------- | ------- | -------------- | ---------------------------------------------------------- |
+| A. On-device portable (`tesseract.js` OCR, `whisper.cpp`/`transformers.js` ASR) _(recommended default)_ | ⚠️→✅                  | ✅      | ✅      | ✅             | lazy-download models, runs in the worker like the embedder |
+| B. macOS-native (Vision OCR, Speech ASR) _(recommended fast path on Mac)_                               | ✅                     | ✅      | ✅      | ❌ Mac-only    | free, fast, excellent; needs a tiny native module          |
+| C. Cloud (vision OCR/caption, Whisper API / Deepgram)                                                   | ✅ (handwriting/noisy) | ❌      | ⚠️      | ✅             | best for hard cases; cost + network                        |
+| D. Defer (keep image/audio capture-only)                                                                | —                      | —       | —       | —              | searchable corpus stays text/PDF-only                      |
+
+### Notes
+
+- **A** — the cross-platform floor. `tesseract.js` (WASM) and a Whisper build (`whisper.cpp`
+  bindings or `transformers.js` whisper, ONNX — same `onnxruntime-node` we already ship) run
+  in the **worker**, lazy-download their models, cache in userData. Slots into the existing
+  `Extractor` path next to `unpdf`. Quality is fine for clean screenshots/clear speech.
+- **B** — on macOS, the **Vision** (OCR) and **Speech** (ASR) frameworks are free, on-device,
+  and beat tesseract/base-Whisper — at the cost of a small native module and being Mac-only.
+  Since macOS is the happy path (per 0003's packaging note), it's worth wiring as an
+  _accelerated path_ with A as the portable fallback.
+- **C** — reserve for hard cases (handwriting, noisy audio) as a later **offload**, opt-in
+  like the cloud drafter (0004). Not the default — defeats the privacy/offline win.
+- **D** — only acceptable very short-term; it leaves a visible hole (voice memos / screenshots
+  are core capture modes for a memory app).
+
+## Recommendation
+
+**On-device by default, behind an `Extractor`-per-type seam** (mirrors `Embedder`/`Drafter`):
+
+- **Portable default (A):** `tesseract.js` for images, a Whisper build for audio — worker-side,
+  lazy models, cached. Gets every platform to "searchable."
+- **macOS fast path (B):** detect Darwin → use Vision/Speech for better quality, free. Tiny
+  native module; fall back to A elsewhere.
+- **Cloud (C) as a later opt-in offload** for hard inputs, gated by the same consent/key
+  pattern as 0004's cloud drafter.
+
+This keeps the most privacy-sensitive captures (photos, voice) **on the device** by default,
+exactly the on-device-first intent of 0003, while leaving a quality escape hatch.
+
+## Consequences
+
+- **Easier:** image/audio become first-class searchable memories; feed `pending → done`
+  actually resolves; no new privacy exposure by default.
+- **Harder:** more lazy-downloaded models (size/first-use latency — same playbook as the
+  embedder); a macOS native module adds to the packaging matrix; HEIC decode for iPhone
+  photos is the known image-prep risk flagged in 0003 (verify `sharp`/`heic-convert`).
+
+## Open questions
+
+- Whisper runtime: `whisper.cpp` native bindings vs `transformers.js` whisper on the
+  `onnxruntime-node` we already have (one fewer addon)?
+- Model sizes/tiers per device (tiny vs base vs small) — auto-pick by hardware?
+- Do we caption images (VLM) in addition to OCR, or is OCR enough for v1 search?
+- Where does extraction run in the lifecycle — at capture (blocks `done`) or async after?
+
+## Action items
+
+1. [ ] Extend `extract.ts` with image + audio branches behind a per-type seam.
+2. [ ] Portable path first: `tesseract.js` + a Whisper build, lazy-download + cache.
+3. [ ] macOS Vision/Speech native module as the Darwin fast path (fallback to portable).
+4. [ ] Verify HEIC decode in the Electron build (the 0003 image-prep risk).

--- a/docs/adr/0006-repo-structure.md
+++ b/docs/adr/0006-repo-structure.md
@@ -1,0 +1,82 @@
+# ADR 0006 — Repo structure: flat now, monorepo when mobile lands
+
+**Status:** Accepted (flat single-app repo now; migrate to a workspace monorepo when the Expo app starts)
+**Date:** 2026-06-01
+**Context owners:** jlee (+ Claude)
+**Related:** corrects the timing in [[0003-all-typescript-on-device-pipeline]] (which pencilled in a turborepo "now"); gates roadmap #14 (RN/Expo)
+
+## Problem
+
+0003 pencilled in a turborepo monorepo (`apps/desktop`, `apps/expo`, `packages/*`) and said
+"this repo becomes `apps/desktop`." Since then the app shipped a lot of surface flat, was
+renamed to **`nimi`**, and a mobile (RN/Expo) app is on the roadmap (#14). So: do we
+restructure into a monorepo now, or stay flat and migrate when mobile actually starts?
+
+The thing 0003 got right: an all-TS desktop **+** mobile future _wants_ shared code. The
+thing to correct: its **timing**. There's exactly one app today, and the shared seam already
+exists as `src/shared` (the IPC + view-model contract). Premature monorepo tooling is pure
+overhead until there's a second consumer of that seam.
+
+## Options considered
+
+Legend: ✅ strong · ⚠️ caveats · ❌ poor
+
+| Option                                                 | Overhead now                       | Ready for mobile     | Code sharing                                          | Churn                          |
+| ------------------------------------------------------ | ---------------------------------- | -------------------- | ----------------------------------------------------- | ------------------------------ |
+| A. Flat now, monorepo when mobile lands _(chosen)_     | ✅ none                            | ⚠️ migrate on demand | ✅ via `src/shared` today → `packages/contract` later | ✅ deferred to when it pays    |
+| B. Monorepo now (preemptive)                           | ❌ tooling + restructure for 1 app | ✅                   | ✅                                                    | ❌ now, for no current benefit |
+| C. Two separate repos sharing a published contract pkg | ⚠️ publish/version a package       | ✅                   | ⚠️ duplicate/publish friction                         | ⚠️                             |
+
+## Decision
+
+**A — stay flat.** Keep `nimi` as a single-app repo. The contract already lives in
+`src/shared` and is the compiler-enforced seam between lanes; that's enough sharing for one
+app. **Migrate to a workspace monorepo when the Expo app is actually started (#14)** — not
+before.
+
+### Target layout (when we migrate)
+
+```
+nimi/                      ← repo root (already renamed)
+  apps/
+    desktop/               ← today's Electron app moves here wholesale
+    mobile/                ← RN + Expo
+  packages/
+    contract/              ← lifted from src/shared (views + ipc types)
+    pipeline/  (maybe)     ← if the on-device pipeline is shared with mobile
+  package.json             ← workspace root
+```
+
+- **pnpm workspaces** is the floor (we already use pnpm); **turborepo** layers task
+  caching/orchestration on top — add it if/when build times or task graphs justify it, not
+  reflexively.
+- `packages/contract` is just `src/shared` promoted — the move is mechanical because the
+  contract was already isolated there.
+
+### Migration trigger
+
+The first commit of real Expo work. Doing it _with_ that work means the monorepo earns its
+keep immediately (two real consumers of `packages/contract`), and the desktop app moves in
+one clean `git mv` of `src → apps/desktop/src`.
+
+### Agent-context hygiene (the real monorepo risk)
+
+Per 0003: once split, use **per-app/per-package `CLAUDE.md`**, root agents at the package
+under work, and worktrees — so a desktop task isn't polluted by mobile context. The root
+`CLAUDE.md` stays the shared spine; lane scoping happens per-package.
+
+## Consequences
+
+- **Easier:** zero tooling tax today; the rename already put us at the would-be monorepo root
+  name; the contract seam means the eventual split is mechanical, not a rewrite.
+- **Harder:** a known future migration sits on the books (cheap, but non-zero); until then,
+  any "shared with mobile" instinct has to wait or be faked via `src/shared`.
+
+## Open questions
+
+- pnpm workspaces alone, or turborepo from the migration moment?
+- Does the **on-device pipeline** become a shared `packages/pipeline`, or is mobile's capture
+  path different enough (RN native modules) that it doesn't share? (Likely diverges → keep
+  `contract` shared, not `pipeline`, until proven.)
+- Does the legacy Python `neeme` backend ever enter this repo, or stay separate until retired
+  (0003 says separate — unchanged here)?


### PR DESCRIPTION
The three decisions the roadmap flagged as ADR-worthy, written up against the `docs/adr/000X` format. Two are **Proposed** (need your ratify), one is **Accepted** (records a call already made).

| ADR | Decision | Status | Gates |
|---|---|---|---|
| **0004** AI drafting model | `Drafter` seam + hybrid: on-device small model as private/offline default; cloud offload **opt-in, BYO-key** for quality drafting + Ask Nimi | Proposed | #3 |
| **0005** image/audio extraction | on-device default (`tesseract.js` / Whisper) behind a per-type seam; macOS Vision/Speech fast path; cloud as later offload | Proposed | #5 |
| **0006** repo structure | stay **flat** now; migrate to a pnpm-workspace monorepo (`apps/desktop` + `apps/mobile` + `packages/contract`) **when Expo starts** — corrects 0003's "monorepo now" timing | Accepted | #14 |

Common thread: each leans on the **seam pattern** that already worked for the embedder, and keeps the privacy-sensitive default **on-device** (per ADR 0003), with cloud as opt-in offload. ROADMAP's decisions section now links all three.

Your move on 0004/0005 — ratify, amend, or push back. 0006 just records the flat-now call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)