### PR TITLE
docs: monorepo migration first (amend ADR 0006 timing)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -20,8 +20,15 @@ Lanes (see `CLAUDE.md`): **back** = `src/main` + `src/shared`; **front** = `src/
 
 ## Punch list
 
+> **DO FIRST (#0): monorepo migration** — `git mv src → apps/desktop/src` + lift `src/shared` →
+> `packages/contract` + pnpm workspaces. It rewrites nearly every path, so it must land in the
+> **quiet window (0 open PRs, pre-ramp)** before any parallel workstream branches — else it's a
+> merge nightmare. See [ADR 0006](adr/0006-repo-structure.md) for the checklist. Everything below
+> branches off the already-monorepo'd `main`.
+
 | #   | Item                                                                                                     | Lane         | Unblocks                                         | Size | When       |
 | --- | -------------------------------------------------------------------------------------------------------- | ------------ | ------------------------------------------------ | ---- | ---------- |
+| 0   | **Monorepo migration** (flat → `apps/desktop` + `packages/contract`, pnpm workspaces)                    | back/struct  | a clean root everyone branches off; unblocks #14 | M    | **FIRST**  |
 | 1   | Smoke-test integrated main (embedder + tray actually run)                                                | human        | confidence in the baseline                       | S    | now        |
 | 2   | **Wire UI → `window.api`** (retire mock `data.ts`; see `INTEGRATION.md`)                                 | front        | the app runs on real data — the headline         | L    | **P0**     |
 | 3   | AI drafting layer (LLM → `brief`/`draft`/`note`, `gathering→drafted`, backlog `conf`, the "why" strings) | back         | every AI-gap field                               | L    | P1 ⚠️      |
@@ -64,8 +71,9 @@ Each is written up as an ADR — settle (ratify) each before starting the items 
    optional parked spike, not a committed path)_.
 2. **OCR / ASR (gates #5):** on-device vs cloud → [ADR 0005](adr/0005-image-audio-extraction.md)
    _(proposed: on-device default, macOS-native fast path, cloud as later offload)_.
-3. **Repo structure (gates #14):** flat vs monorepo → [ADR 0006](adr/0006-repo-structure.md)
-   _(accepted: stay flat now, migrate to a workspace monorepo when the Expo app starts)_.
+3. **Repo structure (gates #14):** → [ADR 0006](adr/0006-repo-structure.md)
+   _(accepted: **migrate to a monorepo NOW** (item #0), before parallel workstreams — the
+   quiet-window beats the premature-tooling cost; supersedes the defer-until-Expo timing)_.
 
 **Native-packaging note (#13):** `onnxruntime-node` ships per-platform prebuilt binaries. macOS
 is the happy path; the Windows build is a deliberate canary to see _how_ it breaks. Fallback if

--- a/docs/adr/0006-repo-structure.md
+++ b/docs/adr/0006-repo-structure.md
@@ -1,6 +1,7 @@
-# ADR 0006 — Repo structure: flat now, monorepo when mobile lands
+# ADR 0006 — Repo structure: migrate to a monorepo now, before parallel workstreams
 
-**Status:** Accepted (flat single-app repo now; migrate to a workspace monorepo when the Expo app starts)
+**Status:** Accepted — **migrate to a pnpm-workspace monorepo NOW**, in the quiet window (0 open
+PRs, pre-agent-ramp), _ahead_ of Expo. Supersedes the original "defer until Expo starts" timing (see Decision).
 **Date:** 2026-06-01
 **Context owners:** jlee (+ Claude)
 **Related:** corrects the timing in [[0003-all-typescript-on-device-pipeline]] (which pencilled in a turborepo "now"); gates roadmap #14 (RN/Expo)
@@ -29,10 +30,16 @@ Legend: ✅ strong · ⚠️ caveats · ❌ poor
 
 ## Decision
 
-**A — stay flat.** Keep `nimi` as a single-app repo. The contract already lives in
-`src/shared` and is the compiler-enforced seam between lanes; that's enough sharing for one
-app. **Migrate to a workspace monorepo when the Expo app is actually started (#14)** — not
-before.
+**Migrate to a pnpm-workspace monorepo _now_** — before the parallel workstreams ramp back up,
+even though Expo hasn't started.
+
+The original "defer until Expo" call (option A) weighed tooling-overhead vs later-churn and
+missed the decisive factor: the migration is a repo-wide `git mv src → apps/desktop/src` that
+rewrites nearly **every path**, so it conflicts with **every open branch**. Done amid parallel
+agent work it's a merge nightmare — the same one the Neeme→Nimi rename would have been mid-flight.
+Done **now** (0 open PRs, single worktree) it's a clean one-shot reshuffle. The quiet window is
+worth far more than a few weeks of "premature" workspace tooling. (`nimi` is already at the
+would-be root name, so this is a pure structural reshuffle, not a re-identity.)
 
 ### Target layout (when we migrate)
 
@@ -53,11 +60,34 @@ nimi/                      ← repo root (already renamed)
 - `packages/contract` is just `src/shared` promoted — the move is mechanical because the
   contract was already isolated there.
 
-### Migration trigger
+### When — now, the pre-ramp quiet window
 
-The first commit of real Expo work. Doing it _with_ that work means the monorepo earns its
-keep immediately (two real consumers of `packages/contract`), and the desktop app moves in
-one clean `git mv` of `src → apps/desktop/src`.
+**Before** restarting the parallel workstreams, not at the first Expo commit. `apps/mobile` is
+added later when Expo actually starts; this migration just stands up the _structure_
+(`apps/desktop` + `packages/contract` + workspace root) into the empty window, so all future
+work — desktop, mobile, parallel agents — branches off an already-monorepo'd `main`.
+
+### Migration checklist (the fiddly bits)
+
+The `git mv` is the easy part; the config rewiring is where it bites. Rough order:
+
+1. `pnpm-workspace.yaml` (`apps/*`, `packages/*`); split the root `package.json` (workspace
+   scripts) from `apps/desktop/package.json` (the app's deps + scripts).
+2. `git mv src apps/desktop/src`, and move `electron.vite.config.ts`, `electron-builder.yml`,
+   `dev-app-update.yml`, `tsconfig*.json`, `index.html`, `resources/`, `build/`, `scripts/` →
+   `apps/desktop/`.
+3. **Lift `src/shared` → `packages/contract`** (own `package.json` + `tsconfig`), make it a
+   workspace dep of desktop, and repoint the `@shared` alias (electron-vite renderer + tsconfig
+   `paths`) at the package (`@nimi/contract`).
+4. **electron-vite:** the multi-entry `input` (main + worker `index.ts`) paths are now relative
+   to `apps/desktop`; confirm the worker fork path (`out/main/worker.js`) still resolves at runtime.
+5. **tsconfig project references** between `desktop` and `contract` (composite).
+6. **electron-builder** `directories`/`files`/`appId` paths from the new app root.
+7. Per-package `CLAUDE.md` (root spine stays; `apps/desktop` gets its own) — see hygiene below.
+8. **Verify:** `pnpm -r typecheck` + full `electron-vite build` green, `pnpm dev` boots and the
+   worker forks. `NEEME_*` env vars are unaffected.
+
+Do it in a worktree on one branch, merged before anything else branches.
 
 ### Agent-context hygiene (the real monorepo risk)
 

--- a/docs/agent-sync/INBOX.md
+++ b/docs/agent-sync/INBOX.md
@@ -1,10 +1,11 @@
 # Agent inbox — human → agent directives
 
-The other half of the loop: `SYNC-BRIEF.md` reports status *to* the human (auto-generated);
-this file carries directives *from* the human. Every agent reads it at the top of a run
+The other half of the loop: `SYNC-BRIEF.md` reports status _to_ the human (auto-generated);
+this file carries directives _from_ the human. Every agent reads it at the top of a run
 (see `CLAUDE.md`). **Tracked on purpose** — it has to reach agents in other worktrees.
 
 **Convention**
+
 - Newest on top. One line each: `@tag   directive`.
 - Tags: `@all` · `@backend` (`src/main`, `src/shared`, pipeline/worker) ·
   `@frontend` (`src/renderer`, UI) · or a branch name (`@tray`, `@embedder`) for one PR.
@@ -12,7 +13,7 @@ this file carries directives *from* the human. Every agent reads it at the top o
 
 ---
 
-@front   **P0** — wire the UI to `window.api`, retire mock `data.ts`. Contract's ready: see `INTEGRATION.md` (swap map) + `ROADMAP.md` #2.
-@back    smoke-test `main` (embedder loads + tray runs + capture→search), then clear the 3 dependabot vulns. `ROADMAP.md` #1, #11.
-@back    AI drafting layer (`ROADMAP.md` #3) — **blocked**: settle the AI-model decision first (on-device vs cloud; ADR).
-@all     baseline is `main` @ #12–#15; pull fresh before new work.
+@all 🚧 **HOLD — monorepo migration lands FIRST** (`ROADMAP.md` #0 / ADR 0006). It moves `src/` → `apps/desktop/src/` (renderer + main both), so do NOT branch new work until it's merged — it'd conflict with everything. One person, one branch, in the quiet window.
+@front after #0: wire the UI to `window.api`, retire mock `data.ts` (`ROADMAP.md` #2, `INTEGRATION.md`). Paths shift to `apps/desktop/src/renderer`.
+@back after #0: smoke-test `main` (embedder + tray + capture→search), clear the 3 dependabot vulns (`ROADMAP.md` #1, #11). AI drafting = cloud (BYO-key) behind the `Drafter` seam (ADR 0004).
+@all AI-model decision settled: cloud-first behind a seam; on-device LLM is a parked spike (ADR 0004).


### PR DESCRIPTION
Amends ADR 0006: migrate flat → pnpm-workspace monorepo **now**, before parallel workstreams ramp, rather than deferring to the first Expo commit.

**Why the flip:** the migration is a repo-wide `git mv src → apps/desktop/src` that rewrites nearly every path → conflicts with every open branch. Done amid parallel agent work it's a merge nightmare (the Neeme→Nimi rename taught us this); done now (0 open PRs, single worktree) it's a clean one-shot. The quiet window is worth more than a few weeks of "premature" workspace tooling.

- **ADR 0006** — status/decision/when → "now"; added an execution checklist (workspaces split, electron-vite input + worker-fork paths, `@shared`→`@nimi/contract` alias, tsconfig project refs, electron-builder paths, verify steps).
- **ROADMAP** — new **#0 monorepo migration (DO FIRST)**; decision-3 pointer synced.
- **INBOX** — top `@all` HOLD: no new branches until #0 lands (it moves `src/renderer` too, so it gates frontend + backend alike).

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)