### PR TITLE
docs: Cursor Cloud development environment guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,45 @@
+## Cursor Cloud specific instructions
+
+### Product
+
+Single runnable app: **nimi Desktop** (`@nimi/desktop`, Electron). `pnpm dev` from the repo root is the dev entry (turbo → `electron-vite dev`). The **neeme FastAPI backend** (sibling repo) and **Logto** are optional; local-first E2E is Electron + worker + embedded libSQL only.
+
+### Verify (no runtime)
+
+From repo root: `pnpm typecheck`, `pnpm build`, `pnpm lint`. Pre-existing ESLint failures in `packages/contract/src/api/generated/**` are expected (hey-api output).
+
+### Run the desktop app
+
+```bash
+NEEME_EMBEDDER=hash pnpm dev
+```
+
+Use `NEEME_EMBEDDER=hash` in cloud/CI VMs to skip ONNX model download and `onnxruntime-node` at runtime. The renderer is also reachable at `http://localhost:5173/` during dev (Vite HMR); `window.api` is only available inside Electron.
+
+**Electron binary:** If `pnpm dev` fails with `Error: Electron uninstall`, the Electron download did not complete. Fix with `node node_modules/electron/install.js` (from repo root), then retry `pnpm dev`.
+
+**Display:** Electron needs X11 (`DISPLAY` is usually `:1` in this environment). Harmless `dbus` errors in logs are normal without a session bus.
+
+**Worker / DB:** On successful boot, main forks the `neeme-data` utilityProcess and creates `neeme.db` under Electron `userData` (Linux: `~/.config/@nimi/desktop/neeme.db`). The renderer still uses sample data in `apps/desktop/src/renderer/src/nimi/data.ts`; IPC (`window.api.pipeline.*`, `window.api.todos.*`) is wired for integration work.
+
+### Data-layer smoke (optional, no Electron UI)
+
+```bash
+mkdir -p /tmp/nimi-smoke
+cd apps/desktop
+NEEME_USER_DATA=/tmp/nimi-smoke NEEME_EMBEDDER=hash pnpm exec tsx -e "
+import { initDb } from './src/main/db/index.ts';
+import { pipelineService } from './src/main/services/pipeline-service.ts';
+(async () => {
+  await initDb();
+  const cap = await pipelineService.captureText('smoke', 'test');
+  console.log('capture', cap.memory.id);
+  console.log('search', await pipelineService.match('smoke', 3));
+})();
+"
+```
+
+### Scoped commands
+
+- Desktop only: `pnpm --filter @nimi/desktop dev|build|typecheck`
+- See root `README.md` and `CLAUDE.md` for monorepo layout and agent lanes (`docs/agent-sync/INBOX.md`).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds `AGENTS.md` with Cursor Cloud–specific instructions for running nimi Desktop in remote VMs.

## What was validated in the cloud VM

- `pnpm install` (pnpm 10.26.0, Node 22)
- `pnpm typecheck` — green
- `pnpm build` — green
- `pnpm lint` — fails only on pre-existing generated API client debt (`packages/contract/src/api/generated/**`)
- `NEEME_EMBEDDER=hash pnpm dev` — Electron + Vite + worker boot; `neeme.db` created under `~/.config/@nimi/desktop/`
- Pipeline capture + semantic search smoke via `tsx` + `NEEME_EMBEDDER=hash`

## VM startup update script

```
pnpm install
node node_modules/electron/install.js
```

The second line fixes intermittent `Error: Electron uninstall` when the Electron binary was not downloaded during install.

## Demo artifacts

[Nimi Today view (renderer dev server)](https://cursor.com/agents/bc-19a42f08-0ab0-4388-abab-825e26c5f651/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fnimi-renderer-dev.png)

[Nimi Feed capture surface](https://cursor.com/agents/bc-19a42f08-0ab0-4388-abab-825e26c5f651/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fnimi-feed-capture.png)

[nimi-dev-demo.mp4](https://cursor.com/agents/bc-19a42f08-0ab0-4388-abab-825e26c5f651/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fnimi-dev-demo.mp4)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-19a42f08-0ab0-4388-abab-825e26c5f651"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-19a42f08-0ab0-4388-abab-825e26c5f651"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

