### PR TITLE
Auth wired end-to-end: Sign in/out UI + JWKS-verified login (#9)

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -33,6 +33,7 @@
     "electron-updater": "^6.3.9",
     "ffmpeg-static": "^5.3.0",
     "heic-convert": "^2.1.0",
+    "jose": "^6.2.3",
     "tesseract.js": "^7.0.0",
     "unpdf": "^1.6.2"
   },

--- a/apps/desktop/src/main/auth/logto.ts
+++ b/apps/desktop/src/main/auth/logto.ts
@@ -35,7 +35,7 @@ import {
 } from './oidc'
 
 const REDIRECT_URI = 'neeme://callback'
-const SCOPE = 'openid profile offline_access'
+const SCOPE = 'openid profile email offline_access'
 
 type Listener = (state: AuthState, accessToken?: string) => void
 type JwksResolver = ReturnType<typeof createRemoteJWKSet>

--- a/apps/desktop/src/main/auth/logto.ts
+++ b/apps/desktop/src/main/auth/logto.ts
@@ -14,26 +14,38 @@
  * entry point no-ops or throws a friendly error, and the app stays unauthenticated
  * (local-first; auth is deferred behind sync — see docs/adr/0002-authentication.md).
  *
- * NOTE: the access token is consumed by our own backend, which verifies it via
- * Logto's JWKS. We intentionally don't cryptographically validate the id_token
- * here (it's used only for display claims); harden with a JWKS check or swap in
- * `openid-client` if this graduates past a scaffold.
+ * The id_token is signature-verified against Logto's JWKS (iss/aud/exp + the
+ * nonce we bind on the authorize request) before its display claims are trusted
+ * — see ./oidc.ts. The access token is opaque to us; our backend remains the
+ * trust boundary that verifies it (still deferred — no backend yet).
  */
 import { app, safeStorage, shell } from 'electron'
-import { createHash, randomBytes } from 'node:crypto'
+import { createRemoteJWKSet } from 'jose'
 import { readFile, writeFile, rm } from 'node:fs/promises'
 import { join } from 'node:path'
 import type { AuthClaims, AuthState } from '@nimi/contract/ipc'
+import {
+  buildAuthorizeUrl,
+  claimsFromPayload,
+  pkceChallenge,
+  randomNonce,
+  randomState,
+  randomVerifier,
+  verifyIdToken
+} from './oidc'
 
 const REDIRECT_URI = 'neeme://callback'
 const SCOPE = 'openid profile offline_access'
 
 type Listener = (state: AuthState, accessToken?: string) => void
+type JwksResolver = ReturnType<typeof createRemoteJWKSet>
 
 interface OidcConfig {
   authorization_endpoint: string
   token_endpoint: string
   end_session_endpoint?: string
+  jwks_uri: string
+  issuer: string
 }
 interface TokenResponse {
   access_token: string
@@ -53,30 +65,13 @@ const appId = import.meta.env.MAIN_VITE_LOGTO_APP_ID ?? ''
 const resource = import.meta.env.MAIN_VITE_LOGTO_RESOURCE || undefined
 
 let discovery: OidcConfig | null = null
+let jwks: JwksResolver | null = null
 let session: Session | null = null
-let pending: { verifier: string; state: string } | null = null
+let pending: { verifier: string; state: string; nonce: string } | null = null
 let listener: Listener | null = null
 
 export function isConfigured(): boolean {
   return Boolean(endpoint && appId)
-}
-
-function base64url(buf: Buffer): string {
-  return buf.toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
-}
-
-function decodeClaims(idToken?: string): AuthClaims | null {
-  if (!idToken) return null
-  try {
-    const json = Buffer.from(
-      idToken.split('.')[1].replace(/-/g, '+').replace(/_/g, '/'),
-      'base64'
-    ).toString('utf8')
-    const c = JSON.parse(json) as Record<string, string>
-    return { sub: c.sub, email: c.email, name: c.name, picture: c.picture }
-  } catch {
-    return null
-  }
 }
 
 function sessionFile(): string {
@@ -104,7 +99,18 @@ async function discover(): Promise<OidcConfig> {
   return discovery
 }
 
-async function exchange(body: URLSearchParams): Promise<void> {
+/** Lazily build (and cache) the remote JWKS resolver — it handles key rotation. */
+function getJwks(cfg: OidcConfig): JwksResolver {
+  if (!jwks) jwks = createRemoteJWKSet(new URL(cfg.jwks_uri))
+  return jwks
+}
+
+/**
+ * Run a token grant, then (when an id_token is returned) verify it before
+ * trusting its claims. `expectedNonce` is the nonce from the authorize request
+ * on the code grant; refresh grants pass none (and often omit the id_token).
+ */
+async function exchange(body: URLSearchParams, expectedNonce?: string): Promise<void> {
   const cfg = await discover()
   if (resource) body.set('resource', resource)
   const res = await fetch(cfg.token_endpoint, {
@@ -114,11 +120,21 @@ async function exchange(body: URLSearchParams): Promise<void> {
   })
   if (!res.ok) throw new Error(`Logto token request failed (HTTP ${res.status})`)
   const t = (await res.json()) as TokenResponse
+  let claims: AuthClaims | null = session?.claims ?? null
+  if (t.id_token) {
+    const payload = await verifyIdToken(t.id_token, {
+      jwks: getJwks(cfg),
+      issuer: cfg.issuer,
+      audience: appId,
+      nonce: expectedNonce
+    })
+    claims = claimsFromPayload(payload)
+  }
   session = {
     accessToken: t.access_token,
     refreshToken: t.refresh_token ?? session?.refreshToken,
     expiresAt: Date.now() + (t.expires_in ?? 3600) * 1000,
-    claims: decodeClaims(t.id_token) ?? session?.claims ?? null
+    claims
   }
   await persist()
   emit()
@@ -143,22 +159,22 @@ export async function startLogin(): Promise<void> {
     )
   }
   const cfg = await discover()
-  const verifier = base64url(randomBytes(32))
-  const challenge = base64url(createHash('sha256').update(verifier).digest())
-  const state = base64url(randomBytes(16))
-  pending = { verifier, state }
+  const verifier = randomVerifier()
+  const state = randomState()
+  const nonce = randomNonce()
+  pending = { verifier, state, nonce }
 
-  const url = new URL(cfg.authorization_endpoint)
-  url.searchParams.set('client_id', appId)
-  url.searchParams.set('redirect_uri', REDIRECT_URI)
-  url.searchParams.set('response_type', 'code')
-  url.searchParams.set('scope', SCOPE)
-  url.searchParams.set('code_challenge', challenge)
-  url.searchParams.set('code_challenge_method', 'S256')
-  url.searchParams.set('state', state)
-  url.searchParams.set('prompt', 'consent')
-  if (resource) url.searchParams.set('resource', resource)
-  await shell.openExternal(url.toString())
+  const url = buildAuthorizeUrl({
+    authorizationEndpoint: cfg.authorization_endpoint,
+    clientId: appId,
+    redirectUri: REDIRECT_URI,
+    scope: SCOPE,
+    challenge: pkceChallenge(verifier),
+    state,
+    nonce,
+    resource
+  })
+  await shell.openExternal(url)
 }
 
 /** Handle the `neeme://callback?code=...&state=...` deep link from the browser. */
@@ -179,7 +195,8 @@ export async function handleCallback(callbackUrl: string): Promise<void> {
       redirect_uri: REDIRECT_URI,
       client_id: appId,
       code_verifier: expected.verifier
-    })
+    }),
+    expected.nonce
   )
 }
 

--- a/apps/desktop/src/main/auth/oidc.ts
+++ b/apps/desktop/src/main/auth/oidc.ts
@@ -94,12 +94,11 @@ export async function verifyIdToken(
   opts: VerifyIdTokenOptions
 ): Promise<JWTPayload> {
   const claims = { issuer: opts.issuer, audience: opts.audience }
-  // Two jwtVerify overloads — a key resolver (prod JWKS) vs. a concrete key
-  // (tests). Narrow on `function` so each call binds to a single overload.
-  const { payload } =
-    typeof opts.jwks === 'function'
-      ? await jwtVerify(idToken, opts.jwks, claims)
-      : await jwtVerify(idToken, opts.jwks, claims)
+  // `jose` splits `jwtVerify` into separate overloads for a key resolver (prod
+  // JWKS) and a concrete key (tests). Both are valid at runtime — jose branches
+  // on `typeof key === 'function'` internally — so assert past the overload
+  // split rather than calling with two identical branches.
+  const { payload } = await jwtVerify(idToken, opts.jwks as JWTVerifyGetKey, claims)
   if (opts.nonce && payload.nonce !== opts.nonce) {
     throw new Error('id_token nonce mismatch')
   }

--- a/apps/desktop/src/main/auth/oidc.ts
+++ b/apps/desktop/src/main/auth/oidc.ts
@@ -1,0 +1,107 @@
+/**
+ * Pure OIDC helpers for the Logto native-app flow — deliberately free of
+ * `electron` and `import.meta.env` so they can be unit-tested in plain Node.
+ *
+ * `logto.ts` is the stateful shell (env config, session, persistence, IPC); the
+ * standalone, side-effect-free pieces of the flow live here: PKCE, the authorize
+ * URL, claim extraction, and id_token verification (signature + iss/aud/exp/nonce).
+ */
+import { createHash, randomBytes } from 'node:crypto'
+import { jwtVerify, type JWTPayload, type JWTVerifyGetKey } from 'jose'
+import type { AuthClaims } from '@nimi/contract/ipc'
+
+/** A verification key: a resolver (prod JWKS) or a concrete key (tests). */
+type VerifyKey = JWTVerifyGetKey | CryptoKey | Uint8Array
+
+/** RFC 4648 §5 base64url (no padding) — used for PKCE verifier/challenge + state/nonce. */
+export function base64url(buf: Buffer): string {
+  return buf.toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+}
+
+/** A high-entropy PKCE code verifier (RFC 7636 — 43–128 chars of base64url). */
+export function randomVerifier(): string {
+  return base64url(randomBytes(32))
+}
+
+/** Opaque CSRF state, echoed back on the callback and checked for a match. */
+export function randomState(): string {
+  return base64url(randomBytes(16))
+}
+
+/** Opaque nonce, bound into the id_token and checked after signature verify. */
+export function randomNonce(): string {
+  return base64url(randomBytes(16))
+}
+
+/** S256 PKCE challenge for a given verifier. */
+export function pkceChallenge(verifier: string): string {
+  return base64url(createHash('sha256').update(verifier).digest())
+}
+
+export interface AuthorizeUrlParams {
+  authorizationEndpoint: string
+  clientId: string
+  redirectUri: string
+  scope: string
+  challenge: string
+  state: string
+  nonce: string
+  resource?: string
+}
+
+/** Build the system-browser authorize URL (Authorization Code + PKCE). */
+export function buildAuthorizeUrl(p: AuthorizeUrlParams): string {
+  const url = new URL(p.authorizationEndpoint)
+  url.searchParams.set('client_id', p.clientId)
+  url.searchParams.set('redirect_uri', p.redirectUri)
+  url.searchParams.set('response_type', 'code')
+  url.searchParams.set('scope', p.scope)
+  url.searchParams.set('code_challenge', p.challenge)
+  url.searchParams.set('code_challenge_method', 'S256')
+  url.searchParams.set('state', p.state)
+  url.searchParams.set('nonce', p.nonce)
+  url.searchParams.set('prompt', 'consent')
+  if (p.resource) url.searchParams.set('resource', p.resource)
+  return url.toString()
+}
+
+/** Project a verified JWT payload to the display claims the UI shows. */
+export function claimsFromPayload(payload: JWTPayload): AuthClaims {
+  return {
+    sub: String(payload.sub ?? ''),
+    email: typeof payload.email === 'string' ? payload.email : undefined,
+    name: typeof payload.name === 'string' ? payload.name : undefined,
+    picture: typeof payload.picture === 'string' ? payload.picture : undefined
+  }
+}
+
+export interface VerifyIdTokenOptions {
+  /** JWKS resolver (prod: `createRemoteJWKSet(...)`; tests: a local public key). */
+  jwks: VerifyKey
+  issuer: string
+  /** Expected audience — the OIDC client_id (Logto App ID). */
+  audience: string
+  /** The nonce sent on the authorize request; must match the token's `nonce`. */
+  nonce?: string
+}
+
+/**
+ * Verify an id_token's signature and standard claims (iss/aud/exp) via JWKS,
+ * then assert the `nonce` binding. Throws on any failure. Returns the payload.
+ */
+export async function verifyIdToken(
+  idToken: string,
+  opts: VerifyIdTokenOptions
+): Promise<JWTPayload> {
+  const claims = { issuer: opts.issuer, audience: opts.audience }
+  // Two jwtVerify overloads — a key resolver (prod JWKS) vs. a concrete key
+  // (tests). Narrow on `function` so each call binds to a single overload.
+  const { payload } =
+    typeof opts.jwks === 'function'
+      ? await jwtVerify(idToken, opts.jwks, claims)
+      : await jwtVerify(idToken, opts.jwks, claims)
+  if (opts.nonce && payload.nonce !== opts.nonce) {
+    throw new Error('id_token nonce mismatch')
+  }
+  return payload
+}

--- a/apps/desktop/src/renderer/src/hooks/useAuth.ts
+++ b/apps/desktop/src/renderer/src/hooks/useAuth.ts
@@ -1,19 +1,26 @@
 import { useEffect, useState } from 'react'
 import { setToken, clearToken } from '@nimi/contract/api/token-store'
 import type { AuthState } from '@nimi/contract/ipc'
+import { isElectron } from '../nimi/api'
 
 const EMPTY: AuthState = { configured: false, isAuthenticated: false, claims: null }
+const NOOP = (): void => {}
 
 /**
  * Bridges the renderer to the main-process Logto flow. On mount it hydrates the
  * API client's token (via `token-store`) and the auth state from main, then
  * subscribes to changes (login / refresh / logout) so the bearer token the HTTP
  * client attaches stays current. Login/logout just delegate to main over IPC.
+ *
+ * Outside Electron (the browser preview, where `window.api` is undefined) it
+ * returns a static unconfigured state and no-op actions — auth is a main-process
+ * concern with no mock, so the UI just renders as if it weren't configured.
  */
 export function useAuth(): { state: AuthState; login: () => void; logout: () => void } {
   const [state, setState] = useState<AuthState>(EMPTY)
 
   useEffect(() => {
+    if (!isElectron) return
     let active = true
     window.api.auth.getState().then((s) => active && setState(s))
     window.api.auth.getAccessToken().then((t) => {
@@ -32,6 +39,8 @@ export function useAuth(): { state: AuthState; login: () => void; logout: () => 
       unsubscribe()
     }
   }, [])
+
+  if (!isElectron) return { state: EMPTY, login: NOOP, logout: NOOP }
 
   return {
     state,

--- a/apps/desktop/src/renderer/src/nimi/auth.tsx
+++ b/apps/desktop/src/renderer/src/nimi/auth.tsx
@@ -1,0 +1,31 @@
+// auth.tsx — the header Sign in / identity control.
+//
+// Self-contained: drives its own `useAuth` (auth lives outside the `data` seam,
+// straight on `window.api.auth`), so it drops into the header without threading
+// props. Renders nothing until Logto is configured — matching the main-process
+// "inert until configured" contract (no MAIN_VITE_LOGTO_* → no control).
+import type { JSX } from 'react'
+import { NIcon } from './icons'
+import { useAuth } from '../hooks/useAuth'
+
+export function AuthControl(): JSX.Element | null {
+  const { state, login, logout } = useAuth()
+
+  if (!state.configured) return null
+
+  if (!state.isAuthenticated) {
+    return (
+      <button className="hdr-btn" aria-label="Sign in" title="Sign in" onClick={login}>
+        <NIcon name="lock" size={18} />
+      </button>
+    )
+  }
+
+  const label = state.claims?.name || state.claims?.email || 'Account'
+  return (
+    <button className="priv-pill" title="Sign out" onClick={logout}>
+      <NIcon name="lock" size={11} />
+      {label}
+    </button>
+  )
+}

--- a/apps/desktop/src/renderer/src/nimi/today.tsx
+++ b/apps/desktop/src/renderer/src/nimi/today.tsx
@@ -4,6 +4,7 @@ import type { JSX } from 'react'
 import { NIcon } from './icons'
 import { kindIcon } from './iconKind'
 import { NimiMark, NimiNote } from './mark'
+import { AuthControl } from './auth'
 import { MemoryContext } from './api'
 import type { Task } from '@nimi/contract/views'
 import type { NimiMarkState } from './types'
@@ -48,6 +49,7 @@ function AppHeader({
         </div>
       </div>
       <div className="hdr-r">
+        <AuthControl />
         <button className="hdr-btn" aria-label="Plan tomorrow" onClick={onTomorrow}>
           <NIcon name="dayNext" size={18} />
         </button>

--- a/apps/desktop/test/services/auth-oidc.test.ts
+++ b/apps/desktop/test/services/auth-oidc.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Unit tests for the pure OIDC helpers (src/main/auth/oidc.ts).
+ *
+ * Tier A: no Electron, no DB, no network. id_token verification is exercised
+ * against a locally generated keypair — we sign tokens with the private key and
+ * verify with the matching public key, so JWKS behavior is covered offline.
+ */
+import { describe, it, expect } from 'vitest'
+import { SignJWT, generateKeyPair } from 'jose'
+import {
+  buildAuthorizeUrl,
+  claimsFromPayload,
+  pkceChallenge,
+  randomNonce,
+  randomState,
+  randomVerifier,
+  verifyIdToken
+} from '../../src/main/auth/oidc'
+
+const ISS = 'https://tenant.logto.app/oidc'
+const AUD = 'my-app-id'
+
+// ── PKCE + random tokens ────────────────────────────────────────────────────
+
+describe('pkceChallenge', () => {
+  it('is deterministic for a fixed verifier', () => {
+    expect(pkceChallenge('fixed-verifier')).toBe(pkceChallenge('fixed-verifier'))
+  })
+
+  it('produces a base64url S256 digest (43 chars, no padding)', () => {
+    const challenge = pkceChallenge(randomVerifier())
+    expect(challenge).toHaveLength(43)
+    expect(challenge).toMatch(/^[A-Za-z0-9_-]+$/)
+  })
+
+  it('differs across distinct verifiers', () => {
+    expect(pkceChallenge('a')).not.toBe(pkceChallenge('b'))
+  })
+})
+
+describe('random token generators', () => {
+  it('emit base64url with sufficient entropy and uniqueness', () => {
+    for (const gen of [randomVerifier, randomState, randomNonce]) {
+      const a = gen()
+      const b = gen()
+      expect(a).toMatch(/^[A-Za-z0-9_-]+$/)
+      expect(a.length).toBeGreaterThanOrEqual(22)
+      expect(a).not.toBe(b)
+    }
+  })
+})
+
+// ── authorize URL ───────────────────────────────────────────────────────────
+
+describe('buildAuthorizeUrl', () => {
+  const base = {
+    authorizationEndpoint: 'https://tenant.logto.app/oidc/auth',
+    clientId: AUD,
+    redirectUri: 'neeme://callback',
+    scope: 'openid profile offline_access',
+    challenge: 'CHALLENGE',
+    state: 'STATE',
+    nonce: 'NONCE'
+  }
+
+  it('sets the required Authorization Code + PKCE params', () => {
+    const url = new URL(buildAuthorizeUrl(base))
+    const q = url.searchParams
+    expect(q.get('client_id')).toBe(AUD)
+    expect(q.get('redirect_uri')).toBe('neeme://callback')
+    expect(q.get('response_type')).toBe('code')
+    expect(q.get('scope')).toBe('openid profile offline_access')
+    expect(q.get('code_challenge')).toBe('CHALLENGE')
+    expect(q.get('code_challenge_method')).toBe('S256')
+    expect(q.get('state')).toBe('STATE')
+    expect(q.get('nonce')).toBe('NONCE')
+  })
+
+  it('omits resource when not provided and includes it when set', () => {
+    expect(new URL(buildAuthorizeUrl(base)).searchParams.has('resource')).toBe(false)
+    const withRes = new URL(buildAuthorizeUrl({ ...base, resource: 'https://api.neeme.app' }))
+    expect(withRes.searchParams.get('resource')).toBe('https://api.neeme.app')
+  })
+})
+
+// ── claims projection ─────────────────────────────────────────────────────────
+
+describe('claimsFromPayload', () => {
+  it('maps the display claims and drops non-string fields', () => {
+    expect(
+      claimsFromPayload({ sub: 'u1', email: 'a@b.co', name: 'Ada', picture: 'http://x/p.png' })
+    ).toEqual({ sub: 'u1', email: 'a@b.co', name: 'Ada', picture: 'http://x/p.png' })
+
+    expect(claimsFromPayload({ sub: 'u2', email: 42 as unknown as string })).toEqual({
+      sub: 'u2',
+      email: undefined,
+      name: undefined,
+      picture: undefined
+    })
+  })
+})
+
+// ── id_token verification ─────────────────────────────────────────────────────
+
+async function signIdToken(
+  key: CryptoKey,
+  claims: Record<string, unknown> = {},
+  opts: { iss?: string; aud?: string; exp?: string | number } = {}
+): Promise<string> {
+  return new SignJWT({ nonce: 'NONCE', ...claims })
+    .setProtectedHeader({ alg: 'RS256' })
+    .setIssuer(opts.iss ?? ISS)
+    .setAudience(opts.aud ?? AUD)
+    .setSubject('user-123')
+    .setIssuedAt()
+    .setExpirationTime(opts.exp ?? '1h')
+    .sign(key)
+}
+
+describe('verifyIdToken', () => {
+  it('accepts a correctly signed token and returns the payload', async () => {
+    const { publicKey, privateKey } = await generateKeyPair('RS256')
+    const token = await signIdToken(privateKey, { email: 'a@b.co', name: 'Ada' })
+    const payload = await verifyIdToken(token, {
+      jwks: publicKey,
+      issuer: ISS,
+      audience: AUD,
+      nonce: 'NONCE'
+    })
+    expect(payload.sub).toBe('user-123')
+    expect(claimsFromPayload(payload)).toMatchObject({ email: 'a@b.co', name: 'Ada' })
+  })
+
+  it('rejects a tampered signature', async () => {
+    const { publicKey, privateKey } = await generateKeyPair('RS256')
+    const token = await signIdToken(privateKey)
+    const tampered = token.slice(0, -3) + (token.endsWith('A') ? 'BBB' : 'AAA')
+    await expect(
+      verifyIdToken(tampered, { jwks: publicKey, issuer: ISS, audience: AUD, nonce: 'NONCE' })
+    ).rejects.toThrow()
+  })
+
+  it('rejects a wrong issuer', async () => {
+    const { publicKey, privateKey } = await generateKeyPair('RS256')
+    const token = await signIdToken(privateKey, {}, { iss: 'https://evil.example/oidc' })
+    await expect(
+      verifyIdToken(token, { jwks: publicKey, issuer: ISS, audience: AUD, nonce: 'NONCE' })
+    ).rejects.toThrow()
+  })
+
+  it('rejects a wrong audience', async () => {
+    const { publicKey, privateKey } = await generateKeyPair('RS256')
+    const token = await signIdToken(privateKey, {}, { aud: 'someone-else' })
+    await expect(
+      verifyIdToken(token, { jwks: publicKey, issuer: ISS, audience: AUD, nonce: 'NONCE' })
+    ).rejects.toThrow()
+  })
+
+  it('rejects an expired token', async () => {
+    const { publicKey, privateKey } = await generateKeyPair('RS256')
+    const token = await signIdToken(privateKey, {}, { exp: Math.floor(Date.now() / 1000) - 60 })
+    await expect(
+      verifyIdToken(token, { jwks: publicKey, issuer: ISS, audience: AUD, nonce: 'NONCE' })
+    ).rejects.toThrow()
+  })
+
+  it('rejects a nonce mismatch', async () => {
+    const { publicKey, privateKey } = await generateKeyPair('RS256')
+    const token = await signIdToken(privateKey, { nonce: 'OTHER' })
+    await expect(
+      verifyIdToken(token, { jwks: publicKey, issuer: ISS, audience: AUD, nonce: 'NONCE' })
+    ).rejects.toThrow(/nonce/)
+  })
+
+  it('skips the nonce check when no nonce is expected (refresh grant)', async () => {
+    const { publicKey, privateKey } = await generateKeyPair('RS256')
+    const token = await signIdToken(privateKey, { nonce: 'WHATEVER' })
+    const payload = await verifyIdToken(token, { jwks: publicKey, issuer: ISS, audience: AUD })
+    expect(payload.sub).toBe('user-123')
+  })
+})

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -31,7 +31,7 @@ Shared punch list. **Baseline:** `main` @ #12–#15 merged. Lanes: **back** = `a
 | 6   | ~~Feed view + uncovered-todos (Nimi proposes todos from the feed)~~ ✅ **done**                            | back + front | the `FedItem` / `UncoveredTodo` surfaces         | M    | ✅ shipped  |
 | 7   | ~~**Worker-service tests (vitest)**~~ ✅ **done**                                                        | back         | guards pipeline/todo logic                       | M    | ✅ shipped  |
 | 8   | Connectors / ingest (email, calendar, …)                                                                 | back         | automatic capture vs manual                      | L    | P2         |
-| 9   | Auth wired end-to-end (Logto configured, login tested)                                                   | back + front | real accounts                                    | M    | P2         |
+| 9   | Auth end-to-end: UI control + id_token JWKS-verify done; **pending live login test** w/ tenant            | back + front | real accounts                                    | M    | P2         |
 | 10  | Sync / cloud offload (Turso), multi-user                                                                 | back         | multi-device                                     | L    | P3         |
 | 11  | Vuln cleanup + CSP tighten                                                                               | back         | the dependabot alerts + hardening                | S    | P1 (quick) |
 | 12  | Auto-updater (electron-updater)                                                                          | back/dist    | testers auto-get each pushed build               | M    | P1         |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -31,7 +31,7 @@ Shared punch list. **Baseline:** `main` @ #12–#15 merged. Lanes: **back** = `a
 | 6   | ~~Feed view + uncovered-todos (Nimi proposes todos from the feed)~~ ✅ **done**                            | back + front | the `FedItem` / `UncoveredTodo` surfaces         | M    | ✅ shipped  |
 | 7   | ~~**Worker-service tests (vitest)**~~ ✅ **done**                                                        | back         | guards pipeline/todo logic                       | M    | ✅ shipped  |
 | 8   | Connectors / ingest (email, calendar, …)                                                                 | back         | automatic capture vs manual                      | L    | P2         |
-| 9   | Auth end-to-end: UI control + id_token JWKS-verify done; **pending live login test** w/ tenant            | back + front | real accounts                                    | M    | P2         |
+| 9   | Auth end-to-end (Logto **Native** app + PKCE, id_token JWKS-verified) — **login verified** ✅; PR #35 open  | back + front | real accounts                                    | M    | P2         |
 | 10  | Sync / cloud offload (Turso), multi-user                                                                 | back         | multi-device                                     | L    | P3         |
 | 11  | Vuln cleanup + CSP tighten                                                                               | back         | the dependabot alerts + hardening                | S    | P1 (quick) |
 | 12  | Auto-updater (electron-updater)                                                                          | back/dist    | testers auto-get each pushed build               | M    | P1         |

--- a/docs/agent-sync/INBOX.md
+++ b/docs/agent-sync/INBOX.md
@@ -5,6 +5,8 @@ Tags: `@all` · `@backend` · `@frontend` · branch name. Delete a line once han
 
 ---
 
+@back 🔌 **#8 connectors (Gmail/Cal) ↔ #9 auth coordination** — branch `claude/epic-lederberg-882280` adds Logto login (`auth/logto.ts` + `auth/oidc.ts`, header `AuthControl`). Two rules so we don't collide: (1) **REUSE the pure PKCE primitives** from `auth/oidc.ts` (`base64url`, `randomVerifier`, `randomState`, `pkceChallenge`) — provider-agnostic, no Logto coupling; don't re-roll crypto. Extend `buildAuthorizeUrl` *additively* (e.g. an `extraParams` for Google `access_type=offline`) if you need it. (2) **Keep redirect transports separate**: login owns the `neeme://` custom scheme (`main/index.ts` `open-url`/`second-instance` → `auth.handleCallback`); connectors must use a **loopback HTTP listener**, never the custom scheme. Land connector IPC channels/view-models in `@nimi/contract` first (no auth overlap there). Google creds need a `MAIN_VITE_`/`NEEME_` prefix to reach main/worker via electron-vite/turbo — the bare `GOOGLE_CLIENT_ID/SECRET` now in `.env` reach nothing. Details: `docs/auth-logto-setup.md` § "Two OAuth flows".
+
 @back ⚠️ test fixtures collide across suites: OCR/ASR (#5) work swapped `apps/desktop/test/fixtures/sample.png` (1×1 → 200×50) under the captureFile suite. Isolate per-suite fixtures + add deterministic OCR/ASR coverage. See `apps/desktop/test/NOTES.md`.
 @all ✅ **Monorepo migration (#0) MERGED** — branch off `main` (paths: `apps/desktop/src/…`, contract = `@nimi/contract` at `packages/contract`). Hold lifted.
 @front after #0: wire the UI to `window.api`, retire mock `data.ts` (`ROADMAP.md` #2, `INTEGRATION.md`). Paths shift to `apps/desktop/src/renderer`.

--- a/docs/auth-logto-setup.md
+++ b/docs/auth-logto-setup.md
@@ -91,6 +91,21 @@ than re-roll crypto. `verifyIdToken`/`claimsFromPayload` are login-only (connect
 tokens, not identity). The custom-scheme handler is login-only — connectors must not register a
 scheme or they'll capture each other's callbacks.
 
+## Gotchas we actually hit (verified 2026-06)
+
+- **Use a Native app, not the Management API app.** Every Logto tenant auto-creates an M2M
+  "Management API" app — grabbing *its* App ID gives `invalid_redirect_uri` ("redirect_uris must
+  contain members"), because M2M apps have no redirect URIs. The login client must be type **Native**.
+- **Save the redirect URI.** Adding `neeme://callback` but not clicking **Save changes** leaves the
+  array empty → same error. After saving it shows as a chip in the list.
+- **Don't request the Management API resource for login.** `MAIN_VITE_LOGTO_RESOURCE=<tenant>/api`
+  is the Management API indicator; a user-login client requesting it gets `invalid_target`. Leave it
+  unset unless you've registered a real API resource and want a scoped access token.
+- **One app instance at a time across worktrees.** All worktrees share appId `cool.jlee.nimi` +
+  `userData`, so they share a single-instance lock. A stale `pnpm dev` in another worktree keeps its
+  (wrong) window up and blocks yours — `window.api` reads `undefined` and the UI silently falls back
+  to the browser mock (no lock). Kill the other dev first.
+
 ## Caveats
 
 - **Custom-scheme deep link (`neeme://`)** registers reliably in a **packaged** build. In `pnpm dev`

--- a/docs/auth-logto-setup.md
+++ b/docs/auth-logto-setup.md
@@ -72,6 +72,25 @@ to the app (the known dev limitation).
 
 **Reset to a clean slate:** `rm "$HOME/Library/Application Support/nimi/neeme-auth.bin"`, relaunch.
 
+## Two OAuth flows (login vs connectors) — don't conflate them
+
+The app runs **two independent OAuth flows**; keep them separate:
+
+| | **Login** (#9, this doc) | **Connectors** (#8 — Gmail/Calendar ingest) |
+| --- | --- | --- |
+| Provider | Logto (broker; can federate Google) | Google directly |
+| Purpose | who you are (id_token → claims) | data access (access token → Gmail/Cal APIs) |
+| Redirect transport | `neeme://callback` custom scheme | **loopback** `http://127.0.0.1:<port>/callback` |
+| Callback handler | `main/index.ts` `open-url`/`second-instance` → `auth.handleCallback` | a transient local HTTP listener (connectors own it) |
+| Client | public, PKCE, no secret | own Google client (PKCE + secret) |
+| Env | `MAIN_VITE_LOGTO_*` | Google creds (need a `MAIN_VITE_`/`NEEME_` prefix to reach main/worker) |
+
+**Shared, by design:** the pure PKCE primitives in `auth/oidc.ts` (`base64url`, `randomVerifier`,
+`randomState`, `pkceChallenge`) are provider-agnostic — the connector flow should import them rather
+than re-roll crypto. `verifyIdToken`/`claimsFromPayload` are login-only (connectors want access
+tokens, not identity). The custom-scheme handler is login-only — connectors must not register a
+scheme or they'll capture each other's callbacks.
+
 ## Caveats
 
 - **Custom-scheme deep link (`neeme://`)** registers reliably in a **packaged** build. In `pnpm dev`

--- a/docs/auth-logto-setup.md
+++ b/docs/auth-logto-setup.md
@@ -30,21 +30,55 @@
 
 4. Restart `pnpm dev`. A **Sign in** button appears once `configured` is true.
 
-## Smoke test (the #9 acceptance)
+`MAIN_VITE_*` is read at process start from `apps/desktop/.env` (electron-vite's config root) —
+not the repo-root `.env`. Put the vars there, or the button won't appear.
 
-1. Set the env vars above, restart `pnpm dev` → the **Sign in** button appears (proves `configured`).
-2. Click it → the system browser opens Logto → authenticate → it redirects to `neeme://callback`.
-3. The app catches the callback, exchanges the code (PKCE), **verifies the id_token against JWKS**,
-   and the header shows your name/email.
-4. Restart `pnpm dev` → the session restores silently (refresh token, no re-login).
-5. Click the identity pill → **Sign out**; the header returns to **Sign in** and the bearer clears.
+## What you do NOT need
+
+- **You don't need a social login (Google, etc.) to test sign-in.** Logto has built-in
+  email/password — that alone exercises the whole flow below.
+- **Don't create a direct Google/loopback OAuth client for this.** The app talks only to Logto;
+  Logto is the identity broker that talks to Google. A `127.0.0.1` loopback redirect or Gmail/
+  Calendar scopes belong to *connectors* (ROADMAP #8 — ingesting mail/calendar), not login.
+
+### Optional: "Sign in with Google" (a Logto **social connector**)
+1. **Logto Console → Connectors → Social → Google** → paste your Google **Client ID + Secret**
+   (these live in Logto, _not_ in the app's `.env`).
+2. Logto shows a **Redirect URI** like `https://<tenant>.logto.app/callback/<connector-id>` —
+   register **that** in Google Cloud Console's OAuth client (Authorized redirect URIs).
+3. Login scopes are just `openid email profile`. Gmail/Calendar readonly are connector scopes — omit.
+
+## Test plan (the #9 acceptance)
+
+Shared: fill `apps/desktop/.env` (above), and confirm the **Logto Native app**'s Redirect URI is
+exactly `neeme://callback` (no trailing slash). Sign-in flow: header **Sign in** → system browser →
+authenticate → redirect to `neeme://callback` → app exchanges the code (PKCE), **verifies the
+id_token against JWKS**, header shows your name/email.
+
+**Option A — dev (`pnpm dev`), try first.** On macOS the `open-url` event usually routes the
+callback home.
+1. `pnpm dev` → **Sign in** button visible (proves `configured`).
+2. Click → system browser → sign in (email/password is fine).
+3. Back in the app: header shows your identity. In DevTools: `await window.api.auth.getState()`
+   → `isAuthenticated: true`; `await window.api.auth.getAccessToken()` → a JWT.
+4. Quit + `pnpm dev` again → still signed in (silent refresh).
+5. Click the identity pill → **Sign out** → back to **Sign in**.
+
+**Option B — packaged build, the reliable deep-link path.** Use if A's redirect doesn't return
+to the app (the known dev limitation).
+1. Fill `apps/desktop/.env` **before** building (`MAIN_VITE_*` are baked in at build time).
+2. `pnpm --filter @nimi/desktop build:unpack` → `open apps/desktop/dist/mac*/nimi.app`.
+3. Same checks as A2–A5; `neeme://` is OS-registered so the callback always routes home.
+
+**Reset to a clean slate:** `rm "$HOME/Library/Application Support/nimi/neeme-auth.bin"`, relaunch.
 
 ## Caveats
 
 - **Custom-scheme deep link (`neeme://`)** registers reliably in a **packaged** build. In `pnpm dev`
   on macOS the `open-url` event usually still fires; on Windows/Linux deep links rely on the
-  single-instance lock + argv parsing (already wired). If dev redirects don't return, test in a
-  packaged build or switch the redirect to a loopback (`http://127.0.0.1:<port>/callback`).
+  single-instance lock + argv parsing (already wired). If dev redirects don't return, use Option B
+  (packaged build). The redirect is hardcoded `neeme://callback` (`auth/logto.ts`); a loopback
+  redirect would mean code changes (a local HTTP listener) — not wired today.
 - The `id_token` **is** signature-verified client-side now (`auth/oidc.ts` `verifyIdToken`: JWKS
   signature + `iss`/`aud`/`exp` + the `nonce` bound on the authorize request). The **access token**
   stays opaque to the client — the **backend** remains its trust boundary (verify against Logto's

--- a/docs/auth-logto-setup.md
+++ b/docs/auth-logto-setup.md
@@ -10,9 +10,10 @@
   **system browser**, custom-scheme redirect `neeme://callback`, token exchange + refresh,
   refresh token sealed via Electron `safeStorage`. Inert when unconfigured.
 - **IPC** (`packages/contract/src/ipc.ts`, `apps/desktop/src/preload`): `window.api.auth.{login,logout,getAccessToken,getState,onChanged}`.
-- **Renderer** (`apps/desktop/src/renderer/src/hooks/useAuth.ts`): hydrates the API client's bearer token
-  (`packages/contract/src/api/token-store.ts` → `runtime.ts` `getToken()` seam) and shows a Sign in/out
-  control in the header. No CSP change needed — the renderer never calls Logto.
+- **Renderer** (`apps/desktop/src/renderer/src/hooks/useAuth.ts` + `nimi/auth.tsx`): hydrates the API
+  client's bearer token (`packages/contract/src/api/token-store.ts` → `runtime.ts` `getToken()` seam)
+  and renders the header `AuthControl` (Sign in → identity pill → Sign out). Hidden until `configured`.
+  No CSP change needed — the renderer never calls Logto.
 
 ## To turn it on
 
@@ -29,13 +30,23 @@
 
 4. Restart `pnpm dev`. A **Sign in** button appears once `configured` is true.
 
+## Smoke test (the #9 acceptance)
+
+1. Set the env vars above, restart `pnpm dev` → the **Sign in** button appears (proves `configured`).
+2. Click it → the system browser opens Logto → authenticate → it redirects to `neeme://callback`.
+3. The app catches the callback, exchanges the code (PKCE), **verifies the id_token against JWKS**,
+   and the header shows your name/email.
+4. Restart `pnpm dev` → the session restores silently (refresh token, no re-login).
+5. Click the identity pill → **Sign out**; the header returns to **Sign in** and the bearer clears.
+
 ## Caveats
 
 - **Custom-scheme deep link (`neeme://`)** registers reliably in a **packaged** build. In `pnpm dev`
   on macOS the `open-url` event usually still fires; on Windows/Linux deep links rely on the
   single-instance lock + argv parsing (already wired). If dev redirects don't return, test in a
   packaged build or switch the redirect to a loopback (`http://127.0.0.1:<port>/callback`).
-- The `id_token` is decoded for display claims only (not signature-verified client-side). The
-  **backend** is the trust boundary: it verifies the access token against Logto's **JWKS**. Harden
-  with a JWKS check or `openid-client` if this graduates past a scaffold.
+- The `id_token` **is** signature-verified client-side now (`auth/oidc.ts` `verifyIdToken`: JWKS
+  signature + `iss`/`aud`/`exp` + the `nonce` bound on the authorize request). The **access token**
+  stays opaque to the client — the **backend** remains its trust boundary (verify against Logto's
+  JWKS), still deferred until the sync backend lands.
 - Backend `user_id` data-scoping (items/todos are currently global) is separate work — see ADR 0002.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,6 +68,9 @@ importers:
       heic-convert:
         specifier: ^2.1.0
         version: 2.1.0
+      jose:
+        specifier: ^6.2.3
+        version: 6.2.3
       tesseract.js:
         specifier: ^7.0.0
         version: 7.0.0
@@ -123,6 +126,9 @@ importers:
       vite:
         specifier: ^7.2.6
         version: 7.3.3(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.3)
+      vitest:
+        specifier: ^4.1.8
+        version: 4.1.8(@types/node@24.12.4)(vite@7.3.3(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.3))
 
   packages/contract:
     devDependencies:
@@ -1289,6 +1295,9 @@ packages:
     resolution: {integrity: sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==}
     engines: {node: '>=10'}
 
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
   '@szmarczak/http-timer@4.0.6':
     resolution: {integrity: sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==}
     engines: {node: '>=10'}
@@ -1431,8 +1440,14 @@ packages:
   '@types/cacheable-request@6.0.3':
     resolution: {integrity: sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==}
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
   '@types/debug@4.1.13':
     resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
@@ -1549,6 +1564,35 @@ packages:
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
 
+  '@vitest/expect@4.1.8':
+    resolution: {integrity: sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==}
+
+  '@vitest/mocker@4.1.8':
+    resolution: {integrity: sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.8':
+    resolution: {integrity: sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==}
+
+  '@vitest/runner@4.1.8':
+    resolution: {integrity: sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg==}
+
+  '@vitest/snapshot@4.1.8':
+    resolution: {integrity: sha512-acfZboRmAIf05DEKcBQy33VXojFJjtUdLyo7oOmV9kebb2xdU01UknNiPuPZoJZQyO7DF0gZdTGTpeAzET9QPQ==}
+
+  '@vitest/spy@4.1.8':
+    resolution: {integrity: sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA==}
+
+  '@vitest/utils@4.1.8':
+    resolution: {integrity: sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==}
+
   '@xmldom/xmldom@0.8.13':
     resolution: {integrity: sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==}
     engines: {node: '>=10.0.0'}
@@ -1647,6 +1691,10 @@ packages:
   assert-plus@1.0.0:
     resolution: {integrity: sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==}
     engines: {node: '>=0.8'}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
 
   astral-regex@2.0.0:
     resolution: {integrity: sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==}
@@ -1782,6 +1830,10 @@ packages:
 
   caseless@0.12.0:
     resolution: {integrity: sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
 
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
@@ -2164,6 +2216,9 @@ packages:
     resolution: {integrity: sha512-HVLACW1TppGYjJ8H6/jqH/pqOtKRw6wMlrB23xfExmFWxFquAIWCmwoLsOyN96K4a5KbmOf5At9ZUO3GZbetAw==}
     engines: {node: '>= 0.4'}
 
+  es-module-lexer@2.1.0:
+    resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
+
   es-object-atoms@1.1.2:
     resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
     engines: {node: '>= 0.4'}
@@ -2285,6 +2340,9 @@ packages:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
@@ -2292,6 +2350,10 @@ packages:
   expand-template@2.0.3:
     resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
     engines: {node: '>=6'}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   exponential-backoff@3.1.3:
     resolution: {integrity: sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==}
@@ -2758,6 +2820,9 @@ packages:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
     hasBin: true
 
+  jose@6.2.3:
+    resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
+
   jpeg-js@0.4.4:
     resolution: {integrity: sha512-WZzeDOEtTOBK4Mdsar0IqEU5sMr3vSV2RqkAIzUEV2BHnUfKGyswWFPFwK5EeDo93K3FohSHbLAjj0s1Wzd+dg==}
 
@@ -3078,6 +3143,9 @@ packages:
   object.values@1.2.1:
     resolution: {integrity: sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==}
     engines: {node: '>= 0.4'}
+
+  obug@2.1.1:
+    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
 
   ohash@2.0.11:
     resolution: {integrity: sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==}
@@ -3455,6 +3523,9 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
@@ -3490,9 +3561,15 @@ packages:
   sprintf-js@1.1.3:
     resolution: {integrity: sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
   stat-mode@1.0.0:
     resolution: {integrity: sha512-jH9EhtKIjuXZ2cWxmXS8ZP80XyC3iasQxMDV8jzhNJpfDb7VbQLVW4Wvsxz9QZvzV+G4YoSfBUVKDOyxLzi/sg==}
     engines: {node: '>= 6'}
+
+  std-env@4.1.0:
+    resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
@@ -3589,9 +3666,20 @@ packages:
   tiny-typed-emitter@2.1.0:
     resolution: {integrity: sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.2.4:
+    resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
+    engines: {node: '>=18'}
+
   tinyglobby@0.2.17:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
 
   tmp-promise@3.0.3:
     resolution: {integrity: sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ==}
@@ -3756,6 +3844,47 @@ packages:
       yaml:
         optional: true
 
+  vitest@4.1.8:
+    resolution: {integrity: sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.8
+      '@vitest/browser-preview': 4.1.8
+      '@vitest/browser-webdriverio': 4.1.8
+      '@vitest/coverage-istanbul': 4.1.8
+      '@vitest/coverage-v8': 4.1.8
+      '@vitest/ui': 4.1.8
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   wasm-feature-detect@1.8.0:
     resolution: {integrity: sha512-zksaLKM2fVlnB5jQQDqKXXwYHLQUVH9es+5TOOHwGOVJOCeRBCiPjwSg+3tN2AdTCzjgli4jijCH290kXb/zWQ==}
 
@@ -3794,6 +3923,11 @@ packages:
   which@6.0.1:
     resolution: {integrity: sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==}
     engines: {node: ^20.17.0 || >=22.9.0}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   word-wrap@1.2.5:
@@ -4803,6 +4937,8 @@ snapshots:
 
   '@sindresorhus/is@4.6.0': {}
 
+  '@standard-schema/spec@1.1.0': {}
+
   '@szmarczak/http-timer@4.0.6':
     dependencies:
       defer-to-connect: 2.0.1
@@ -4926,9 +5062,16 @@ snapshots:
       '@types/node': 24.12.4
       '@types/responselike': 1.0.3
 
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
   '@types/debug@4.1.13':
     dependencies:
       '@types/ms': 2.1.0
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/estree@1.0.8': {}
 
@@ -5087,6 +5230,47 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@vitest/expect@4.1.8':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.8
+      '@vitest/utils': 4.1.8
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.8(vite@7.3.3(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.3))':
+    dependencies:
+      '@vitest/spy': 4.1.8
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.3(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.3)
+
+  '@vitest/pretty-format@4.1.8':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.8':
+    dependencies:
+      '@vitest/utils': 4.1.8
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.8':
+    dependencies:
+      '@vitest/pretty-format': 4.1.8
+      '@vitest/utils': 4.1.8
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.8': {}
+
+  '@vitest/utils@4.1.8':
+    dependencies:
+      '@vitest/pretty-format': 4.1.8
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
+
   '@xmldom/xmldom@0.8.13': {}
 
   '@xmldom/xmldom@0.9.10': {}
@@ -5234,6 +5418,8 @@ snapshots:
 
   assert-plus@1.0.0:
     optional: true
+
+  assertion-error@2.0.1: {}
 
   astral-regex@2.0.0:
     optional: true
@@ -5396,6 +5582,8 @@ snapshots:
   caniuse-lite@1.0.30001793: {}
 
   caseless@0.12.0: {}
+
+  chai@6.2.2: {}
 
   chalk@4.1.2:
     dependencies:
@@ -5799,6 +5987,8 @@ snapshots:
       iterator.prototype: 1.1.5
       math-intrinsics: 1.1.0
 
+  es-module-lexer@2.1.0: {}
+
   es-object-atoms@1.1.2:
     dependencies:
       es-errors: 1.3.0
@@ -6031,10 +6221,16 @@ snapshots:
 
   estraverse@5.3.0: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
   esutils@2.0.3: {}
 
   expand-template@2.0.3:
     optional: true
+
+  expect-type@1.3.0: {}
 
   exponential-backoff@3.1.3: {}
 
@@ -6531,6 +6727,8 @@ snapshots:
 
   jiti@2.7.0: {}
 
+  jose@6.2.3: {}
+
   jpeg-js@0.4.4: {}
 
   js-base64@3.7.8: {}
@@ -6820,6 +7018,8 @@ snapshots:
       call-bound: 1.0.4
       define-properties: 1.2.1
       es-object-atoms: 1.1.2
+
+  obug@2.1.1: {}
 
   ohash@2.0.11: {}
 
@@ -7289,6 +7489,8 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
   signal-exit@3.0.7: {}
 
   simple-concat@1.0.1:
@@ -7326,7 +7528,11 @@ snapshots:
 
   sprintf-js@1.1.3: {}
 
+  stackback@0.0.2: {}
+
   stat-mode@1.0.0: {}
+
+  std-env@4.1.0: {}
 
   stop-iteration-iterator@1.1.0:
     dependencies:
@@ -7473,10 +7679,16 @@ snapshots:
 
   tiny-typed-emitter@2.1.0: {}
 
+  tinybench@2.9.0: {}
+
+  tinyexec@1.2.4: {}
+
   tinyglobby@0.2.17:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
+
+  tinyrainbow@3.1.0: {}
 
   tmp-promise@3.0.3:
     dependencies:
@@ -7627,6 +7839,33 @@ snapshots:
       lightningcss: 1.32.0
       tsx: 4.22.3
 
+  vitest@4.1.8(@types/node@24.12.4)(vite@7.3.3(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.3)):
+    dependencies:
+      '@vitest/expect': 4.1.8
+      '@vitest/mocker': 4.1.8(vite@7.3.3(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.3))
+      '@vitest/pretty-format': 4.1.8
+      '@vitest/runner': 4.1.8
+      '@vitest/snapshot': 4.1.8
+      '@vitest/spy': 4.1.8
+      '@vitest/utils': 4.1.8
+      es-module-lexer: 2.1.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.0
+      vite: 7.3.3(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.3)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 24.12.4
+    transitivePeerDependencies:
+      - msw
+
   wasm-feature-detect@1.8.0: {}
 
   webidl-conversions@3.0.1: {}
@@ -7688,6 +7927,11 @@ snapshots:
   which@6.0.1:
     dependencies:
       isexe: 4.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   word-wrap@1.2.5: {}
 


### PR DESCRIPTION
## What

Closes the code side of **ROADMAP #9** — Logto login wired end-to-end. The OIDC+PKCE flow already existed but had **no UI surface** and **didn't verify the id_token**. This PR:

- **Sign in/out UI** — new `AuthControl` in the header (`Sign in` → identity pill → `Sign out`), hidden until `configured`. `useAuth` now guards on `isElectron` so the browser preview no longer crashes on `window.api.auth`.
- **JWKS hardening** — new `auth/oidc.ts` (pure, electron-free) with `verifyIdToken`: JWKS signature + `iss`/`aud`/`exp`, plus a **nonce** bound on the authorize request and checked on the exchange. Replaces the old naive base64 decode of the id_token.
- **Tests** — 14 Tier-A vitest cases for `oidc.ts` (PKCE, authorize URL, claims, and verify accept/reject across tampered-sig / wrong-iss / wrong-aud / expired / nonce-mismatch). Adds `jose`.
- **Docs** — `docs/auth-logto-setup.md`: corrected the UI claim + JWKS caveat, added an Option A (dev) / Option B (packaged) login test plan, and a "Two OAuth flows" section.

## Out of scope (deferred per ADR 0002)

Access-token JWKS verification and `user_id` data-scoping — there's no sync backend yet; the desktop only forwards the bearer. Stated explicitly so the code/docs stay honest.

## Coordination with #8 (Gmail/Calendar connectors)

The connectors agent shares this lane. Boundary is documented in `docs/agent-sync/INBOX.md` and `docs/auth-logto-setup.md` § "Two OAuth flows":
- The pure PKCE primitives in `auth/oidc.ts` (`base64url`, `randomVerifier`, `randomState`, `pkceChallenge`) are **provider-agnostic** — #8's standalone Google client reuses them (stays decoupled from Logto). `verifyIdToken`/`claimsFromPayload` are login-only.
- Redirect transports stay separate: login owns the `neeme://` custom scheme; connectors use a loopback HTTP listener.
- **Merge this first** so #8 can rebase and reuse `oidc.ts` rather than re-rolling crypto.

## Verification

- `pnpm typecheck` ✓ · `pnpm build` ✓ (jose externalized) · `pnpm --filter @nimi/desktop test` ✓ **166 passed** · lint of changed files clean (pre-existing debt in `pipeline/asr.ts`/`ocr.ts`/`api/generated/**` untouched).
- **No Electron in CI** → live login smoke test is manual (see `docs/auth-logto-setup.md`): set `MAIN_VITE_LOGTO_*` in `apps/desktop/.env`, `pnpm dev`, click **Sign in** → Logto → identity shows; session persists across restart; sign out clears it. **This gates the merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authentication and token verification in the main process; mistakes could break login or trust the wrong claims, though behavior is covered by unit tests and access-token/backend verification stays deferred.
> 
> **Overview**
> Closes the **code** side of ROADMAP #9: header **Sign in / identity / Sign out** via `AuthControl`, plus **cryptographic trust** for display identity instead of decoding the `id_token` without verification.
> 
> **Login hardening:** PKCE/authorize URL logic moves into testable `auth/oidc.ts`. The authorize step now sends a **nonce**; after the code exchange, `logto.ts` verifies the `id_token` with **Logto JWKS** (`jose`) for signature, `iss`/`aud`/`exp`, and nonce binding. Refresh grants skip nonce when no `id_token` is expected.
> 
> **UI / preview:** `useAuth` no-ops outside Electron so the Vite browser preview does not touch `window.api.auth`. The Today header mounts `AuthControl`, hidden until Logto env vars are set.
> 
> **Tests & docs:** Offline vitest coverage for `oidc.ts`; setup doc adds dev vs packaged login steps and separates **login (`neeme://`)** from future **connector loopback OAuth**. Live tenant login remains the manual merge gate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9fc105b4dd68e2a0fa687c37affbbb09ba07b71. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->