### PR TITLE
fix(asr): correct Float32Array input and buffer copy for WhisperAsr

### DIFF
--- a/apps/desktop/src/main/pipeline/asr.ts
+++ b/apps/desktop/src/main/pipeline/asr.ts
@@ -28,7 +28,7 @@ export interface Asr {
 const DEFAULT_WHISPER_MODEL = 'Xenova/whisper-tiny'
 
 type AsrPipeline = (
-  input: { data: Float32Array; sampling_rate: number },
+  input: Float32Array,
   opts?: { chunk_length_s?: number; stride_length_s?: number }
 ) => Promise<{ text: string }>
 
@@ -84,7 +84,10 @@ export class WhisperAsr implements Asr {
           return
         }
         const buf = Buffer.concat(chunks)
-        resolve(new Float32Array(buf.buffer, buf.byteOffset, buf.byteLength / 4))
+        // Copy into a fresh ArrayBuffer — a Node Buffer's .buffer is a shared pool
+        // slab with a non-zero byteOffset, which breaks typed-array ops in ONNX.
+        const view = new Float32Array(buf.buffer, buf.byteOffset, buf.byteLength / 4)
+        resolve(new Float32Array(view))
       })
     })
   }
@@ -92,10 +95,9 @@ export class WhisperAsr implements Asr {
   async extract(filePath: string): Promise<string> {
     const [ffmpegBin, pipe] = await Promise.all([this.loadFfmpeg(), this.loadPipeline()])
     const pcm = await this.decodePcm(filePath, ffmpegBin)
-    const result = await pipe(
-      { data: pcm, sampling_rate: 16000 },
-      { chunk_length_s: 30, stride_length_s: 5 }
-    )
+    // v4 AudioInput = Float32Array directly (not { data, sampling_rate }).
+    // The feature extractor reads sampling_rate from the model config (16kHz for Whisper).
+    const result = await pipe(pcm, { chunk_length_s: 30, stride_length_s: 5 })
     return result.text.trim()
   }
 }


### PR DESCRIPTION
## Summary

- **Wrong input shape**: transformers.js v4 `AudioInput = Float32Array` directly — not `{ data, sampling_rate }` (the v3/Xenova API). Passing the object caused `TypeError: aud.subarray is not a function` inside `_call_whisper`, setting every audio item to `status=failed`.
- **Shared-pool Buffer byte offset**: `Buffer.concat()` returns a Buffer backed by Node's pool slab with a non-zero `byteOffset`. The `Float32Array` view we built from it had `byteOffset > 0`, which ONNX Runtime rejects. Fix: copy into a fresh `Float32Array` with its own `ArrayBuffer`.

## Verification

```
test:smoke        24/24 ✓  (PDF, text, PNG, HEIC, WAV → pending; search)
test:smoke:ocr     6/6 ✓  (PNG → tesseract, HEIC → heic-convert → tesseract)
test:smoke:asr        ✓  (WAV → ffmpeg → Whisper-tiny → "Hello Nimi Smoke Test Audio Transcription.")
typecheck          2/2 ✓
```

macOS Speech ASR (`nimi-extract asr`) runs as an Electron child process and requires the app bundle's TCC authorization — verified via direct CLI call (`nimi-extract ocr` reads text correctly; `asr` needs the Electron context for `SFSpeechRecognizer.requestAuthorization`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow fix to portable Whisper decoding/input only; macOS Speech path untouched and smoke tests cover WAV transcription.
> 
> **Overview**
> Fixes **portable Whisper ASR** so audio items stop failing during transcription.
> 
> `WhisperAsr` now passes a plain **`Float32Array`** into the transformers.js v4 ASR pipeline instead of the old `{ data, sampling_rate }` object, which was causing `aud.subarray is not a function` and marking every audio extraction as failed.
> 
> After **ffmpeg** decodes to PCM, the code **copies** samples into a new `Float32Array` so ONNX is not handed a view over Node’s shared `Buffer` pool (non-zero `byteOffset`). **MacSpeechAsr** is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a303b07c252836a6d1106d1dccc696c6cb8241fd. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->