### PR TITLE
feat(test): add vitest harness + worker-service tests (ROADMAP #7)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,9 @@ Single runnable app: **nimi Desktop** (`@nimi/desktop`, Electron). `pnpm dev` fr
 
 ### Verify (no runtime)
 
-From repo root: `pnpm typecheck`, `pnpm build`, `pnpm lint`. Pre-existing ESLint failures in `packages/contract/src/api/generated/**` are expected (hey-api output).
+From repo root: `pnpm typecheck`, `pnpm build`, `pnpm lint`, `pnpm test`. Pre-existing ESLint failures in `packages/contract/src/api/generated/**` are expected (hey-api output).
+
+`pnpm test` runs 152 vitest tests in plain Node (no Electron, no model download): pipeline unit tests + integration tests for pipeline-service/todo-service/draft-service against a temp libSQL DB with `NEEME_EMBEDDER=hash` + `NEEME_DRAFTER=off`.
 
 ### Run the desktop app
 
@@ -77,5 +79,5 @@ import { pipelineService } from './src/main/services/pipeline-service.ts';
 
 ### Scoped commands
 
-- Desktop only: `pnpm --filter @nimi/desktop dev|build|typecheck`
+- Desktop only: `pnpm --filter @nimi/desktop dev|build|typecheck|test`
 - See root `README.md` and `CLAUDE.md` for monorepo layout and agent lanes (`docs/agent-sync/INBOX.md`).

--- a/apps/desktop/CLAUDE.md
+++ b/apps/desktop/CLAUDE.md
@@ -50,6 +50,20 @@ If you change the contract, edit it in `packages/contract` and update `docs/INTE
 - The worker receives its data dir from main as `NEEME_USER_DATA` when forked (it has no
   `electron.app`).
 
+## Tests (vitest)
+
+Worker-service tests live under `test/` and run in plain Node (no Electron):
+
+```bash
+pnpm --filter @nimi/desktop test        # run once
+pnpm --filter @nimi/desktop test:watch  # watch mode
+```
+
+Tests use `NEEME_EMBEDDER=hash` + `NEEME_DRAFTER=off` + a per-file temp libSQL DB
+(auto-created / cleaned up). No ONNX model download, no network, no Electron required.
+Tier A: pure unit tests (chunk, extract, embed, draft, projectors). Tier B: integration
+tests against a real libSQL file (pipeline-service, todo-service, draft-service).
+
 ## Security
 
 The non-negotiable Electron invariants live in the root `CLAUDE.md` and `docs/SECURITY.md`.

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -9,6 +9,8 @@
     "typecheck:node": "tsc --noEmit -p tsconfig.node.json --composite false",
     "typecheck:web": "tsc --noEmit -p tsconfig.web.json --composite false",
     "typecheck": "npm run typecheck:node && npm run typecheck:web",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "start": "electron-vite preview",
     "dev": "electron-vite dev",
     "build": "npm run typecheck && electron-vite build",
@@ -43,6 +45,7 @@
     "react-dom": "^19.2.1",
     "tailwindcss": "^4.3.0",
     "typescript": "^6.0.3",
-    "vite": "^7.2.6"
+    "vite": "^7.2.6",
+    "vitest": "^4.1.8"
   }
 }

--- a/apps/desktop/test/helpers.ts
+++ b/apps/desktop/test/helpers.ts
@@ -1,0 +1,14 @@
+/**
+ * Shared helpers for integration tests. Import ONLY from integration test files
+ * (not from pure unit tests) — importing this module triggers the db/index.ts
+ * singleton, which requires NEEME_USER_DATA to be set (done by test/setup.ts).
+ */
+import { client } from '../src/main/db/index'
+
+/** Wipe all rows between tests — preserves schema, resets state. */
+export async function clearTables(): Promise<void> {
+  // Delete in dependency order (FKs may or may not be enforced, but order is safe)
+  await client.executeMultiple(
+    'DELETE FROM todo_ai; DELETE FROM todo_context; DELETE FROM todos; DELETE FROM chunks; DELETE FROM items; DELETE FROM meta;'
+  )
+}

--- a/apps/desktop/test/pipeline/chunk.test.ts
+++ b/apps/desktop/test/pipeline/chunk.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest'
+import { chunkText } from '../../src/main/pipeline/chunk'
+
+describe('chunkText', () => {
+  it('returns [] for empty string', () => {
+    expect(chunkText('')).toEqual([])
+  })
+
+  it('returns [] for whitespace-only string', () => {
+    expect(chunkText('   \n\t  ')).toEqual([])
+  })
+
+  it('returns the trimmed text as a single chunk when shorter than maxChars', () => {
+    const text = 'hello world'
+    const result = chunkText(text, 800)
+    expect(result).toEqual(['hello world'])
+  })
+
+  it('returns a single chunk when text equals maxChars exactly', () => {
+    const text = 'a'.repeat(800)
+    const result = chunkText(text, 800)
+    expect(result).toEqual([text])
+  })
+
+  it('splits long text into overlapping windows', () => {
+    const text = 'a'.repeat(1000)
+    const result = chunkText(text, 800, 100)
+    // First chunk: 0..800, second: 700..1000
+    expect(result.length).toBe(2)
+    expect(result[0]).toHaveLength(800)
+    expect(result[1]).toHaveLength(300)
+  })
+
+  it('every character is covered by at least one chunk', () => {
+    const text = 'abcdefghij'.repeat(100) // 1000 chars
+    const chunks = chunkText(text, 300, 50)
+    const covered = new Set<number>()
+    let pos = 0
+    for (const chunk of chunks) {
+      for (let i = 0; i < chunk.length; i++) {
+        covered.add(pos + i)
+      }
+      pos += 300 - 50 // advance by (maxChars - overlap) each step
+    }
+    for (let i = 0; i < text.trim().length; i++) {
+      expect(covered.has(i)).toBe(true)
+    }
+  })
+
+  it('consecutive chunks overlap by exactly the overlap amount', () => {
+    const text = 'x'.repeat(2000)
+    const maxChars = 500
+    const overlap = 100
+    const chunks = chunkText(text, maxChars, overlap)
+    for (let i = 1; i < chunks.length; i++) {
+      // The tail of chunk[i-1] should equal the head of chunk[i]
+      const tail = chunks[i - 1]!.slice(-overlap)
+      const head = chunks[i]!.slice(0, overlap)
+      expect(head).toBe(tail)
+    }
+  })
+
+  it('trims leading/trailing whitespace before chunking', () => {
+    const [chunk] = chunkText('  hello  ')
+    expect(chunk).toBe('hello')
+  })
+
+  it('throws when overlap >= maxChars', () => {
+    expect(() => chunkText('x'.repeat(1000), 100, 100)).toThrow('overlap must be < maxChars')
+    expect(() => chunkText('x'.repeat(1000), 100, 200)).toThrow('overlap must be < maxChars')
+  })
+
+  it('uses defaults (maxChars=800, overlap=100) when not specified', () => {
+    const text = 'word '.repeat(200) // 1000 chars
+    const chunks = chunkText(text)
+    expect(chunks.length).toBeGreaterThan(1)
+    expect(chunks[0]).toHaveLength(800)
+  })
+})

--- a/apps/desktop/test/pipeline/draft.test.ts
+++ b/apps/desktop/test/pipeline/draft.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest'
+import { NullDrafter } from '../../src/main/pipeline/draft'
+import type { DraftInput } from '../../src/main/pipeline/draft'
+
+const EMPTY_INPUT: DraftInput = {
+  title: 'Test task',
+  notes: null,
+  pinnedIds: [],
+  context: []
+}
+
+const RICH_INPUT: DraftInput = {
+  title: 'Write quarterly report',
+  notes: 'Focus on engineering metrics',
+  pinnedIds: ['item-1'],
+  context: [
+    {
+      itemId: 'item-1',
+      sourceName: 'metrics.md',
+      contentType: 'text',
+      excerpt: 'Q3 engineering metrics: 200 deployments, 99.9% uptime',
+      rel: 0.9
+    },
+    {
+      itemId: 'item-2',
+      sourceName: 'notes.txt',
+      contentType: 'text',
+      excerpt: 'Previous quarter numbers for comparison',
+      rel: 0.6
+    }
+  ]
+}
+
+describe('NullDrafter', () => {
+  const drafter = new NullDrafter()
+
+  it('name is "null-drafter"', () => {
+    expect(drafter.name).toBe('null-drafter')
+  })
+
+  it('returns status: "gathered" with all nullable fields null', async () => {
+    const result = await drafter.draft(EMPTY_INPUT)
+    expect(result.status).toBe('gathered')
+    expect(result.brief).toBeNull()
+    expect(result.draft).toBeNull()
+    expect(result.draftNote).toBeNull()
+    expect(result.note).toBeNull()
+    expect(result.noteKind).toBeNull()
+    expect(result.conf).toBeNull()
+    expect(result.why).toEqual({})
+  })
+
+  it('ignores a rich input and still returns null fields', async () => {
+    const result = await drafter.draft(RICH_INPUT)
+    expect(result.status).toBe('gathered')
+    expect(result.brief).toBeNull()
+    expect(result.draft).toBeNull()
+    expect(result.why).toEqual({})
+  })
+
+  it('resolves (does not throw or reject)', async () => {
+    await expect(drafter.draft(EMPTY_INPUT)).resolves.toBeDefined()
+  })
+})

--- a/apps/desktop/test/pipeline/embed.test.ts
+++ b/apps/desktop/test/pipeline/embed.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vitest'
+import { HashEmbedder } from '../../src/main/pipeline/embed'
+
+/** Cosine similarity for two unit vectors (dot product suffices since L2 norm ≈ 1). */
+function cosineSim(a: number[], b: number[]): number {
+  return a.reduce((s, x, i) => s + x * (b[i] ?? 0), 0)
+}
+
+describe('HashEmbedder', () => {
+  const embedder = new HashEmbedder()
+
+  it('produces vectors of length 384 (EMBED_DIM)', async () => {
+    const [vec] = await embedder.embed(['hello world'])
+    expect(vec).toHaveLength(384)
+  })
+
+  it('produces a unit vector (L2 norm ≈ 1)', async () => {
+    const [vec] = await embedder.embed(['neural network learning'])
+    const norm = Math.sqrt(vec!.reduce((s, x) => s + x * x, 0))
+    expect(norm).toBeCloseTo(1.0, 5)
+  })
+
+  it('returns zero vector (norm ≈ 0) for empty string', async () => {
+    const [vec] = await embedder.embed([''])
+    const norm = Math.sqrt(vec!.reduce((s, x) => s + x * x, 0))
+    expect(norm).toBeCloseTo(0, 5)
+  })
+
+  it('is deterministic — same input produces same vector', async () => {
+    const text = 'machine learning neural network'
+    const [v1] = await embedder.embed([text])
+    const [v2] = await embedder.embed([text])
+    expect(v1).toEqual(v2)
+  })
+
+  it('handles a batch of texts in one call', async () => {
+    const texts = ['apple', 'banana', 'cherry']
+    const vecs = await embedder.embed(texts)
+    expect(vecs).toHaveLength(3)
+    for (const v of vecs) {
+      expect(v).toHaveLength(384)
+    }
+  })
+
+  it('texts sharing tokens are closer than disjoint texts', async () => {
+    const [vML, vRecipe, vShared] = await embedder.embed([
+      'machine learning neural network training data',
+      'cooking pasta recipe ingredients dinner',
+      'machine learning cooking'
+    ])
+    // vShared shares tokens with both, so intermediate — just check it's closer
+    // to each individual doc than completely disjoint docs are to each other
+    const simMLRecipe = cosineSim(vML!, vRecipe!)
+    const simMLShared = cosineSim(vML!, vShared!)
+    const simRecipeShared = cosineSim(vRecipe!, vShared!)
+    // shared tokens → higher cosine similarity
+    expect(simMLShared).toBeGreaterThan(simMLRecipe)
+    expect(simRecipeShared).toBeGreaterThan(simMLRecipe)
+  })
+
+  it('identical texts produce cosine similarity ≈ 1', async () => {
+    const [v1, v2] = await embedder.embed([
+      'identical text for testing',
+      'identical text for testing'
+    ])
+    expect(cosineSim(v1!, v2!)).toBeCloseTo(1.0, 5)
+  })
+
+  it('name is "hash-placeholder"', () => {
+    expect(embedder.name).toBe('hash-placeholder')
+  })
+
+  it('dim is 384', () => {
+    expect(embedder.dim).toBe(384)
+  })
+
+  it('respects a custom dim', async () => {
+    const custom = new HashEmbedder(128)
+    const [vec] = await custom.embed(['test'])
+    expect(vec).toHaveLength(128)
+  })
+})

--- a/apps/desktop/test/pipeline/extract.test.ts
+++ b/apps/desktop/test/pipeline/extract.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect } from 'vitest'
+import { suffixOf, detectContentType, extract } from '../../src/main/pipeline/extract'
+
+describe('suffixOf', () => {
+  it('returns empty string for names without an extension', () => {
+    expect(suffixOf('README')).toBe('')
+    expect(suffixOf('')).toBe('')
+  })
+
+  it('returns the lowercase dot-prefixed extension', () => {
+    expect(suffixOf('note.md')).toBe('.md')
+    expect(suffixOf('doc.PDF')).toBe('.pdf')
+    expect(suffixOf('photo.JPEG')).toBe('.jpeg')
+  })
+
+  it('handles multiple dots — returns the last extension only', () => {
+    expect(suffixOf('archive.tar.gz')).toBe('.gz')
+    expect(suffixOf('report.final.docx')).toBe('.docx')
+  })
+
+  it('handles a path with directory separators', () => {
+    expect(suffixOf('/home/user/file.txt')).toBe('.txt')
+  })
+})
+
+describe('detectContentType', () => {
+  it('maps text extensions', () => {
+    expect(detectContentType('note.md')).toBe('text')
+    expect(detectContentType('readme.txt')).toBe('text')
+    expect(detectContentType('data.csv')).toBe('text')
+    expect(detectContentType('log.log')).toBe('text')
+    expect(detectContentType('config.json')).toBe('text')
+  })
+
+  it('maps pdf extension', () => {
+    expect(detectContentType('report.pdf')).toBe('pdf')
+  })
+
+  it('maps image extensions', () => {
+    expect(detectContentType('photo.png')).toBe('image')
+    expect(detectContentType('photo.jpg')).toBe('image')
+    expect(detectContentType('anim.gif')).toBe('image')
+  })
+
+  it('maps audio extensions', () => {
+    expect(detectContentType('voice.m4a')).toBe('audio')
+    expect(detectContentType('clip.mp3')).toBe('audio')
+    expect(detectContentType('rec.wav')).toBe('audio')
+  })
+
+  it('falls back to MIME when extension is unknown', () => {
+    expect(detectContentType('file.unknown', 'image/png')).toBe('image')
+    expect(detectContentType('file.unknown', 'audio/mpeg')).toBe('audio')
+    expect(detectContentType('file.unknown', 'application/pdf')).toBe('pdf')
+    expect(detectContentType('file.unknown', 'text/plain')).toBe('text')
+    expect(detectContentType('file.unknown', 'application/json')).toBe('text')
+  })
+
+  it("returns 'other' when neither extension nor MIME matches", () => {
+    expect(detectContentType('file.xyz')).toBe('other')
+    expect(detectContentType('file.xyz', 'application/octet-stream')).toBe('other')
+  })
+
+  it('extension wins over MIME when both are present', () => {
+    // .md is 'text' even if MIME says something else
+    expect(detectContentType('note.md', 'application/octet-stream')).toBe('text')
+  })
+})
+
+describe('extract', () => {
+  it('decodes UTF-8 text bytes and returns extracted status', async () => {
+    const text = 'Hello world from nimi'
+    const bytes = new TextEncoder().encode(text)
+    const result = await extract('text', bytes)
+    expect(result.text).toBe(text)
+    expect(result.status).toBe('extracted')
+  })
+
+  it('returns pending + empty text for empty bytes (text type)', async () => {
+    const result = await extract('text', new Uint8Array(0))
+    expect(result.text).toBe('')
+    expect(result.status).toBe('pending')
+  })
+
+  it('returns pending + empty text for whitespace-only content (text type)', async () => {
+    const bytes = new TextEncoder().encode('   \n\t  ')
+    const result = await extract('text', bytes)
+    expect(result.text).toBe('')
+    expect(result.status).toBe('pending')
+  })
+
+  it('returns pending for image type (no extractor yet)', async () => {
+    const result = await extract('image', new Uint8Array([1, 2, 3]))
+    expect(result.text).toBe('')
+    expect(result.status).toBe('pending')
+  })
+
+  it('returns pending for audio type (no extractor yet)', async () => {
+    const result = await extract('audio', new Uint8Array([1, 2, 3]))
+    expect(result.text).toBe('')
+    expect(result.status).toBe('pending')
+  })
+
+  it('returns pending for other type', async () => {
+    const result = await extract('other', new Uint8Array([1, 2, 3]))
+    expect(result.text).toBe('')
+    expect(result.status).toBe('pending')
+  })
+})

--- a/apps/desktop/test/services/draft-service.test.ts
+++ b/apps/desktop/test/services/draft-service.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect, beforeAll, beforeEach } from 'vitest'
+import { rowToTaskDraft } from '../../src/main/services/draft-service'
+import type { TodoAiRow } from '../../src/main/db/schema'
+
+// ── rowToTaskDraft — pure unit tests (no DB) ──────────────────────────────────
+
+/** Build a minimal TodoAiRow for testing. Drizzle inferred types have Dates. */
+function makeRow(overrides: Partial<TodoAiRow> = {}): TodoAiRow {
+  return {
+    todoId: 'todo-1',
+    status: 'gathered',
+    brief: null,
+    draft: null,
+    draftNote: null,
+    note: null,
+    noteKind: null,
+    conf: null,
+    meta: null,
+    inputsHash: 'abc',
+    updatedAt: new Date(),
+    ...overrides
+  }
+}
+
+describe('rowToTaskDraft', () => {
+  it('status "gathered" when row.status is anything other than "drafted"', () => {
+    expect(rowToTaskDraft(makeRow({ status: 'gathered' })).status).toBe('gathered')
+    expect(rowToTaskDraft(makeRow({ status: 'other' })).status).toBe('gathered')
+  })
+
+  it('status "drafted" when row.status is "drafted"', () => {
+    expect(rowToTaskDraft(makeRow({ status: 'drafted' })).status).toBe('drafted')
+  })
+
+  it('parses JSON draft array from row.draft', () => {
+    const result = rowToTaskDraft(makeRow({ draft: '["Step 1","Step 2"]' }))
+    expect(result.draft).toEqual(['Step 1', 'Step 2'])
+  })
+
+  it('returns null for draft when row.draft is null', () => {
+    expect(rowToTaskDraft(makeRow({ draft: null })).draft).toBeNull()
+  })
+
+  it('returns null for draft when row.draft is malformed JSON', () => {
+    expect(rowToTaskDraft(makeRow({ draft: 'not json' })).draft).toBeNull()
+  })
+
+  it('returns null for draft when row.draft is a JSON non-array', () => {
+    expect(rowToTaskDraft(makeRow({ draft: '{"key":"val"}' })).draft).toBeNull()
+  })
+
+  it('passes through brief, draftNote, note when present', () => {
+    const result = rowToTaskDraft(
+      makeRow({ brief: 'My brief', draftNote: 'draft note', note: 'Nimi note' })
+    )
+    expect(result.brief).toBe('My brief')
+    expect(result.draftNote).toBe('draft note')
+    expect(result.note).toBe('Nimi note')
+  })
+
+  it('passes through valid noteKind values', () => {
+    for (const kind of ['ready', 'ask', 'wait', 'gathered', 'done'] as const) {
+      expect(rowToTaskDraft(makeRow({ noteKind: kind })).noteKind).toBe(kind)
+    }
+    expect(rowToTaskDraft(makeRow({ noteKind: null })).noteKind).toBeNull()
+  })
+
+  it('parses meta fields from JSON', () => {
+    const meta = JSON.stringify({
+      draftFor: 'user@example.com',
+      draftType: 'email',
+      draftIcon: '📧',
+      useLabel: 'Send',
+      useNote: 'via email',
+      useDone: 'Sent'
+    })
+    const result = rowToTaskDraft(makeRow({ meta }))
+    expect(result.draftFor).toBe('user@example.com')
+    expect(result.draftType).toBe('email')
+    expect(result.useLabel).toBe('Send')
+    expect(result.useDone).toBe('Sent')
+  })
+
+  it('tolerates null meta (meta fields become undefined)', () => {
+    const result = rowToTaskDraft(makeRow({ meta: null }))
+    expect(result.draftFor).toBeUndefined()
+    expect(result.draftType).toBeUndefined()
+  })
+
+  it('tolerates malformed meta JSON (falls back to empty object)', () => {
+    const result = rowToTaskDraft(makeRow({ meta: 'bad json' }))
+    expect(result.draftFor).toBeUndefined()
+  })
+
+  it('returns empty why map (why is not stored in the row, only per-context)', () => {
+    const result = rowToTaskDraft(makeRow())
+    expect(result.why).toEqual({})
+  })
+
+  it('passes through conf when numeric', () => {
+    expect(rowToTaskDraft(makeRow({ conf: 0.72 })).conf).toBeCloseTo(0.72, 5)
+    expect(rowToTaskDraft(makeRow({ conf: null })).conf).toBeNull()
+  })
+})
+
+// ── Integration: draftService (regenerate + read) with real DB ────────────────
+//
+// todo_ai has a FK to todos(id), so we create real todos via todoService.add
+// before calling draftService.regenerate.
+
+import { initDb } from '../../src/main/db/index'
+import { draftService } from '../../src/main/services/draft-service'
+import { todoService } from '../../src/main/services/todo-service'
+import { clearTables } from '../helpers'
+
+describe('draftService integration', () => {
+  beforeAll(async () => {
+    await initDb()
+  })
+
+  beforeEach(async () => {
+    await clearTables()
+  })
+
+  it('read returns null when no AI row exists', async () => {
+    const row = await draftService.read('nonexistent-id')
+    expect(row).toBeNull()
+  })
+
+  it('regenerate upserts a todo_ai row with NullDrafter (status: gathered)', async () => {
+    // Create a real todo so the FK on todo_ai → todos is satisfied
+    const task = await todoService.add('Write integration test')
+    const row = await draftService.read(task.id)
+    // todoService.add already calls draftService.regenerate internally
+    expect(row).not.toBeNull()
+    expect(row!.status).toBe('gathered')
+    expect(row!.todoId).toBe(task.id)
+  })
+
+  it('regenerate is a no-op on second call when inputs have not changed', async () => {
+    const task = await todoService.add('Idempotent draft task')
+    const row1 = await draftService.read(task.id)
+    expect(row1).not.toBeNull()
+    const hash1 = row1!.inputsHash
+
+    // Call regenerate again with the same inputs
+    const todo = {
+      id: task.id,
+      title: task.title,
+      notes: null,
+      status: 'open' as const,
+      day: new Date().toISOString().slice(0, 10),
+      position: 0,
+      createdAt: new Date(),
+      completedAt: null
+    }
+    await draftService.regenerate(todo, [])
+
+    const row2 = await draftService.read(task.id)
+    // Same inputs hash → regenerate returned early, row unchanged
+    expect(row2!.inputsHash).toBe(hash1)
+    expect(row2!.updatedAt.getTime()).toBe(row1!.updatedAt.getTime())
+  })
+
+  it('read returns the persisted row after add (which calls regenerate)', async () => {
+    const task = await todoService.add('Read after regenerate')
+    const row = await draftService.read(task.id)
+    expect(row).toBeDefined()
+    expect(row!.todoId).toBe(task.id)
+    expect(row!.inputsHash).toBeTruthy()
+  })
+
+  it('inputsHash differs for todos with different titles', async () => {
+    const t1 = await todoService.add('First title for hashing')
+    const t2 = await todoService.add('Second title for hashing')
+    const row1 = await draftService.read(t1.id)
+    const row2 = await draftService.read(t2.id)
+    expect(row1!.inputsHash).not.toBe(row2!.inputsHash)
+  })
+})

--- a/apps/desktop/test/services/pipeline-service.test.ts
+++ b/apps/desktop/test/services/pipeline-service.test.ts
@@ -1,0 +1,233 @@
+/**
+ * Integration tests for pipelineService.
+ * Requires NEEME_USER_DATA + NEEME_EMBEDDER=hash (set by test/setup.ts).
+ */
+import { describe, it, expect, beforeAll, beforeEach } from 'vitest'
+import { initDb, client } from '../../src/main/db/index'
+import { pipelineService } from '../../src/main/services/pipeline-service'
+import { clearTables } from '../helpers'
+
+beforeAll(async () => {
+  await initDb()
+})
+
+beforeEach(async () => {
+  await clearTables()
+})
+
+// ── captureText ────────────────────────────────────────────────────────────────
+
+describe('pipelineService.captureText', () => {
+  it('captures text and returns created:true on first call', async () => {
+    const result = await pipelineService.captureText('Hello nimi world', 'note.md')
+    expect(result.created).toBe(true)
+    expect(result.memory.id).toBeTruthy()
+    expect(result.memory.title).toBe('Hello nimi world')
+  })
+
+  it('returns created:false (idempotent) for identical content', async () => {
+    const text = 'Idempotency test content'
+    const r1 = await pipelineService.captureText(text)
+    const r2 = await pipelineService.captureText(text)
+    expect(r1.created).toBe(true)
+    expect(r2.created).toBe(false)
+    // Same memory id
+    expect(r2.memory.id).toBe(r1.memory.id)
+  })
+
+  it('treats different text as a new capture', async () => {
+    const r1 = await pipelineService.captureText('First document content')
+    const r2 = await pipelineService.captureText('Second document content')
+    expect(r1.created).toBe(true)
+    expect(r2.created).toBe(true)
+    expect(r2.memory.id).not.toBe(r1.memory.id)
+  })
+
+  it('captures multiple items and lists them', async () => {
+    await pipelineService.captureText('Item A text', 'a.md')
+    await pipelineService.captureText('Item B text', 'b.md')
+    const items = await pipelineService.listItems()
+    expect(items.length).toBe(2)
+  })
+})
+
+// ── captureFile ────────────────────────────────────────────────────────────────
+
+describe('pipelineService.captureFile', () => {
+  it('captures raw bytes as a text file', async () => {
+    const bytes = new TextEncoder().encode('File content for testing')
+    const result = await pipelineService.captureFile(bytes, 'test.txt', 'text/plain')
+    expect(result.created).toBe(true)
+    expect(result.memory.kind).toBe('note')
+  })
+
+  it('is idempotent — same bytes + name gives created:false', async () => {
+    const bytes = new TextEncoder().encode('Repeated file content')
+    const r1 = await pipelineService.captureFile(bytes, 'file.txt')
+    const r2 = await pipelineService.captureFile(bytes, 'file.txt')
+    expect(r1.created).toBe(true)
+    expect(r2.created).toBe(false)
+  })
+})
+
+// ── search + match ────────────────────────────────────────────────────────────
+
+describe('pipelineService.search', () => {
+  it('returns empty array when no items captured', async () => {
+    const hits = await pipelineService.search('anything')
+    expect(hits).toEqual([])
+  })
+
+  it('finds a captured item when the query shares tokens', async () => {
+    await pipelineService.captureText(
+      'machine learning neural network training optimization',
+      'ml.md'
+    )
+    await pipelineService.captureText(
+      'cooking pasta recipe ingredients dinner preparation',
+      'food.md'
+    )
+    const hits = await pipelineService.search('neural network machine learning', 8)
+    expect(hits.length).toBeGreaterThan(0)
+    // ML document should appear somewhere in results
+    const sources = hits.map((h) => h.sourceName)
+    expect(sources).toContain('ml.md')
+  })
+
+  it('returns hits sorted by score ascending (lowest cosine distance first)', async () => {
+    await pipelineService.captureText('alpha beta gamma delta epsilon', 'doc1.md')
+    await pipelineService.captureText('zeta eta theta iota kappa', 'doc2.md')
+    const hits = await pipelineService.search('alpha beta gamma', 10)
+    for (let i = 1; i < hits.length; i++) {
+      expect(hits[i]!.score).toBeGreaterThanOrEqual(hits[i - 1]!.score)
+    }
+  })
+})
+
+describe('pipelineService.match', () => {
+  it('returns MatchHit[] with rel in 0..1 range', async () => {
+    await pipelineService.captureText('project deadline milestone sprint planning', 'proj.md')
+    const hits = await pipelineService.match('sprint planning milestone', 8)
+    expect(hits.length).toBeGreaterThan(0)
+    for (const h of hits) {
+      expect(h.rel).toBeGreaterThanOrEqual(0)
+      expect(h.rel).toBeLessThanOrEqual(1)
+    }
+  })
+
+  it('deduplicates — at most one hit per item', async () => {
+    // Long text will be chunked into multiple chunks
+    const longText = 'semantic search relevance score '.repeat(100)
+    await pipelineService.captureText(longText, 'long.md')
+    const hits = await pipelineService.match('semantic search relevance', 20)
+    const ids = hits.map((h) => h.id)
+    const unique = new Set(ids)
+    expect(ids.length).toBe(unique.size)
+  })
+
+  it('returns hits sorted by rel descending (most relevant first)', async () => {
+    await pipelineService.captureText('vitest unit testing coverage assertions', 'tests.md')
+    await pipelineService.captureText('unrelated content xyz abc qrs tuv', 'other.md')
+    const hits = await pipelineService.match('unit testing vitest', 8)
+    for (let i = 1; i < hits.length; i++) {
+      expect(hits[i]!.rel).toBeLessThanOrEqual(hits[i - 1]!.rel)
+    }
+  })
+})
+
+// ── archive + feed ────────────────────────────────────────────────────────────
+
+describe('pipelineService.archive + feed', () => {
+  it('archive returns Memory[] for all captured items', async () => {
+    await pipelineService.captureText('Memory one content', 'one.md')
+    await pipelineService.captureText('Memory two content', 'two.md')
+    const memories = await pipelineService.archive()
+    expect(memories.length).toBe(2)
+    expect(memories[0]).toHaveProperty('id')
+    expect(memories[0]).toHaveProperty('kind')
+    expect(memories[0]).toHaveProperty('title')
+  })
+
+  it('feed returns FedItem[] with status done for extracted items', async () => {
+    await pipelineService.captureText('Feed item text content here', 'feed.md')
+    const feed = await pipelineService.feed()
+    expect(feed.length).toBe(1)
+    expect(feed[0]!.status).toBe('done')
+  })
+})
+
+// ── reindexAll ────────────────────────────────────────────────────────────────
+
+describe('pipelineService.reindexAll', () => {
+  it('returns 0 when no items exist', async () => {
+    const n = await pipelineService.reindexAll()
+    expect(n).toBe(0)
+  })
+
+  it('returns count of re-indexed items', async () => {
+    await pipelineService.captureText('Reindex document one text', 'r1.md')
+    await pipelineService.captureText('Reindex document two text', 'r2.md')
+    const n = await pipelineService.reindexAll()
+    expect(n).toBe(2)
+  })
+
+  it('chunks are still searchable after reindex', async () => {
+    await pipelineService.captureText('reindex search verification test content', 'doc.md')
+    await pipelineService.reindexAll()
+    const hits = await pipelineService.search('reindex search verification', 5)
+    expect(hits.length).toBeGreaterThan(0)
+  })
+})
+
+// ── syncEmbedder ──────────────────────────────────────────────────────────────
+
+describe('pipelineService.syncEmbedder', () => {
+  it('sets meta.embedder to the active embedder name', async () => {
+    await pipelineService.syncEmbedder()
+    const res = await client.execute({
+      sql: 'SELECT value FROM meta WHERE key = ?',
+      args: ['embedder']
+    })
+    expect(res.rows[0]?.value).toBe('hash-placeholder')
+  })
+
+  it('is a no-op on second call with the same embedder', async () => {
+    await pipelineService.captureText('sync embedder idempotency test', 'doc.md')
+    await pipelineService.syncEmbedder()
+
+    // Count chunks after first sync
+    const before = await client.execute('SELECT COUNT(*) AS n FROM chunks')
+    const countBefore = Number(before.rows[0]!.n)
+
+    await pipelineService.syncEmbedder()
+
+    const after = await client.execute('SELECT COUNT(*) AS n FROM chunks')
+    const countAfter = Number(after.rows[0]!.n)
+
+    // No additional chunks created — reindexAll was not called
+    expect(countAfter).toBe(countBefore)
+  })
+
+  it('reindexes when meta.embedder differs from the active embedder', async () => {
+    await pipelineService.captureText('embedder change triggers reindex content', 'doc.md')
+
+    // Simulate a stale embedder record
+    await client.execute({
+      sql: 'INSERT OR REPLACE INTO meta (key, value) VALUES (?, ?)',
+      args: ['embedder', 'old-embedder-name']
+    })
+
+    await pipelineService.syncEmbedder()
+
+    // Meta should now reflect the current embedder
+    const res = await client.execute({
+      sql: 'SELECT value FROM meta WHERE key = ?',
+      args: ['embedder']
+    })
+    expect(res.rows[0]?.value).toBe('hash-placeholder')
+
+    // Chunks were rebuilt — still searchable
+    const hits = await pipelineService.search('embedder change reindex', 5)
+    expect(hits.length).toBeGreaterThan(0)
+  })
+})

--- a/apps/desktop/test/services/project.test.ts
+++ b/apps/desktop/test/services/project.test.ts
@@ -1,0 +1,348 @@
+import { describe, it, expect } from 'vitest'
+import {
+  toMemory,
+  toFedItem,
+  toMatchHits,
+  toTask,
+  toBacklogItem
+} from '../../src/main/services/project'
+import type { Item, Todo, ContextEntry } from '@nimi/contract/ipc'
+import type { TaskDraft } from '../../src/main/pipeline/draft'
+
+// ── factories ─────────────────────────────────────────────────────────────────
+
+function makeItem(overrides: Partial<Item> = {}): Item {
+  return {
+    id: 'item-1',
+    sourceName: 'note.md',
+    contentType: 'text',
+    sizeBytes: 100,
+    status: 'extracted',
+    text: 'Hello world',
+    createdAt: new Date(Date.now() - 30_000), // 30 seconds ago
+    ...overrides
+  }
+}
+
+function makeTodo(overrides: Partial<Todo> = {}): Todo {
+  return {
+    id: 'todo-1',
+    title: 'Write tests',
+    notes: null,
+    status: 'open',
+    day: new Date().toISOString().slice(0, 10),
+    position: 0,
+    createdAt: new Date(),
+    completedAt: null,
+    ...overrides
+  }
+}
+
+function makeContext(overrides: Partial<ContextEntry> = {}): ContextEntry {
+  return {
+    itemId: 'item-1',
+    score: 0.2,
+    sourceName: 'note.md',
+    contentType: 'text',
+    excerpt: 'Relevant excerpt',
+    state: 'surfaced',
+    why: null,
+    ...overrides
+  }
+}
+
+function makeDraft(overrides: Partial<TaskDraft> = {}): TaskDraft {
+  return {
+    brief: 'Here is a brief',
+    draft: ['Step 1', 'Step 2'],
+    draftNote: 'draft note',
+    note: 'Nimi note',
+    noteKind: 'ready',
+    status: 'drafted',
+    conf: 0.85,
+    why: { 'item-1': 'The most relevant document' },
+    ...overrides
+  }
+}
+
+// ── toMemory ──────────────────────────────────────────────────────────────────
+
+describe('toMemory', () => {
+  it('maps a text/md item to kind "note"', () => {
+    const m = toMemory(makeItem({ sourceName: 'diary.md', contentType: 'text' }))
+    expect(m.kind).toBe('note')
+  })
+
+  it('maps a text/.txt item to kind "note"', () => {
+    const m = toMemory(makeItem({ sourceName: 'readme.txt', contentType: 'text' }))
+    expect(m.kind).toBe('note')
+  })
+
+  it('maps a text item without md/txt extension to kind "text"', () => {
+    const m = toMemory(makeItem({ sourceName: 'data.csv', contentType: 'text' }))
+    expect(m.kind).toBe('text')
+  })
+
+  it('maps a pdf item to kind "pdf"', () => {
+    const m = toMemory(makeItem({ sourceName: 'report.pdf', contentType: 'pdf' }))
+    expect(m.kind).toBe('pdf')
+  })
+
+  it('maps a png image to kind "screenshot"', () => {
+    const m = toMemory(makeItem({ sourceName: 'screen.png', contentType: 'image' }))
+    expect(m.kind).toBe('screenshot')
+  })
+
+  it('maps a jpg image to kind "image"', () => {
+    const m = toMemory(makeItem({ sourceName: 'photo.jpg', contentType: 'image' }))
+    expect(m.kind).toBe('image')
+  })
+
+  it('maps an audio item to kind "voice"', () => {
+    const m = toMemory(makeItem({ sourceName: 'memo.m4a', contentType: 'audio' }))
+    expect(m.kind).toBe('voice')
+  })
+
+  it('derives title from the first non-empty line of text', () => {
+    const m = toMemory(makeItem({ text: '\nFirst line\nSecond line' }))
+    expect(m.title).toBe('First line')
+  })
+
+  it('falls back to sourceName when text is empty', () => {
+    const m = toMemory(makeItem({ text: '' }))
+    expect(m.title).toBe('note.md')
+  })
+
+  it('truncates title longer than 80 chars with ellipsis', () => {
+    const longLine = 'a'.repeat(100)
+    const m = toMemory(makeItem({ text: longLine }))
+    expect(m.title).toHaveLength(80) // 79 chars + ellipsis char
+    expect(m.title.endsWith('…')).toBe(true)
+  })
+
+  it('truncates snip longer than 160 chars with ellipsis', () => {
+    const m = toMemory(makeItem({ text: 'x'.repeat(200) }))
+    expect(m.snip).toHaveLength(160)
+    expect(m.snip.endsWith('…')).toBe(true)
+  })
+
+  it('snip collapses whitespace', () => {
+    const m = toMemory(makeItem({ text: 'word1\nword2\n  word3' }))
+    expect(m.snip).toBe('word1 word2 word3')
+  })
+
+  it('sets src to sourceName', () => {
+    const m = toMemory(makeItem({ sourceName: 'my-file.md' }))
+    expect(m.src).toBe('my-file.md')
+  })
+
+  it('sets id', () => {
+    const m = toMemory(makeItem({ id: 'abc123' }))
+    expect(m.id).toBe('abc123')
+  })
+
+  it('sets when to a human-readable relative string', () => {
+    const m = toMemory(makeItem({ createdAt: new Date(Date.now() - 30_000) }))
+    expect(m.when).toMatch(/just now|min ago/)
+  })
+
+  it('formats old dates as ISO date string', () => {
+    const old = new Date('2024-01-15')
+    const m = toMemory(makeItem({ createdAt: old }))
+    expect(m.when).toBe('2024-01-15')
+  })
+})
+
+// ── toFedItem ─────────────────────────────────────────────────────────────────
+
+describe('toFedItem', () => {
+  it('status is "done" for extracted items', () => {
+    const f = toFedItem(makeItem({ status: 'extracted' }))
+    expect(f.status).toBe('done')
+  })
+
+  it('status is "done" for captured items', () => {
+    const f = toFedItem(makeItem({ status: 'captured' }))
+    expect(f.status).toBe('done')
+  })
+
+  it('status is "pending" for pending items', () => {
+    const f = toFedItem(makeItem({ status: 'pending' }))
+    expect(f.status).toBe('pending')
+  })
+
+  it('status is "pending" for failed items', () => {
+    const f = toFedItem(makeItem({ status: 'failed' }))
+    expect(f.status).toBe('pending')
+  })
+
+  it('has id, kind, title, when fields', () => {
+    const f = toFedItem(makeItem())
+    expect(f).toHaveProperty('id')
+    expect(f).toHaveProperty('kind')
+    expect(f).toHaveProperty('title')
+    expect(f).toHaveProperty('when')
+  })
+})
+
+// ── toMatchHits ───────────────────────────────────────────────────────────────
+
+describe('toMatchHits', () => {
+  it('returns empty array for empty input', () => {
+    expect(toMatchHits([])).toEqual([])
+  })
+
+  it('converts cosine distance to 0..1 relevance (lower dist = higher rel)', () => {
+    const hits = toMatchHits([{ itemId: 'a', score: 0.1 }])
+    expect(hits[0]!.rel).toBeCloseTo(0.9, 5)
+  })
+
+  it('clamps rel to 0 for distance ≥ 1', () => {
+    const hits = toMatchHits([{ itemId: 'a', score: 1.5 }])
+    expect(hits[0]!.rel).toBe(0)
+  })
+
+  it('keeps best (lowest distance) chunk per item', () => {
+    const raw = [
+      { itemId: 'a', score: 0.3 },
+      { itemId: 'a', score: 0.1 }, // better chunk for item a
+      { itemId: 'b', score: 0.5 }
+    ]
+    const hits = toMatchHits(raw)
+    const itemA = hits.find((h) => h.id === 'a')!
+    expect(itemA.rel).toBeCloseTo(1 - 0.1, 5)
+    expect(hits).toHaveLength(2)
+  })
+
+  it('sorts results by rel descending (closest first)', () => {
+    const raw = [
+      { itemId: 'b', score: 0.5 }, // rel 0.5
+      { itemId: 'a', score: 0.1 }, // rel 0.9
+      { itemId: 'c', score: 0.3 } // rel 0.7
+    ]
+    const hits = toMatchHits(raw)
+    expect(hits[0]!.id).toBe('a')
+    expect(hits[1]!.id).toBe('c')
+    expect(hits[2]!.id).toBe('b')
+  })
+})
+
+// ── toTask ────────────────────────────────────────────────────────────────────
+
+describe('toTask', () => {
+  it('status is "done" for a done todo regardless of AI', () => {
+    const task = toTask(makeTodo({ status: 'done' }), [], makeDraft())
+    expect(task.status).toBe('done')
+    expect(task.done).toBe(true)
+  })
+
+  it('status is "drafted" when todo is open and AI status is drafted', () => {
+    const task = toTask(makeTodo(), [], makeDraft({ status: 'drafted' }))
+    expect(task.status).toBe('drafted')
+    expect(task.done).toBe(false)
+  })
+
+  it('status is "gathered" when todo is open and no AI', () => {
+    const task = toTask(makeTodo(), [])
+    expect(task.status).toBe('gathered')
+  })
+
+  it('status is "gathered" when todo is open and AI status is gathered', () => {
+    const task = toTask(makeTodo(), [], makeDraft({ status: 'gathered' }))
+    expect(task.status).toBe('gathered')
+  })
+
+  it('populates relMap from context entries', () => {
+    const ctx = [makeContext({ itemId: 'item-x', score: 0.2 })]
+    const task = toTask(makeTodo(), ctx)
+    expect(task.relMap?.['item-x']).toBeCloseTo(0.8, 5)
+  })
+
+  it('populates whyMap from context entries with why set', () => {
+    const ctx = [makeContext({ itemId: 'item-x', why: 'The deadline email' })]
+    const task = toTask(makeTodo(), ctx)
+    expect(task.whyMap?.['item-x']).toBe('The deadline email')
+  })
+
+  it('omits whyMap when no context has why strings', () => {
+    const task = toTask(makeTodo(), [makeContext({ why: null })])
+    expect(task.whyMap).toBeUndefined()
+  })
+
+  it('ctx contains non-dismissed item ids in order', () => {
+    const ctx = [
+      makeContext({ itemId: 'a', state: 'surfaced' }),
+      makeContext({ itemId: 'b', state: 'pinned' })
+    ]
+    const task = toTask(makeTodo(), ctx)
+    expect(task.ctx).toContain('a')
+    expect(task.ctx).toContain('b')
+  })
+
+  it('pinned only contains pinned item ids', () => {
+    const ctx = [
+      makeContext({ itemId: 'a', state: 'surfaced' }),
+      makeContext({ itemId: 'b', state: 'pinned' }),
+      makeContext({ itemId: 'c', state: 'dismissed' })
+    ]
+    const task = toTask(makeTodo(), ctx)
+    expect(task.pinned).toEqual(['b'])
+  })
+
+  it('degrades gracefully when AI is absent (draft/note/brief are null)', () => {
+    const task = toTask(makeTodo(), [])
+    expect(task.draft).toBeNull()
+    expect(task.draftNote).toBeNull()
+    expect(task.note).toBeNull()
+    expect(task.brief).toBeUndefined()
+  })
+
+  it('populates AI fields when AI is provided', () => {
+    const task = toTask(makeTodo(), [], makeDraft())
+    expect(task.draft).toEqual(['Step 1', 'Step 2'])
+    expect(task.brief).toBe('Here is a brief')
+    expect(task.note).toBe('Nimi note')
+    expect(task.noteKind).toBe('ready')
+  })
+
+  it('when is "today" for today\'s day', () => {
+    const today = new Date().toISOString().slice(0, 10)
+    const task = toTask(makeTodo({ day: today }), [])
+    expect(task.when).toBe('today')
+  })
+
+  it('when is "today" for day=null', () => {
+    const task = toTask(makeTodo({ day: null }), [])
+    expect(task.when).toBe('today')
+  })
+})
+
+// ── toBacklogItem ─────────────────────────────────────────────────────────────
+
+describe('toBacklogItem', () => {
+  it('conf is null without AI', () => {
+    const item = toBacklogItem(makeTodo())
+    expect(item.conf).toBeNull()
+  })
+
+  it('conf is set when AI provides it', () => {
+    const item = toBacklogItem(makeTodo(), makeDraft({ conf: 0.75 }))
+    expect(item.conf).toBeCloseTo(0.75, 5)
+  })
+
+  it('hint is the todo notes, or empty string if null', () => {
+    expect(toBacklogItem(makeTodo({ notes: null })).hint).toBe('')
+    expect(toBacklogItem(makeTodo({ notes: 'My hint' })).hint).toBe('My hint')
+  })
+
+  it('ctx is empty (surfaced only when scheduled)', () => {
+    const item = toBacklogItem(makeTodo())
+    expect(item.ctx).toEqual([])
+  })
+
+  it('id and title are passed through', () => {
+    const item = toBacklogItem(makeTodo({ id: 'todo-xyz', title: 'Do the thing' }))
+    expect(item.id).toBe('todo-xyz')
+    expect(item.title).toBe('Do the thing')
+  })
+})

--- a/apps/desktop/test/services/todo-service.test.ts
+++ b/apps/desktop/test/services/todo-service.test.ts
@@ -1,0 +1,337 @@
+/**
+ * Integration tests for todoService.
+ * Requires NEEME_USER_DATA + NEEME_EMBEDDER=hash (set by test/setup.ts).
+ *
+ * Context pool tests also require captured items. We capture text that shares
+ * tokens with todo titles so the hash embedder surfaces them as context.
+ */
+import { describe, it, expect, beforeAll, beforeEach } from 'vitest'
+import { initDb } from '../../src/main/db/index'
+import { todoService } from '../../src/main/services/todo-service'
+import { pipelineService } from '../../src/main/services/pipeline-service'
+import { CAP_REACHED } from '@nimi/contract/ipc'
+import { clearTables } from '../helpers'
+
+const TODAY = new Date().toISOString().slice(0, 10)
+
+beforeAll(async () => {
+  await initDb()
+})
+
+beforeEach(async () => {
+  await clearTables()
+})
+
+// ── add (cap-5 + latch) ───────────────────────────────────────────────────────
+
+describe('todoService.add — cap-5 rule', () => {
+  it('allows adding up to 5 todos on a given day', async () => {
+    for (let i = 1; i <= 5; i++) {
+      const task = await todoService.add(`Task ${i}`)
+      expect(task.id).toBeTruthy()
+      expect(task.title).toBe(`Task ${i}`)
+    }
+  })
+
+  it('throws CAP_REACHED when trying to add a 6th todo', async () => {
+    for (let i = 1; i <= 5; i++) {
+      await todoService.add(`Task ${i}`)
+    }
+    await expect(todoService.add('Task 6')).rejects.toThrow(CAP_REACHED)
+  })
+
+  it('includes optional notes in the returned task', async () => {
+    const task = await todoService.add('My task', 'with some notes')
+    // notes are internal; task is the projected view (Task shape)
+    expect(task.title).toBe('My task')
+    expect(task.id).toBeTruthy()
+  })
+
+  it('returns a task with gathered status (NullDrafter)', async () => {
+    const task = await todoService.add('Draft test task')
+    expect(task.status).toBe('gathered')
+    expect(task.done).toBe(false)
+  })
+})
+
+describe('todoService.add — finish-the-list latch', () => {
+  it('allows adding again after all 5 todos are completed', async () => {
+    // Fill the cap
+    const tasks: string[] = []
+    for (let i = 1; i <= 5; i++) {
+      const t = await todoService.add(`Task ${i}`)
+      tasks.push(t.id)
+    }
+    // Complete all of them
+    for (const id of tasks) {
+      await todoService.complete(id)
+    }
+    // Now the day is fully cleared — latch opens
+    const extra = await todoService.add('After latch task')
+    expect(extra.id).toBeTruthy()
+    expect(extra.title).toBe('After latch task')
+  })
+
+  it('cannot add when some are done and some are still open (partially cleared)', async () => {
+    const tasks = await Promise.all([1, 2, 3, 4, 5].map((i) => todoService.add(`Task ${i}`)))
+
+    // Complete only the first two
+    await todoService.complete(tasks[0]!.id)
+    await todoService.complete(tasks[1]!.id)
+    // tasks 3, 4, 5 are still open — cap still full (5 total scheduled)
+    await expect(todoService.add('Task 6')).rejects.toThrow(CAP_REACHED)
+  })
+})
+
+// ── today ─────────────────────────────────────────────────────────────────────
+
+describe('todoService.today', () => {
+  it('returns empty array when no todos scheduled', async () => {
+    const tasks = await todoService.today()
+    expect(tasks).toEqual([])
+  })
+
+  it('returns tasks ordered by position', async () => {
+    await todoService.add('First')
+    await todoService.add('Second')
+    await todoService.add('Third')
+    const tasks = await todoService.today()
+    expect(tasks[0]!.title).toBe('First')
+    expect(tasks[1]!.title).toBe('Second')
+    expect(tasks[2]!.title).toBe('Third')
+  })
+
+  it('returns tasks for a specific day', async () => {
+    await todoService.add('Today task')
+    // Request a different (future) day — should be empty
+    const tasks = await todoService.today('2099-01-01')
+    expect(tasks).toHaveLength(0)
+  })
+})
+
+// ── complete + reopen ─────────────────────────────────────────────────────────
+
+describe('todoService.complete', () => {
+  it('marks a todo as done', async () => {
+    const t = await todoService.add('Complete me')
+    const done = await todoService.complete(t.id)
+    expect(done!.status).toBe('done')
+    expect(done!.done).toBe(true)
+  })
+
+  it('returns null for a non-existent id', async () => {
+    const result = await todoService.complete('no-such-id')
+    expect(result).toBeNull()
+  })
+})
+
+describe('todoService.reopen', () => {
+  it('reopens a completed todo', async () => {
+    const t = await todoService.add('Complete then reopen')
+    await todoService.complete(t.id)
+    const reopened = await todoService.reopen(t.id)
+    expect(reopened!.status).toBe('gathered')
+    expect(reopened!.done).toBe(false)
+  })
+})
+
+// ── backlog ────────────────────────────────────────────────────────────────────
+
+describe('todoService.backlog', () => {
+  it('returns empty when no backlog items', async () => {
+    expect(await todoService.backlog()).toEqual([])
+  })
+
+  it('returns items swept to the backlog by plan', async () => {
+    const t1 = await todoService.add('Keep this')
+    await todoService.add('Sweep this')
+
+    await todoService.plan([t1.id])
+    const backlog = await todoService.backlog()
+    expect(backlog.some((b) => b.title === 'Sweep this')).toBe(true)
+    expect(backlog.some((b) => b.title === 'Keep this')).toBe(false)
+  })
+})
+
+// ── done log ──────────────────────────────────────────────────────────────────
+
+describe('todoService.done', () => {
+  it('returns empty when nothing completed', async () => {
+    expect(await todoService.done()).toHaveLength(0)
+  })
+
+  it('includes both completed todos in the done list', async () => {
+    const t1 = await todoService.add('First completed')
+    await todoService.complete(t1.id)
+    const t2 = await todoService.add('Second completed')
+    await todoService.complete(t2.id)
+
+    const doneList = await todoService.done()
+    expect(doneList).toHaveLength(2)
+    const titles = doneList.map((t) => t.title)
+    expect(titles).toContain('First completed')
+    expect(titles).toContain('Second completed')
+  })
+
+  it('respects the limit parameter', async () => {
+    for (let i = 1; i <= 3; i++) {
+      const t = await todoService.add(`Done ${i}`)
+      await todoService.complete(t.id)
+    }
+    const limited = await todoService.done(2)
+    expect(limited).toHaveLength(2)
+  })
+})
+
+// ── plan (carry-over + backlog sweep) ─────────────────────────────────────────
+
+describe('todoService.plan', () => {
+  it('throws CAP_REACHED when keep list exceeds 5', async () => {
+    await expect(todoService.plan(['a', 'b', 'c', 'd', 'e', 'f'])).rejects.toThrow(CAP_REACHED)
+  })
+
+  it('carries kept items onto the target day', async () => {
+    const t1 = await todoService.add('Keep A')
+    const t2 = await todoService.add('Keep B')
+    await todoService.add('Sweep C')
+
+    const tasks = await todoService.plan([t1.id, t2.id], TODAY)
+    const titles = tasks.map((t) => t.title)
+    expect(titles).toContain('Keep A')
+    expect(titles).toContain('Keep B')
+    expect(titles).not.toContain('Sweep C')
+  })
+
+  it('sweeps non-kept open items to the backlog (day becomes null)', async () => {
+    await todoService.add('Will be swept')
+    const tasks = await todoService.plan([], TODAY)
+    // Empty plan — all swept
+    expect(tasks).toHaveLength(0)
+    const backlog = await todoService.backlog()
+    expect(backlog.some((b) => b.title === 'Will be swept')).toBe(true)
+  })
+
+  it('keeps done items in done log (not swept)', async () => {
+    const t = await todoService.add('Done item')
+    await todoService.complete(t.id)
+    // plan with empty keep — only open items are swept
+    await todoService.plan([], TODAY)
+    const doneList = await todoService.done()
+    expect(doneList.some((d) => d.title === 'Done item')).toBe(true)
+  })
+
+  it('assigns positions 0..n-1 to kept items', async () => {
+    const t1 = await todoService.add('First')
+    const t2 = await todoService.add('Second')
+    const tasks = await todoService.plan([t1.id, t2.id], TODAY)
+    // tasks are ordered by position
+    expect(tasks[0]!.title).toBe('First')
+    expect(tasks[1]!.title).toBe('Second')
+  })
+})
+
+// ── schedule ──────────────────────────────────────────────────────────────────
+
+describe('todoService.schedule', () => {
+  it('moves a backlog item onto a day (cap-enforced)', async () => {
+    // Create 5 items and sweep one to backlog
+    const t1 = await todoService.add('Keep 1')
+    const t2 = await todoService.add('Keep 2')
+    const t3 = await todoService.add('Keep 3')
+    const t4 = await todoService.add('Keep 4')
+    const backlogItem = await todoService.add('Schedule me later')
+    // Sweep the last to backlog via plan with only first 4
+    await todoService.plan([t1.id, t2.id, t3.id, t4.id], TODAY)
+
+    // Now try to schedule the backlog item — cap is currently 4/5 → OK
+    const scheduled = await todoService.schedule(backlogItem.id, TODAY)
+    expect(scheduled).not.toBeNull()
+    expect(scheduled!.title).toBe('Schedule me later')
+  })
+
+  it('throws CAP_REACHED when day is already at cap', async () => {
+    // Fill cap
+    const allTasks = []
+    for (let i = 1; i <= 5; i++) {
+      allTasks.push(await todoService.add(`Task ${i}`))
+    }
+    // Create a backlog item by sweeping one then re-trying to schedule
+    const toSweep = allTasks[4]!
+    await todoService.plan(
+      [allTasks[0]!.id, allTasks[1]!.id, allTasks[2]!.id, allTasks[3]!.id],
+      TODAY
+    )
+    // Day now has 4 open + 0 done; add one more to hit 5
+    await todoService.add('Fill to cap')
+    // Now at cap — scheduling the swept item should fail
+    await expect(todoService.schedule(toSweep.id, TODAY)).rejects.toThrow(CAP_REACHED)
+  })
+
+  it('returns null for a non-existent id', async () => {
+    const result = await todoService.schedule('no-such-id')
+    expect(result).toBeNull()
+  })
+})
+
+// ── context pool (surface / pin / dismiss) ────────────────────────────────────
+
+describe('todoService context pool', () => {
+  beforeEach(async () => {
+    // Capture items with tokens that share with todo titles so the hash embedder
+    // can surface them. The todo title is also used as a search query.
+    await pipelineService.captureText(
+      'sprint planning backlog grooming velocity story points estimation',
+      'sprint.md'
+    )
+    await pipelineService.captureText(
+      'deployment pipeline ci cd release automation docker kubernetes',
+      'deploy.md'
+    )
+  })
+
+  it('searchMoreContext surfaces relevant items from the pipeline', async () => {
+    const task = await todoService.add('sprint planning velocity estimation')
+    const updated = await todoService.searchMoreContext(task.id)
+    // Should have context items surfaced (sprint doc shares tokens with title)
+    expect(updated).not.toBeNull()
+    expect(updated!.ctx.length).toBeGreaterThan(0)
+  })
+
+  it('pinContext persists pinned state and lists pinned ids', async () => {
+    const task = await todoService.add('sprint planning velocity estimation')
+    const withCtx = await todoService.searchMoreContext(task.id)
+    expect(withCtx).not.toBeNull()
+    const ctxId = withCtx!.ctx[0]
+    if (!ctxId) return // skip if no context surfaced
+
+    const pinned = await todoService.pinContext(task.id, ctxId)
+    expect(pinned).not.toBeNull()
+    expect(pinned!.pinned).toContain(ctxId)
+  })
+
+  it('dismissContext removes item from visible context', async () => {
+    const task = await todoService.add('sprint planning velocity estimation')
+    const withCtx = await todoService.searchMoreContext(task.id)
+    expect(withCtx).not.toBeNull()
+    const ctxId = withCtx!.ctx[0]
+    if (!ctxId) return // skip if no context surfaced
+
+    const dismissed = await todoService.dismissContext(task.id, ctxId)
+    expect(dismissed).not.toBeNull()
+    // Dismissed item should no longer appear in ctx
+    expect(dismissed!.ctx).not.toContain(ctxId)
+  })
+
+  it('pinContext places pinned items first in ctx', async () => {
+    const task = await todoService.add('sprint planning velocity estimation')
+    const withCtx = await todoService.searchMoreContext(task.id)
+    if (!withCtx || withCtx.ctx.length < 2) return // need ≥2 items
+
+    // Pin the second item
+    const secondId = withCtx.ctx[1]!
+    const pinned = await todoService.pinContext(task.id, secondId)
+    expect(pinned).not.toBeNull()
+    expect(pinned!.ctx[0]).toBe(secondId)
+    expect(pinned!.pinned[0]).toBe(secondId)
+  })
+})

--- a/apps/desktop/test/setup.ts
+++ b/apps/desktop/test/setup.ts
@@ -1,0 +1,27 @@
+/**
+ * Global vitest setup — runs before each test file's own imports are evaluated.
+ *
+ * Sets the three env-var singletons that src/main modules read at load time:
+ *   NEEME_USER_DATA  → a per-test-file temp dir (unique, writable, cleaned up)
+ *   NEEME_EMBEDDER   → 'hash'  forces HashEmbedder (no ONNX / model download)
+ *   NEEME_DRAFTER    → 'off'   forces NullDrafter  (no network / API key)
+ *
+ * Because this setupFile runs before the test file's static imports are resolved,
+ * all libSQL clients and embedder/drafter singletons will pick up these values.
+ *
+ * Per-file isolation (vitest default, isolate:true) means each test file gets
+ * its own fresh module registry + its own temp dir → its own DB file.
+ */
+import { afterAll } from 'vitest'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+const tmpDir = mkdtempSync(join(tmpdir(), 'nimi-test-'))
+process.env.NEEME_USER_DATA = tmpDir
+process.env.NEEME_EMBEDDER = 'hash'
+process.env.NEEME_DRAFTER = 'off'
+
+afterAll(() => {
+  rmSync(tmpDir, { recursive: true, force: true })
+})

--- a/apps/desktop/vitest.config.ts
+++ b/apps/desktop/vitest.config.ts
@@ -1,0 +1,34 @@
+import { resolve } from 'path'
+import { fileURLToPath } from 'url'
+import { defineConfig } from 'vitest/config'
+
+const __dirname = fileURLToPath(new URL('.', import.meta.url))
+
+/**
+ * Vitest config for @nimi/desktop worker/service tests.
+ *
+ * Runs in plain Node (no Electron). Tests live under test/ and import directly
+ * from src/main/ — the hash embedder + NullDrafter + a temp libSQL DB created
+ * by test/setup.ts before any module is loaded.
+ *
+ * @nimi/contract/* is consumed from .ts source via a prefix alias, mirroring
+ * tsconfig.node.json paths.
+ */
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@nimi/contract': resolve(__dirname, '../../packages/contract/src')
+    }
+  },
+  test: {
+    environment: 'node',
+    globals: true,
+    setupFiles: ['./test/setup.ts'],
+    include: ['test/**/*.test.ts'],
+    // Each test file gets its own module registry so that env-var singletons
+    // (embedder, drafter, db path) are re-evaluated per file.
+    isolate: true,
+    // Reasonable timeout for integration tests (libSQL file I/O + embedding).
+    testTimeout: 15_000
+  }
+})

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -26,7 +26,7 @@ Shared punch list. **Baseline:** `main` @ #12–#15 merged. Lanes: **back** = `a
 | 4   | `captureFile` over IPC + capture UX (drag-drop / picker)                                                 | back + front | capturing PDFs/files, not just typed notes       | M    | P1         |
 | 5   | Image + audio extraction (OCR / transcription)                                                           | back         | screenshots & voice memos as memories            | M–L  | P1 ⚠️      |
 | 6   | Feed view + uncovered-todos (Nimi proposes todos from the feed)                                          | back + front | the `FedItem` / `UncoveredTodo` surfaces         | M    | P2         |
-| 7   | Worker-service tests (vitest)                                                                            | back         | guards pipeline/todo logic                       | M    | P1         |
+| 7   | ~~**Worker-service tests (vitest)**~~ ✅ **done**                                                        | back         | guards pipeline/todo logic                       | M    | ✅ shipped  |
 | 8   | Connectors / ingest (email, calendar, …)                                                                 | back         | automatic capture vs manual                      | L    | P2         |
 | 9   | Auth wired end-to-end (Logto configured, login tested)                                                   | back + front | real accounts                                    | M    | P2         |
 | 10  | Sync / cloud offload (Turso), multi-user                                                                 | back         | multi-device                                     | L    | P3         |

--- a/docs/plans/worker-service-vitest.plan.md
+++ b/docs/plans/worker-service-vitest.plan.md
@@ -1,0 +1,80 @@
+---
+todos:
+  - id: harness
+    status: completed
+    content: Add vitest devDependency + test scripts to apps/desktop/package.json; add root test script and turbo.json test task
+  - id: config-setup
+    status: completed
+    content: 'Create apps/desktop/vitest.config.ts (node env, setupFiles, include test/**) and apps/desktop/test/setup.ts (temp NEEME_USER_DATA dir, NEEME_EMBEDDER=hash, NEEME_DRAFTER=off, clearTables helper, teardown)'
+  - id: tier-a-pure
+    status: completed
+    content: 'Write pure unit tests: chunk, extract, HashEmbedder, NullDrafter, project.ts projectors, rowToTaskDraft'
+  - id: tier-b-pipeline
+    status: completed
+    content: 'Write pipeline-service integration tests: capture idempotency, search/match ranking, reindexAll, syncEmbedder no-op vs reindex'
+  - id: tier-b-todo
+    status: completed
+    content: 'Write todo-service integration tests: cap-5 + CAP_REACHED, finish-list latch, plan carry-over/sweep, schedule cap, context pool surface/pin/dismiss/sort'
+  - id: tier-b-draft
+    status: completed
+    content: 'Write draft-service integration tests: regenerate upsert with NullDrafter, inputsHash dedup no-op, read'
+  - id: docs-verify
+    status: completed
+    content: 'Update ROADMAP #7 + add run-tests note to CLAUDE.md/AGENTS.md; run pnpm --filter @nimi/desktop test, typecheck, lint; fix eslint test glob if needed'
+name: worker service vitest
+overview: 'Add a vitest harness to @nimi/desktop and write unit + integration tests that guard the worker''s pipeline and todo logic (capture/search, cap-5 + latch, plan/carry-over, context pool, projection, AI-gap degradation), using the hash embedder and a temp libSQL DB so tests run with no Electron, no model, and no network.'
+isProject: false
+---
+# Worker-service tests (vitest) — ROADMAP #7
+
+Add a vitest test harness in `apps/desktop` and tests that guard the worker's pipeline/todo logic. Tests run in plain Node (no Electron) against the **hash embedder** + **null drafter** + a **temp libSQL file DB**, mirroring the documented `tsx` smoke in `AGENTS.md`.
+
+## Key constraint: env is read at module load
+
+Three singletons resolve from `process.env` **at import time**, so the env must be set before any worker module is imported:
+- [`apps/desktop/src/main/db/index.ts`](apps/desktop/src/main/db/index.ts) builds `dbPath = join(userDataDir(), 'neeme.db')` at top level → requires `NEEME_USER_DATA` (`runtime/paths.ts` throws otherwise). Note `embed.ts` imports `EMBED_DIM` from `db`, so even "pure" embedder tests trigger this.
+- [`embed.ts`](apps/desktop/src/main/pipeline/embed.ts): `NEEME_EMBEDDER=hash` → `HashEmbedder` (no ONNX/model).
+- [`draft.ts`](apps/desktop/src/main/pipeline/draft.ts): `NEEME_DRAFTER=off` → `NullDrafter` (no network/key).
+
+Solution: a vitest **setup file** (runs before each test file's own imports are evaluated) creates a unique temp dir via `mkdtempSync` and sets `NEEME_USER_DATA`, `NEEME_EMBEDDER=hash`, `NEEME_DRAFTER=off`. Vitest's default per-file isolation gives each test file its own module registry → its own libSQL singleton bound to its own temp DB. Tear down the temp dir in an `afterAll`/global teardown.
+
+## Harness setup
+
+- Add `vitest` (latest) to `devDependencies` in [`apps/desktop/package.json`](apps/desktop/package.json); add script `"test": "vitest run"` (and `"test:watch": "vitest"`).
+- New [`apps/desktop/vitest.config.ts`](apps/desktop/vitest.config.ts): `test.environment = 'node'`, `test.setupFiles = ['./test/setup.ts']`, `test.include = ['test/**/*.test.ts']`, `globals: true`. `@nimi/contract/*` resolves through the package's `exports` map to `.ts` source (vite transforms it); add a `resolve.alias` to `packages/contract/src/*` only if resolution fails.
+- New [`apps/desktop/test/setup.ts`](apps/desktop/test/setup.ts): set the three env vars to a fresh temp dir before tests; helper to clear tables between tests.
+- Place all tests under `apps/desktop/test/` (NOT under `src/main/**`) so they stay out of the electron-vite build (explicit entries in [`electron.vite.config.ts`](apps/desktop/electron.vite.config.ts)) and out of the app `tsconfig.node.json` `include`.
+- Root [`package.json`](package.json): add `"test": "turbo run test"`. [`turbo.json`](turbo.json): add a `test` task (`dependsOn: ["^build"]`, no persistent). `NEEME_*` is already in `globalEnv`.
+
+## Tier A — pure unit tests (no DB writes)
+
+- `test/pipeline/chunk.test.ts` — [`chunk.ts`](apps/desktop/src/main/pipeline/chunk.ts): empty/whitespace → `[]`; short text → single chunk; long text → overlapping windows (verify overlap continuity + coverage); `overlap >= maxChars` throws.
+- `test/pipeline/extract.test.ts` — [`extract.ts`](apps/desktop/src/main/pipeline/extract.ts): `suffixOf`; `detectContentType` by extension, by MIME fallback, and `'other'` default; `extract('text', …)` UTF-8 decode + `pending` status on empty.
+- `test/pipeline/embed.test.ts` — `HashEmbedder` directly: vector length = 384, deterministic for same input, L2 norm ≈ 1, shared tokens → smaller cosine distance than disjoint tokens.
+- `test/pipeline/draft.test.ts` — `NullDrafter.draft` returns `status:'gathered'` with null fields + empty `why`.
+- `test/services/project.test.ts` — [`project.ts`](apps/desktop/src/main/services/project.ts): `toMemory` kind/title/snip + truncation; `toFedItem` done-vs-pending status; `toMatchHits` best-chunk-per-item + closest-first sort + 0..1 clamp; `toTask` status precedence (`done` > `drafted` > `gathered`), `relMap`/`whyMap`/`pinned` derivation, AI-null degradation; `toBacklogItem` `conf` null without AI.
+- `test/services/draft-service.test.ts` — `rowToTaskDraft`: JSON `draft` parse, bad-JSON fallback to null, `noteKind`/`status` mapping.
+
+## Tier B — integration tests (temp DB + hash embedder)
+
+Each file: `beforeAll(initDb)`, `beforeEach(clearTables)` (DELETE from `todo_ai`, `todo_context`, `todos`, `chunks`, `items`, `meta`).
+
+- `test/services/pipeline-service.test.ts` — [`pipeline-service.ts`](apps/desktop/src/main/services/pipeline-service.ts): `captureText` idempotency (`created:true` then `created:false` for same bytes); `search`/`match` return hits ranked closest-first with best-chunk-per-item; `reindexAll` returns item count; `syncEmbedder` no-ops when `meta.embedder` matches and reindexes when it differs.
+- `test/services/todo-service.test.ts` — [`todo-service.ts`](apps/desktop/src/main/services/todo-service.ts): `add` up to `CAP=5` then throws `CAP_REACHED`; latch (complete all 5 → `canAdd` true again); `plan` carries `keep` onto the day, sweeps the rest to backlog (`day=null`), and throws when `keep.length > CAP`; `schedule` respects the cap; context pool — capture items first, then `add`/`searchMoreContext` surfaces them; `pinContext`/`dismissContext` persist verdicts; `listContext` puts pinned first then sorts by score and excludes dismissed.
+- `test/services/draft-service.test.ts` (integration portion) — `regenerate` with `NullDrafter` upserts a `todo_ai` row (`status:'gathered'`); second call with unchanged inputs is a no-op via `inputsHash`; `read` returns the row.
+
+Context hits rely on the lexical hash embedder, so tests use captured text that shares words with the todo title to guarantee surfaced context.
+
+## Docs
+
+- Mark ROADMAP #7 as in-progress/shipped in [`docs/ROADMAP.md`](docs/ROADMAP.md) and add a one-line "run tests" note (`pnpm --filter @nimi/desktop test`) to [`apps/desktop/CLAUDE.md`](apps/desktop/CLAUDE.md) / `AGENTS.md` verify section.
+
+## Verify
+
+- `pnpm --filter @nimi/desktop test` green.
+- `pnpm typecheck` + `pnpm lint` still green for app code (tests live outside `src/main`, so they don't enter the node/web typecheck; lint config may need a glob for `test/**` — confirm and add if eslint flags it).
+
+## Risks / notes
+
+- libSQL `file:` client runs fine in plain Node (the `AGENTS.md` `tsx` smoke proves it) — no Electron/native rebuild needed.
+- `buildUserMessage`/`coerceTaskDraft` in `draft.ts` are not exported; covering them is optional and would require either exporting them or driving `CloudDrafter` with a mocked global `fetch`. Default scope: cover `NullDrafter` only; treat `CloudDrafter`/`LocalEmbedder` as out-of-scope (network/model).

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "dev": "turbo run dev",
     "build": "turbo run build",
     "typecheck": "turbo run typecheck",
+    "test": "turbo run test",
     "lint": "eslint --cache .",
     "format": "prettier --write .",
     "gen:api": "pnpm --filter @nimi/contract gen:api"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -111,6 +111,9 @@ importers:
       vite:
         specifier: ^7.2.6
         version: 7.3.3(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.3)
+      vitest:
+        specifier: ^4.1.8
+        version: 4.1.8(@types/node@24.12.4)(vite@7.3.3(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.3))
 
   packages/contract:
     devDependencies:
@@ -1268,6 +1271,9 @@ packages:
     resolution: {integrity: sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==}
     engines: {node: '>=10'}
 
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
   '@szmarczak/http-timer@4.0.6':
     resolution: {integrity: sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==}
     engines: {node: '>=10'}
@@ -1410,8 +1416,14 @@ packages:
   '@types/cacheable-request@6.0.3':
     resolution: {integrity: sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==}
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
   '@types/debug@4.1.13':
     resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
@@ -1525,6 +1537,35 @@ packages:
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
 
+  '@vitest/expect@4.1.8':
+    resolution: {integrity: sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==}
+
+  '@vitest/mocker@4.1.8':
+    resolution: {integrity: sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.8':
+    resolution: {integrity: sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==}
+
+  '@vitest/runner@4.1.8':
+    resolution: {integrity: sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg==}
+
+  '@vitest/snapshot@4.1.8':
+    resolution: {integrity: sha512-acfZboRmAIf05DEKcBQy33VXojFJjtUdLyo7oOmV9kebb2xdU01UknNiPuPZoJZQyO7DF0gZdTGTpeAzET9QPQ==}
+
+  '@vitest/spy@4.1.8':
+    resolution: {integrity: sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA==}
+
+  '@vitest/utils@4.1.8':
+    resolution: {integrity: sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==}
+
   '@xmldom/xmldom@0.8.13':
     resolution: {integrity: sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==}
     engines: {node: '>=10.0.0'}
@@ -1619,6 +1660,10 @@ packages:
   assert-plus@1.0.0:
     resolution: {integrity: sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==}
     engines: {node: '>=0.8'}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
 
   astral-regex@2.0.0:
     resolution: {integrity: sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==}
@@ -1748,6 +1793,10 @@ packages:
 
   caniuse-lite@1.0.30001793:
     resolution: {integrity: sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
 
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
@@ -2126,6 +2175,9 @@ packages:
     resolution: {integrity: sha512-HVLACW1TppGYjJ8H6/jqH/pqOtKRw6wMlrB23xfExmFWxFquAIWCmwoLsOyN96K4a5KbmOf5At9ZUO3GZbetAw==}
     engines: {node: '>= 0.4'}
 
+  es-module-lexer@2.1.0:
+    resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
+
   es-object-atoms@1.1.2:
     resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
     engines: {node: '>= 0.4'}
@@ -2247,6 +2299,9 @@ packages:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
@@ -2254,6 +2309,10 @@ packages:
   expand-template@2.0.3:
     resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
     engines: {node: '>=6'}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   exponential-backoff@3.1.3:
     resolution: {integrity: sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==}
@@ -2995,6 +3054,9 @@ packages:
     resolution: {integrity: sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==}
     engines: {node: '>= 0.4'}
 
+  obug@2.1.1:
+    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
   ohash@2.0.11:
     resolution: {integrity: sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==}
 
@@ -3347,6 +3409,9 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
@@ -3382,9 +3447,15 @@ packages:
   sprintf-js@1.1.3:
     resolution: {integrity: sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
   stat-mode@1.0.0:
     resolution: {integrity: sha512-jH9EhtKIjuXZ2cWxmXS8ZP80XyC3iasQxMDV8jzhNJpfDb7VbQLVW4Wvsxz9QZvzV+G4YoSfBUVKDOyxLzi/sg==}
     engines: {node: '>= 6'}
+
+  std-env@4.1.0:
+    resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
@@ -3475,9 +3546,20 @@ packages:
   tiny-typed-emitter@2.1.0:
     resolution: {integrity: sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.2.4:
+    resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
+    engines: {node: '>=18'}
+
   tinyglobby@0.2.17:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
 
   tmp-promise@3.0.3:
     resolution: {integrity: sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ==}
@@ -3636,6 +3718,47 @@ packages:
       yaml:
         optional: true
 
+  vitest@4.1.8:
+    resolution: {integrity: sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.8
+      '@vitest/browser-preview': 4.1.8
+      '@vitest/browser-webdriverio': 4.1.8
+      '@vitest/coverage-istanbul': 4.1.8
+      '@vitest/coverage-v8': 4.1.8
+      '@vitest/ui': 4.1.8
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
     engines: {node: '>= 0.4'}
@@ -3665,6 +3788,11 @@ packages:
   which@6.0.1:
     resolution: {integrity: sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==}
     engines: {node: ^20.17.0 || >=22.9.0}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   word-wrap@1.2.5:
@@ -4660,6 +4788,8 @@ snapshots:
 
   '@sindresorhus/is@4.6.0': {}
 
+  '@standard-schema/spec@1.1.0': {}
+
   '@szmarczak/http-timer@4.0.6':
     dependencies:
       defer-to-connect: 2.0.1
@@ -4783,9 +4913,16 @@ snapshots:
       '@types/node': 24.12.4
       '@types/responselike': 1.0.3
 
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
   '@types/debug@4.1.13':
     dependencies:
       '@types/ms': 2.1.0
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/estree@1.0.8': {}
 
@@ -4942,6 +5079,47 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@vitest/expect@4.1.8':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.8
+      '@vitest/utils': 4.1.8
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.8(vite@7.3.3(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.3))':
+    dependencies:
+      '@vitest/spy': 4.1.8
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.3(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.3)
+
+  '@vitest/pretty-format@4.1.8':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.8':
+    dependencies:
+      '@vitest/utils': 4.1.8
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.8':
+    dependencies:
+      '@vitest/pretty-format': 4.1.8
+      '@vitest/utils': 4.1.8
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.8': {}
+
+  '@vitest/utils@4.1.8':
+    dependencies:
+      '@vitest/pretty-format': 4.1.8
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
+
   '@xmldom/xmldom@0.8.13': {}
 
   '@xmldom/xmldom@0.9.10': {}
@@ -5083,6 +5261,8 @@ snapshots:
 
   assert-plus@1.0.0:
     optional: true
+
+  assertion-error@2.0.1: {}
 
   astral-regex@2.0.0:
     optional: true
@@ -5241,6 +5421,8 @@ snapshots:
   callsites@3.1.0: {}
 
   caniuse-lite@1.0.30001793: {}
+
+  chai@6.2.2: {}
 
   chalk@4.1.2:
     dependencies:
@@ -5637,6 +5819,8 @@ snapshots:
       iterator.prototype: 1.1.5
       math-intrinsics: 1.1.0
 
+  es-module-lexer@2.1.0: {}
+
   es-object-atoms@1.1.2:
     dependencies:
       es-errors: 1.3.0
@@ -5869,10 +6053,16 @@ snapshots:
 
   estraverse@5.3.0: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
   esutils@2.0.3: {}
 
   expand-template@2.0.3:
     optional: true
+
+  expect-type@1.3.0: {}
 
   exponential-backoff@3.1.3: {}
 
@@ -6614,6 +6804,8 @@ snapshots:
       define-properties: 1.2.1
       es-object-atoms: 1.1.2
 
+  obug@2.1.1: {}
+
   ohash@2.0.11: {}
 
   once@1.4.0:
@@ -7068,6 +7260,8 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
   signal-exit@3.0.7: {}
 
   simple-concat@1.0.1:
@@ -7105,7 +7299,11 @@ snapshots:
 
   sprintf-js@1.1.3: {}
 
+  stackback@0.0.2: {}
+
   stat-mode@1.0.0: {}
+
+  std-env@4.1.0: {}
 
   stop-iteration-iterator@1.1.0:
     dependencies:
@@ -7237,10 +7435,16 @@ snapshots:
 
   tiny-typed-emitter@2.1.0: {}
 
+  tinybench@2.9.0: {}
+
+  tinyexec@1.2.4: {}
+
   tinyglobby@0.2.17:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
+
+  tinyrainbow@3.1.0: {}
 
   tmp-promise@3.0.3:
     dependencies:
@@ -7388,6 +7592,33 @@ snapshots:
       lightningcss: 1.32.0
       tsx: 4.22.3
 
+  vitest@4.1.8(@types/node@24.12.4)(vite@7.3.3(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.3)):
+    dependencies:
+      '@vitest/expect': 4.1.8
+      '@vitest/mocker': 4.1.8(vite@7.3.3(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.3))
+      '@vitest/pretty-format': 4.1.8
+      '@vitest/runner': 4.1.8
+      '@vitest/snapshot': 4.1.8
+      '@vitest/spy': 4.1.8
+      '@vitest/utils': 4.1.8
+      es-module-lexer: 2.1.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.0
+      vite: 7.3.3(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.3)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 24.12.4
+    transitivePeerDependencies:
+      - msw
+
   which-boxed-primitive@1.1.1:
     dependencies:
       is-bigint: 1.1.0
@@ -7440,6 +7671,11 @@ snapshots:
   which@6.0.1:
     dependencies:
       isexe: 4.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   word-wrap@1.2.5: {}
 

--- a/turbo.json
+++ b/turbo.json
@@ -16,6 +16,9 @@
     "typecheck": {
       "dependsOn": ["^build"]
     },
+    "test": {
+      "dependsOn": ["^build"]
+    },
     "dev": {
       "cache": false,
       "persistent": true


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Implements ROADMAP #7 — adds a vitest test harness to `@nimi/desktop` and 152 tests (8 files) covering the worker's pipeline and todo logic. Tests run in plain Node with no Electron, no ONNX model download, and no network.

## How it works

**Test isolation:** `test/setup.ts` (a vitest `setupFile`) runs before each test file's module imports. It creates a unique temp dir and sets three env vars that the worker services read at module load time:
- `NEEME_USER_DATA=<tmpdir>` — per-file libSQL DB
- `NEEME_EMBEDDER=hash` — `HashEmbedder` (deterministic, no ONNX)
- `NEEME_DRAFTER=off` — `NullDrafter` (no network / API key)

Vitest's default `isolate: true` gives each test file its own module registry, so singletons (`client`, `db`, `embedder`, `drafter`) are re-evaluated fresh per file with that file's env.

**`@nimi/contract/*` resolution:** `vitest.config.ts` aliases `@nimi/contract` → `packages/contract/src`, mirroring `tsconfig.node.json` paths, so Vite can transform the `.ts` source.

## Test coverage

### Tier A — pure unit (no DB writes)

| File | What's tested |
|------|--------------|
| `test/pipeline/chunk.test.ts` | `chunkText`: empty/whitespace, single chunk, overlap continuity, full coverage, throws on invalid overlap |
| `test/pipeline/extract.test.ts` | `suffixOf`, `detectContentType` (ext/MIME/fallback), `extract(text/image/audio/other)` |
| `test/pipeline/embed.test.ts` | `HashEmbedder`: dim=384, determinism, L2 norm≈1, shared tokens → closer cosine distance |
| `test/pipeline/draft.test.ts` | `NullDrafter`: returns `gathered` + all-null fields + empty `why` |
| `test/services/project.test.ts` | `toMemory`/`toFedItem`/`toMatchHits`/`toTask`/`toBacklogItem` projectors, AI-gap degradation |
| `test/services/draft-service.test.ts` | `rowToTaskDraft`: JSON draft parsing, bad-JSON fallback, status/noteKind mapping, meta fields |

### Tier B — integration (temp libSQL + hash embedder)

| File | What's tested |
|------|--------------|
| `test/services/pipeline-service.test.ts` | Capture idempotency, search/match ranking, best-chunk-per-item dedup, `reindexAll`, `syncEmbedder` no-op + reindex-on-change |
| `test/services/todo-service.test.ts` | cap-5 + `CAP_REACHED`, finish-the-list latch, `plan` carry-over + backlog sweep, `schedule` cap, context pool surface/pin/dismiss |
| `test/services/draft-service.test.ts` | `regenerate` upsert (NullDrafter), `inputsHash` dedup no-op, `read` |

## Run tests

```bash
pnpm --filter @nimi/desktop test        # run once
pnpm --filter @nimi/desktop test:watch  # watch mode
pnpm test                               # all packages via turbo
```

## Verify

- `pnpm --filter @nimi/desktop test` → 152/152 passed (8 files)
- `pnpm typecheck` → green
- `pnpm lint` → only pre-existing `packages/contract/src/api/generated/**` debt (expected, documented in CLAUDE.md)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cf6d8b09-0716-48c2-b5c8-f4e923bd3611"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cf6d8b09-0716-48c2-b5c8-f4e923bd3611"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

