### PR TITLE
docs: Cursor Cloud dev environment notes (AGENTS.md)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,35 @@
+# nimi — agent guide (monorepo root)
+
+See **`CLAUDE.md`** for the full shared spine (architecture, contract, verify steps, security).
+
+## Cursor Cloud specific instructions
+
+### Services (this repo)
+
+| Service | Required for dev? | Notes |
+|--------|-------------------|--------|
+| **Electron app** (`pnpm dev`) | Yes | Starts main + preload + renderer (Vite `:5173`) + data **utilityProcess** worker |
+| **neeme FastAPI** (`:8000`) | No | Sibling repo; only if testing `@nimi/contract/api` HTTP client |
+| **Logto OIDC** | No | Inert until `MAIN_VITE_LOGTO_*` env is set |
+
+### Verify (from repo root)
+
+Standard commands are in **`README.md`** / **`CLAUDE.md`**:
+
+- `pnpm typecheck` — turbo fans out `@nimi/contract` + `@nimi/desktop`
+- `pnpm build` — electron-vite production bundles
+- `pnpm lint` — eslint; **pre-existing debt** in `packages/contract/src/api/generated/**` (hey-api) may fail a full-tree lint even when app code is clean
+
+### Running the desktop app in Cloud / headless VMs
+
+- **Display:** Cloud VMs usually expose `DISPLAY` (e.g. `:1`). D-Bus warnings in logs are normal and non-fatal.
+- **Electron binary:** If `electron-vite dev` fails with `Error: Electron uninstall`, the Electron binary was not downloaded yet. Run once: `node node_modules/electron/install.js` (or `pnpm exec electron --version`), then retry `pnpm dev`.
+- **Faster worker smoke (no HuggingFace model):** `NEEME_EMBEDDER=hash pnpm dev`
+- **Renderer still uses sample UI data** (`apps/desktop/src/renderer/src/nimi/data.ts`); on-device persistence is via `window.api.pipeline.*` (see `docs/INTEGRATION.md`). To smoke-test **pipeline + libSQL** without the UI, from `apps/desktop` import `initDb` and `pipelineService` under `src/main/` with `NEEME_EMBEDDER=hash` and a writable `NEEME_USER_DATA` directory (mkdir first), then call `captureText` / `match`.
+
+- **User data / DB:** `~/.config/@nimi/desktop/neeme.db` when running under Electron.
+
+### Dev server
+
+- Root: `pnpm dev` (turbo → `@nimi/desktop` → `electron-vite dev`)
+- Vite renderer only (no `window.api`): `http://localhost:5173/` while dev is running


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds `AGENTS.md` with Cloud Agent–specific guidance for running the Nimi Electron monorepo in headless VMs:

- Service matrix (Electron vs optional neeme/Logto)
- Electron binary bootstrap when `electron-vite` reports "Electron uninstall"
- `NEEME_EMBEDDER=hash` for fast worker smoke without model download
- Note that renderer capture UI still uses sample data; pipeline is exercised via `window.api` / worker

No application code changes — documentation only for future cloud sessions.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c56d4781-9003-4da4-ad66-153293178bea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c56d4781-9003-4da4-ad66-153293178bea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

