### PR TITLE
feat(connectors): Gmail + Calendar ingest pipeline (ROADMAP #8)

### DIFF
--- a/apps/desktop/src/main/connectors/google-auth.ts
+++ b/apps/desktop/src/main/connectors/google-auth.ts
@@ -1,0 +1,327 @@
+/**
+ * Standalone Google OAuth client for the nimi connectors (Gmail + Google Calendar).
+ *
+ * Architecture:
+ *   - Decoupled from Logto (ADR 0002): Logto authenticates *who the user is* to nimi;
+ *     this module grants nimi *read access to the user's Google data* — separate concern,
+ *     separate client, separate tokens.
+ *   - Inert until `MAIN_VITE_GOOGLE_CLIENT_ID` is set.
+ *   - Redirect: Google Desktop-app OAuth clients reject custom schemes, so we use a
+ *     **loopback redirect** (`http://127.0.0.1:<port>`). An ephemeral `http.createServer`
+ *     runs only during the flow (listening for the `?code` callback), then closes.
+ *   - Tokens: refresh token sealed in OS keychain via `safeStorage` (`neeme-connectors.bin`).
+ *     Access tokens (short-lived) stay in memory only.
+ *   - PKCE helpers reused from `../auth/oidc.ts` (provider-agnostic; see PR #35 notes).
+ *
+ * Env knobs (MAIN_VITE_* are baked by electron-vite; NEEME_* are runtime process.env):
+ *   MAIN_VITE_GOOGLE_CLIENT_ID      — required; Desktop OAuth client id
+ *   MAIN_VITE_GOOGLE_CLIENT_SECRET  — required; Desktop OAuth client secret (non-confidential)
+ *   MAIN_VITE_GOOGLE_SCOPES         — optional scope override (default: gmail.readonly + calendar.readonly)
+ *
+ * Note on `access_type=offline`: required to receive a refresh_token on first consent.
+ * Combined with `prompt=consent`, this reliably re-issues the refresh token even for
+ * previously-authorized clients, which matters for developer iteration.
+ */
+import { app, safeStorage, shell } from 'electron'
+import { createServer } from 'node:http'
+import { readFile, writeFile, rm } from 'node:fs/promises'
+import { join } from 'node:path'
+import { randomVerifier, pkceChallenge, randomState } from '../auth/oidc'
+import type { ConnectorId, ConnectorsState, ProviderState } from '@nimi/contract/ipc'
+
+const GOOGLE_AUTH_URL = 'https://accounts.google.com/o/oauth2/v2/auth'
+const GOOGLE_TOKEN_URL = 'https://oauth2.googleapis.com/token'
+const DEFAULT_SCOPES = [
+  'openid',
+  'email',
+  'profile',
+  'https://www.googleapis.com/auth/gmail.readonly',
+  'https://www.googleapis.com/auth/calendar.readonly'
+].join(' ')
+
+interface TokenResponse {
+  access_token: string
+  refresh_token?: string
+  expires_in?: number
+  token_type?: string
+}
+
+interface ProviderSession {
+  accessToken: string
+  refreshToken: string
+  expiresAt: number // epoch ms
+}
+
+// In-memory sessions — only access tokens; refresh tokens persist via safeStorage.
+const sessions = new Map<ConnectorId, ProviderSession>()
+
+// Pending PKCE flow state (one at a time per provider).
+let pending: { provider: ConnectorId; verifier: string; state: string; port: number } | null = null
+
+export function isConfigured(): boolean {
+  return Boolean(
+    import.meta.env.MAIN_VITE_GOOGLE_CLIENT_ID && import.meta.env.MAIN_VITE_GOOGLE_CLIENT_SECRET
+  )
+}
+
+function clientId(): string {
+  return import.meta.env.MAIN_VITE_GOOGLE_CLIENT_ID ?? ''
+}
+function clientSecret(): string {
+  return import.meta.env.MAIN_VITE_GOOGLE_CLIENT_SECRET ?? ''
+}
+function scopes(): string {
+  return import.meta.env.MAIN_VITE_GOOGLE_SCOPES ?? DEFAULT_SCOPES
+}
+
+// ── Persistence (refresh tokens only) ──────────────────────────────────────
+
+function sessionsFile(): string {
+  return join(app.getPath('userData'), 'neeme-connectors.bin')
+}
+
+interface PersistedData {
+  gmail?: { refreshToken: string }
+  gcal?: { refreshToken: string }
+}
+
+async function loadPersisted(): Promise<PersistedData> {
+  try {
+    const blob = await readFile(sessionsFile())
+    const plain = safeStorage.isEncryptionAvailable()
+      ? safeStorage.decryptString(blob)
+      : blob.toString('utf8')
+    return JSON.parse(plain) as PersistedData
+  } catch {
+    return {}
+  }
+}
+
+async function savePersisted(): Promise<void> {
+  const data: PersistedData = {}
+  const gmailSession = sessions.get('gmail')
+  const gcalSession = sessions.get('gcal')
+  if (gmailSession) data.gmail = { refreshToken: gmailSession.refreshToken }
+  if (gcalSession) data.gcal = { refreshToken: gcalSession.refreshToken }
+  if (!data.gmail && !data.gcal) {
+    await rm(sessionsFile(), { force: true }).catch(() => {})
+    return
+  }
+  const plain = JSON.stringify(data)
+  const blob = safeStorage.isEncryptionAvailable()
+    ? safeStorage.encryptString(plain)
+    : Buffer.from(plain, 'utf8')
+  await writeFile(sessionsFile(), blob)
+}
+
+// ── Token exchange + refresh ────────────────────────────────────────────────
+
+async function exchangeCode(
+  code: string,
+  redirectUri: string,
+  verifier: string
+): Promise<TokenResponse> {
+  const body = new URLSearchParams({
+    code,
+    client_id: clientId(),
+    client_secret: clientSecret(),
+    redirect_uri: redirectUri,
+    grant_type: 'authorization_code',
+    code_verifier: verifier
+  })
+  const res = await fetch(GOOGLE_TOKEN_URL, {
+    method: 'POST',
+    headers: { 'content-type': 'application/x-www-form-urlencoded' },
+    body
+  })
+  if (!res.ok) throw new Error(`Google token exchange failed (HTTP ${res.status})`)
+  return res.json() as Promise<TokenResponse>
+}
+
+async function refreshAccessToken(provider: ConnectorId, refreshToken: string): Promise<string> {
+  const body = new URLSearchParams({
+    refresh_token: refreshToken,
+    client_id: clientId(),
+    client_secret: clientSecret(),
+    grant_type: 'refresh_token'
+  })
+  const res = await fetch(GOOGLE_TOKEN_URL, {
+    method: 'POST',
+    headers: { 'content-type': 'application/x-www-form-urlencoded' },
+    body
+  })
+  if (!res.ok) throw new Error(`Google token refresh failed (HTTP ${res.status})`)
+  const t = (await res.json()) as TokenResponse
+  const session = sessions.get(provider)
+  if (session) {
+    session.accessToken = t.access_token
+    session.expiresAt = Date.now() + (t.expires_in ?? 3600) * 1000
+    if (t.refresh_token) session.refreshToken = t.refresh_token
+    await savePersisted()
+  }
+  return t.access_token
+}
+
+// ── Public API ─────────────────────────────────────────────────────────────
+
+/**
+ * Restore persisted sessions on startup (silent refresh).
+ * Called once from main/index.ts after `startWorker()`.
+ */
+export async function init(): Promise<void> {
+  if (!isConfigured()) return
+  const data = await loadPersisted()
+  const providers: ConnectorId[] = ['gmail', 'gcal']
+  for (const provider of providers) {
+    const saved = data[provider]
+    if (!saved?.refreshToken) continue
+    try {
+      const accessToken = await refreshAccessToken(provider, saved.refreshToken)
+      sessions.set(provider, {
+        accessToken,
+        refreshToken: saved.refreshToken,
+        expiresAt: Date.now() + 3600 * 1000
+      })
+      console.log(`[connectors] restored ${provider} session`)
+    } catch (err) {
+      console.warn(`[connectors] ${provider} refresh failed on startup — disconnected`, err)
+    }
+  }
+}
+
+/**
+ * Return a valid access token for the given provider, refreshing if near expiry.
+ * Returns undefined if not connected.
+ */
+export async function getAccessToken(provider: ConnectorId): Promise<string | undefined> {
+  const session = sessions.get(provider)
+  if (!session) return undefined
+  if (Date.now() < session.expiresAt - 60_000) return session.accessToken
+  try {
+    return await refreshAccessToken(provider, session.refreshToken)
+  } catch {
+    sessions.delete(provider)
+    await savePersisted()
+    return undefined
+  }
+}
+
+/**
+ * Start the OAuth PKCE flow for a provider: open the system browser to Google's
+ * authorize URL, then listen on a random loopback port for the `?code` callback.
+ * Resolves once tokens are stored (or rejects on error/timeout).
+ */
+export async function connect(provider: ConnectorId): Promise<void> {
+  if (!isConfigured()) throw new Error('Google OAuth is not configured (set MAIN_VITE_GOOGLE_CLIENT_ID + _SECRET in .env)')
+
+  return new Promise<void>((resolve, reject) => {
+    // Spin up an ephemeral loopback server on a random OS-assigned port.
+    const server = createServer((req, res) => {
+      if (!req.url?.startsWith('/?')) {
+        res.writeHead(400)
+        res.end('Bad request')
+        return
+      }
+      const params = new URL(req.url, 'http://127.0.0.1').searchParams
+      const code = params.get('code')
+      const stateParam = params.get('state')
+      const error = params.get('error')
+
+      res.writeHead(200, { 'content-type': 'text/html' })
+      res.end(
+        '<html><head><meta charset="utf-8"></head><body><h2>Connected to nimi &#8212; you can close this tab.</h2></body></html>'
+      )
+      server.close()
+
+      if (!pending || stateParam !== pending.state || pending.provider !== provider) {
+        reject(new Error('OAuth callback: state mismatch or no pending flow'))
+        return
+      }
+      if (error) {
+        reject(new Error(`Google OAuth error: ${error}`))
+        return
+      }
+      if (!code) {
+        reject(new Error('Google OAuth callback: missing code'))
+        return
+      }
+
+      const { verifier, port } = pending
+      pending = null
+      const redirectUri = `http://127.0.0.1:${port}`
+
+      exchangeCode(code, redirectUri, verifier)
+        .then((t) => {
+          if (!t.refresh_token) {
+            throw new Error('Google did not return a refresh_token — ensure access_type=offline and prompt=consent')
+          }
+          sessions.set(provider, {
+            accessToken: t.access_token,
+            refreshToken: t.refresh_token,
+            expiresAt: Date.now() + (t.expires_in ?? 3600) * 1000
+          })
+          return savePersisted()
+        })
+        .then(resolve)
+        .catch(reject)
+    })
+
+    server.listen(0, '127.0.0.1', () => {
+      const addr = server.address()
+      if (!addr || typeof addr === 'string') {
+        server.close()
+        reject(new Error('Failed to bind loopback server'))
+        return
+      }
+      const port = addr.port
+      const verifier = randomVerifier()
+      const challenge = pkceChallenge(verifier)
+      const state = randomState()
+      const redirectUri = `http://127.0.0.1:${port}`
+
+      pending = { provider, verifier, state, port }
+
+      const url = new URL(GOOGLE_AUTH_URL)
+      url.searchParams.set('client_id', clientId())
+      url.searchParams.set('redirect_uri', redirectUri)
+      url.searchParams.set('response_type', 'code')
+      url.searchParams.set('scope', scopes())
+      url.searchParams.set('code_challenge', challenge)
+      url.searchParams.set('code_challenge_method', 'S256')
+      url.searchParams.set('state', state)
+      url.searchParams.set('access_type', 'offline')
+      url.searchParams.set('prompt', 'consent')
+
+      shell.openExternal(url.toString()).catch(reject)
+    })
+
+    // Timeout after 5 minutes if the user doesn't complete the flow.
+    setTimeout(() => {
+      if (pending?.provider === provider) {
+        pending = null
+        server.close()
+        reject(new Error('Google OAuth flow timed out (5 min)'))
+      }
+    }, 5 * 60 * 1000)
+  })
+}
+
+/** Revoke the session and clear persisted tokens for a provider. */
+export async function disconnect(provider: ConnectorId): Promise<void> {
+  sessions.delete(provider)
+  await savePersisted()
+}
+
+/** Snapshot of connector state for all providers. */
+export function getState(): Pick<ConnectorsState, 'configured' | 'gmail' | 'gcal'> {
+  const providerState = (id: ConnectorId): ProviderState => ({
+    connected: sessions.has(id),
+    lastSyncAt: null, // filled in by main/index.ts from worker DB state
+    itemCount: 0
+  })
+  return {
+    configured: isConfigured(),
+    gmail: providerState('gmail'),
+    gcal: providerState('gcal')
+  }
+}

--- a/apps/desktop/src/main/connectors/normalizers.ts
+++ b/apps/desktop/src/main/connectors/normalizers.ts
@@ -1,0 +1,113 @@
+/**
+ * Pure normalization helpers for Gmail messages and Google Calendar events.
+ * Extracted here so they can be unit-tested without a DB or network.
+ * Imported by connector-service.ts.
+ */
+
+// ── Gmail ───────────────────────────────────────────────────────────────────
+
+export interface GmailMessage {
+  id: string
+  threadId?: string
+  payload?: GmailPayload
+  snippet?: string
+  internalDate?: string
+}
+
+export interface GmailPayload {
+  mimeType?: string
+  headers?: Array<{ name: string; value: string }>
+  body?: { data?: string }
+  parts?: GmailPayload[]
+}
+
+/** Extract the best plain-text body from a Gmail message payload (recursive). */
+export function extractGmailText(payload: GmailPayload): string {
+  if (payload.mimeType === 'text/plain' && payload.body?.data) {
+    return Buffer.from(payload.body.data, 'base64url').toString('utf8')
+  }
+  if (payload.parts) {
+    // Prefer text/plain, fall back to text/html → strip tags.
+    const plain = payload.parts.find((p) => p.mimeType === 'text/plain')
+    if (plain) return extractGmailText(plain)
+    const html = payload.parts.find((p) => p.mimeType === 'text/html')
+    if (html) return extractGmailText(html)
+    // Recurse into multipart containers.
+    for (const part of payload.parts) {
+      const text = extractGmailText(part)
+      if (text) return text
+    }
+  }
+  if (payload.mimeType === 'text/html' && payload.body?.data) {
+    const html = Buffer.from(payload.body.data, 'base64url').toString('utf8')
+    return html.replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim()
+  }
+  return ''
+}
+
+export function gmailHeader(payload: GmailPayload, name: string): string {
+  return payload.headers?.find((h) => h.name.toLowerCase() === name.toLowerCase())?.value ?? ''
+}
+
+/** Compose a human-readable title for a Gmail message. */
+export function gmailTitle(msg: GmailMessage): string {
+  if (!msg.payload) return `Gmail message ${msg.id}`
+  const subject = gmailHeader(msg.payload, 'Subject') || '(no subject)'
+  const from = gmailHeader(msg.payload, 'From') || ''
+  return from ? `${subject} — from ${from}` : subject
+}
+
+/** Build the full text representation of a Gmail message. */
+export function gmailToText(msg: GmailMessage): string {
+  if (!msg.payload) return msg.snippet ?? ''
+  const subject = gmailHeader(msg.payload, 'Subject')
+  const from = gmailHeader(msg.payload, 'From')
+  const to = gmailHeader(msg.payload, 'To')
+  const date = gmailHeader(msg.payload, 'Date')
+  const body = extractGmailText(msg.payload) || msg.snippet || ''
+  return [subject && `Subject: ${subject}`, from && `From: ${from}`, to && `To: ${to}`, date && `Date: ${date}`, '', body]
+    .filter((l) => l !== undefined)
+    .join('\n')
+    .trim()
+}
+
+// ── Calendar ─────────────────────────────────────────────────────────────────
+
+export interface CalendarEvent {
+  id: string
+  summary?: string
+  description?: string
+  location?: string
+  start?: { dateTime?: string; date?: string }
+  end?: { dateTime?: string; date?: string }
+  organizer?: { email?: string; displayName?: string }
+  attendees?: Array<{ email?: string; displayName?: string; responseStatus?: string }>
+  htmlLink?: string
+  status?: string
+}
+
+/** Build a plain-text representation of a Calendar event. */
+export function calendarToText(event: CalendarEvent): string {
+  const lines: string[] = []
+  if (event.summary) lines.push(`Event: ${event.summary}`)
+  const start = event.start?.dateTime ?? event.start?.date ?? ''
+  const end = event.end?.dateTime ?? event.end?.date ?? ''
+  if (start) lines.push(`Start: ${start}`)
+  if (end) lines.push(`End: ${end}`)
+  if (event.location) lines.push(`Location: ${event.location}`)
+  if (event.organizer?.displayName || event.organizer?.email) {
+    lines.push(`Organizer: ${event.organizer.displayName ?? event.organizer.email}`)
+  }
+  if (event.attendees?.length) {
+    const names = event.attendees
+      .map((a) => a.displayName ?? a.email ?? '')
+      .filter(Boolean)
+      .slice(0, 10)
+      .join(', ')
+    lines.push(`Attendees: ${names}`)
+  }
+  if (event.description) {
+    lines.push('', event.description.replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim())
+  }
+  return lines.join('\n').trim()
+}

--- a/apps/desktop/src/main/db/index.ts
+++ b/apps/desktop/src/main/db/index.ts
@@ -100,9 +100,28 @@ export async function initDb(): Promise<void> {
     );
   `)
 
+  // connector_state: tracks per-provider sync cursors (Gmail historyId / Calendar syncToken).
+  await client.execute(`
+    CREATE TABLE IF NOT EXISTS connector_state (
+      provider TEXT PRIMARY KEY,
+      cursor TEXT,
+      item_count INTEGER NOT NULL DEFAULT 0,
+      last_sync_at INTEGER
+    )
+  `)
+
   // Additive migrations: add columns that may not exist on older DBs.
   // Each is guarded so it's a no-op if the column already exists.
   await addColumnIfMissing('todo_context', 'why', 'TEXT')
+  // Connector provenance on items (additive, null for manual captures).
+  await addColumnIfMissing('items', 'connector', 'TEXT')
+  await addColumnIfMissing('items', 'external_id', 'TEXT')
+  await addColumnIfMissing('items', 'uri', 'TEXT')
+  // Unique index on external_id — SQLite allows multiple NULLs in a unique index
+  // so existing manual items are unaffected.
+  await client.execute(
+    `CREATE UNIQUE INDEX IF NOT EXISTS items_external_id_idx ON items (external_id) WHERE external_id IS NOT NULL`
+  )
 }
 
 /** Add a column to an existing table only if it doesn't already exist. */

--- a/apps/desktop/src/main/db/schema.ts
+++ b/apps/desktop/src/main/db/schema.ts
@@ -1,5 +1,5 @@
 import { sql } from 'drizzle-orm'
-import { sqliteTable, text, integer, real } from 'drizzle-orm/sqlite-core'
+import { sqliteTable, text, integer, real, uniqueIndex } from 'drizzle-orm/sqlite-core'
 
 /**
  * `memories` — the atomic unit of neeme's local store.
@@ -28,22 +28,49 @@ export type NewMemory = typeof memories.$inferInsert
  * normalized `text`, and an extraction `status`. The vector index lives in a
  * separate `chunks` table (created in db/index.ts — it uses libSQL's native
  * F32_BLOB type, so it's managed via raw SQL rather than the Drizzle schema).
+ *
+ * Connector provenance: `connector` identifies the source (gmail, gcal, or null for
+ * manual captures); `externalId` is the provider's stable id for dedup across re-syncs;
+ * `uri` is an optional deep-link back to the original item.
  */
-export const items = sqliteTable('items', {
-  id: text('id').primaryKey(), // sha256 of the raw bytes
-  sourceName: text('source_name').notNull(),
-  contentType: text('content_type').notNull(), // text | pdf | image | audio | other
-  sizeBytes: integer('size_bytes').notNull(),
-  storedPath: text('stored_path'),
-  text: text('text').notNull().default(''),
-  status: text('status').notNull(), // captured | extracted | pending | failed
-  createdAt: integer('created_at', { mode: 'timestamp' })
-    .notNull()
-    .default(sql`(unixepoch())`)
-})
+export const items = sqliteTable(
+  'items',
+  {
+    id: text('id').primaryKey(), // sha256 of the raw bytes
+    sourceName: text('source_name').notNull(),
+    contentType: text('content_type').notNull(), // text | pdf | image | audio | other
+    sizeBytes: integer('size_bytes').notNull(),
+    storedPath: text('stored_path'),
+    text: text('text').notNull().default(''),
+    status: text('status').notNull(), // captured | extracted | pending | failed
+    // Connector provenance (null for manual captures)
+    connector: text('connector'), // gmail | gcal | null
+    externalId: text('external_id'), // provider's stable id (Gmail message id, Calendar event id)
+    uri: text('uri'), // optional deep-link to the original item
+    createdAt: integer('created_at', { mode: 'timestamp' })
+      .notNull()
+      .default(sql`(unixepoch())`)
+  },
+  (t) => [uniqueIndex('items_external_id_idx').on(t.externalId)]
+)
 
 export type Item = typeof items.$inferSelect
 export type NewItem = typeof items.$inferInsert
+
+/**
+ * `connector_state` — per-provider sync cursor and metadata. Tracks the
+ * Gmail historyId and Calendar syncToken so incremental syncs only fetch deltas.
+ * One row per provider; upserted on every successful sync.
+ */
+export const connectorState = sqliteTable('connector_state', {
+  provider: text('provider').primaryKey(), // gmail | gcal
+  cursor: text('cursor'), // Gmail historyId | Calendar syncToken (null = full re-sync needed)
+  itemCount: integer('item_count').notNull().default(0),
+  lastSyncAt: integer('last_sync_at', { mode: 'timestamp' })
+})
+
+export type ConnectorStateRow = typeof connectorState.$inferSelect
+export type NewConnectorStateRow = typeof connectorState.$inferInsert
 
 /**
  * `todos` — the daily focus list (cap 5). `day` is the ISO date the item lives

--- a/apps/desktop/src/main/env.d.ts
+++ b/apps/desktop/src/main/env.d.ts
@@ -12,4 +12,10 @@ interface ImportMetaEnv {
   readonly MAIN_VITE_LOGTO_APP_ID?: string
   /** Optional API resource indicator the access token should be scoped to. */
   readonly MAIN_VITE_LOGTO_RESOURCE?: string
+  /** Google Desktop-app OAuth client ID (for Gmail + Calendar connectors). */
+  readonly MAIN_VITE_GOOGLE_CLIENT_ID?: string
+  /** Google Desktop-app OAuth client secret (non-confidential in a native app). */
+  readonly MAIN_VITE_GOOGLE_CLIENT_SECRET?: string
+  /** Optional space-separated scope override for Google OAuth. */
+  readonly MAIN_VITE_GOOGLE_SCOPES?: string
 }

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -4,7 +4,9 @@ import { electronApp, optimizer } from '@electron-toolkit/utils'
 import { startWorker, call } from './worker/client'
 import { initTrayWindow, showWindow, setBadge } from './window/tray-window'
 import * as auth from './auth/logto'
+import * as googleAuth from './connectors/google-auth'
 import { IPC } from '@nimi/contract/ipc'
+import type { ConnectorId, ConnectorsState, IngestResult } from '@nimi/contract/ipc'
 
 // Register `neeme://` as the OAuth callback scheme. In dev (electron launched
 // with a script arg) we must pass execPath + the project dir so the OS routes
@@ -115,6 +117,85 @@ app.whenReady().then(async () => {
   ipcMain.handle(IPC.authLogout, () => auth.logout())
   ipcMain.handle(IPC.authGetToken, () => auth.getAccessToken())
   ipcMain.handle(IPC.authGetState, () => auth.getState())
+
+  // Connectors (Google OAuth + periodic ingest) — main-only, like auth.
+  // Inert until MAIN_VITE_GOOGLE_CLIENT_ID is set.
+  function broadcastConnectorsState(state: ConnectorsState): void {
+    for (const win of BrowserWindow.getAllWindows()) {
+      win.webContents.send(IPC.connectorsChanged, state)
+    }
+  }
+
+  /**
+   * Build the full ConnectorsState by merging googleAuth's in-memory OAuth
+   * connection status with the DB-persisted item counts + last-sync timestamps
+   * (fetched from the worker via connectorsGetStats).
+   */
+  async function buildConnectorsState(): Promise<ConnectorsState> {
+    const base = googleAuth.getState()
+    try {
+      const stats = await call<{
+        gmail: { itemCount: number; lastSyncAt: string | null }
+        gcal: { itemCount: number; lastSyncAt: string | null }
+      }>(IPC.connectorsGetStats, [])
+      base.gmail.itemCount = stats.gmail.itemCount
+      base.gmail.lastSyncAt = stats.gmail.lastSyncAt
+      base.gcal.itemCount = stats.gcal.itemCount
+      base.gcal.lastSyncAt = stats.gcal.lastSyncAt
+    } catch {
+      // DB stats unavailable — connected/configured status is still correct
+    }
+    return base as ConnectorsState
+  }
+
+  /**
+   * Run a sync for one provider: get a fresh token, call the worker, broadcast
+   * the updated state. Returns the IngestResult for syncNow IPC.
+   */
+  async function runSync(provider: ConnectorId): Promise<IngestResult> {
+    const accessToken = await googleAuth.getAccessToken(provider)
+    if (!accessToken) throw new Error(`${provider} is not connected`)
+    const result = await call<IngestResult>(IPC.connectorsIngest, [provider, accessToken])
+    // Broadcast updated state after sync (best-effort).
+    buildConnectorsState().then(broadcastConnectorsState).catch(() => {})
+    return result
+  }
+
+  // Restore persisted sessions silently on startup.
+  await googleAuth.init()
+
+  // IPC handlers — main-only (not forwarded to worker).
+  ipcMain.handle(IPC.connectorsGetState, () => buildConnectorsState())
+
+  ipcMain.handle(IPC.connectorsConnect, async (_e, provider: ConnectorId) => {
+    await googleAuth.connect(provider)
+    // Kick off an immediate first sync in the background so the feed populates.
+    runSync(provider).catch((err) => console.error(`[connectors] initial sync failed for ${provider}`, err))
+    broadcastConnectorsState(googleAuth.getState())
+  })
+
+  ipcMain.handle(IPC.connectorsDisconnect, async (_e, provider: ConnectorId) => {
+    await googleAuth.disconnect(provider)
+    broadcastConnectorsState(googleAuth.getState())
+  })
+
+  ipcMain.handle(IPC.connectorsSyncNow, async (_e, provider: ConnectorId) => {
+    return runSync(provider)
+  })
+
+  // Periodic background sync — every NEEME_CONNECTOR_SYNC_MINUTES (default 15).
+  const syncMinutes = Math.max(1, parseInt(process.env.NEEME_CONNECTOR_SYNC_MINUTES ?? '15', 10))
+  const syncInterval = setInterval(() => {
+    const providers: ConnectorId[] = ['gmail', 'gcal']
+    for (const provider of providers) {
+      if (!googleAuth.getState()[provider].connected) continue
+      runSync(provider).catch((err) =>
+        console.error(`[connectors] background sync failed for ${provider}`, err)
+      )
+    }
+  }, syncMinutes * 60 * 1000)
+  // Ensure the interval doesn't keep the process alive after quit.
+  syncInterval.unref()
 
   // UI-only: renderer pushes the "waiting" count → tray + Dock badge.
   ipcMain.handle(IPC.traySetBadge, (_e, count: number) => setBadge(count))

--- a/apps/desktop/src/main/services/connector-service.ts
+++ b/apps/desktop/src/main/services/connector-service.ts
@@ -1,0 +1,193 @@
+/**
+ * Connector sync engine — runs in the utilityProcess worker.
+ *
+ * Given `{ provider, accessToken }` (main passes a fresh token via IPC), this
+ * service fetches delta messages/events from the Google APIs, normalises each to
+ * plain text, calls `pipelineService.captureExternal`, and persists the new
+ * sync cursor. Returns `{ ingested, lastSyncAt }` for main to broadcast.
+ *
+ * API docs:
+ *   Gmail:    https://developers.google.com/gmail/api/reference/rest
+ *   Calendar: https://developers.google.com/calendar/api/v3/reference/events/list
+ *
+ * Sync strategy:
+ *   Gmail:    historyId cursor (incremental via users.history.list). On first run
+ *             or expired cursor → full inbox list (INBOX, newest 200).
+ *   Calendar: syncToken cursor (incremental via events.list?syncToken=…). On first
+ *             run or expired token (HTTP 410) → full events list.
+ */
+import { pipelineService, type ExternalProvenance } from './pipeline-service'
+import type { ConnectorId, IngestResult } from '@nimi/contract/ipc'
+import {
+  gmailToText,
+  gmailTitle,
+  calendarToText,
+  type GmailMessage,
+  type CalendarEvent
+} from '../connectors/normalizers'
+
+const GMAIL_BASE = 'https://gmail.googleapis.com/gmail/v1/users/me'
+const CALENDAR_BASE = 'https://www.googleapis.com/calendar/v3/calendars/primary'
+
+// ── Google API fetch helper ─────────────────────────────────────────────────
+
+async function gFetch<T>(url: string, accessToken: string): Promise<T> {
+  const res = await fetch(url, {
+    headers: { Authorization: `Bearer ${accessToken}` }
+  })
+  if (!res.ok) {
+    const body = await res.text().catch(() => '')
+    const err = new Error(`Google API error ${res.status}: ${body.slice(0, 200)}`) as Error & { status: number }
+    err.status = res.status
+    throw err
+  }
+  return res.json() as Promise<T>
+}
+
+// ── Gmail sync ──────────────────────────────────────────────────────────────
+
+async function syncGmail(accessToken: string): Promise<number> {
+  const cursor = await pipelineService.getConnectorCursor('gmail')
+  let messageIds: string[] = []
+
+  if (cursor) {
+    // Incremental: fetch message ids added since the stored historyId.
+    try {
+      const historyRes = await gFetch<{ history?: Array<{ messagesAdded?: Array<{ message: { id: string } }> }>; historyId?: string }>(
+        `${GMAIL_BASE}/history?startHistoryId=${encodeURIComponent(cursor)}&historyTypes=messageAdded&labelId=INBOX`,
+        accessToken
+      )
+      const added = historyRes.history?.flatMap((h) => h.messagesAdded?.map((m) => m.message.id) ?? []) ?? []
+      messageIds = added
+      // Update cursor to the latest historyId even if there are no new messages.
+      if (historyRes.historyId) {
+        await pipelineService.setConnectorCursor('gmail', historyRes.historyId, 0)
+      }
+    } catch (err: unknown) {
+      const status = (err as { status?: number }).status
+      if (status === 404) {
+        // historyId expired — fall through to full re-list.
+        console.warn('[connectors:gmail] historyId expired, falling back to full list')
+      } else {
+        throw err
+      }
+    }
+  }
+
+  if (!cursor || messageIds.length === 0) {
+    // Full list: grab the 200 most recent INBOX messages.
+    const listRes = await gFetch<{ messages?: Array<{ id: string }>; historyId?: string }>(
+      `${GMAIL_BASE}/messages?labelIds=INBOX&maxResults=200`,
+      accessToken
+    )
+    messageIds = listRes.messages?.map((m) => m.id) ?? []
+    if (listRes.historyId) {
+      await pipelineService.setConnectorCursor('gmail', listRes.historyId, 0)
+    }
+  }
+
+  let ingested = 0
+  for (const msgId of messageIds) {
+    try {
+      const msg = await gFetch<GmailMessage>(
+        `${GMAIL_BASE}/messages/${msgId}?format=full`,
+        accessToken
+      )
+      const text = gmailToText(msg)
+      if (!text.trim()) continue
+      const name = gmailTitle(msg)
+      const uri = `https://mail.google.com/mail/u/0/#inbox/${msg.id}`
+      const provenance: ExternalProvenance = { connector: 'gmail', externalId: msg.id, uri }
+      const result = await pipelineService.captureExternal(text, name, provenance)
+      if (result.created) ingested++
+    } catch (err) {
+      console.warn(`[connectors:gmail] failed to fetch message ${msgId}`, err)
+    }
+  }
+
+  if (ingested > 0) {
+    // Increment item count for the UI.
+    await pipelineService.setConnectorCursor(
+      'gmail',
+      await pipelineService.getConnectorCursor('gmail'),
+      ingested
+    )
+  }
+  return ingested
+}
+
+// ── Calendar sync ───────────────────────────────────────────────────────────
+
+async function syncCalendar(accessToken: string): Promise<number> {
+  const syncToken = await pipelineService.getConnectorCursor('gcal')
+  let events: CalendarEvent[] = []
+  let nextSyncToken: string | null = null
+
+  const doFullList = async (): Promise<void> => {
+    const url = `${CALENDAR_BASE}/events?singleEvents=true&orderBy=startTime&maxResults=500`
+    const res = await gFetch<{ items?: CalendarEvent[]; nextSyncToken?: string }>(url, accessToken)
+    events = res.items ?? []
+    nextSyncToken = res.nextSyncToken ?? null
+  }
+
+  if (syncToken) {
+    try {
+      const url = `${CALENDAR_BASE}/events?syncToken=${encodeURIComponent(syncToken)}&singleEvents=true`
+      const res = await gFetch<{ items?: CalendarEvent[]; nextSyncToken?: string }>(url, accessToken)
+      events = res.items ?? []
+      nextSyncToken = res.nextSyncToken ?? null
+    } catch (err: unknown) {
+      const status = (err as { status?: number }).status
+      if (status === 410) {
+        // syncToken expired — full re-list.
+        console.warn('[connectors:gcal] syncToken expired, doing full list')
+        await pipelineService.resetConnectorCursor('gcal')
+        await doFullList()
+      } else {
+        throw err
+      }
+    }
+  } else {
+    await doFullList()
+  }
+
+  let ingested = 0
+  for (const event of events) {
+    if (!event.id || event.status === 'cancelled') continue
+    const text = calendarToText(event)
+    if (!text.trim()) continue
+    const name = event.summary ?? `Calendar event ${event.id}`
+    const uri = event.htmlLink ?? undefined
+    const provenance: ExternalProvenance = { connector: 'gcal', externalId: event.id, uri }
+    const result = await pipelineService.captureExternal(text, name, provenance)
+    if (result.created) ingested++
+  }
+
+  if (nextSyncToken) {
+    await pipelineService.setConnectorCursor('gcal', nextSyncToken, ingested)
+  } else if (ingested > 0) {
+    await pipelineService.setConnectorCursor('gcal', null, ingested)
+  }
+
+  return ingested
+}
+
+// ── Public service ──────────────────────────────────────────────────────────
+
+export const connectorService = {
+  /**
+   * Run an incremental sync for the given provider using the supplied access token.
+   * Returns the number of newly ingested items and the ISO timestamp of this sync.
+   * Called by the worker handler (channel `connectors:ingest`).
+   */
+  async ingest(provider: ConnectorId, accessToken: string): Promise<IngestResult> {
+    const ingested =
+      provider === 'gmail'
+        ? await syncGmail(accessToken)
+        : await syncCalendar(accessToken)
+
+    const lastSyncAt = new Date().toISOString()
+    console.log(`[connectors:${provider}] ingested ${ingested} item(s)`)
+    return { ingested, lastSyncAt }
+  }
+}

--- a/apps/desktop/src/main/services/pipeline-service.ts
+++ b/apps/desktop/src/main/services/pipeline-service.ts
@@ -1,6 +1,6 @@
-import { desc, eq, inArray } from 'drizzle-orm'
+import { desc, eq, inArray, sql } from 'drizzle-orm'
 import { client, db } from '../db'
-import { items, type Item as ItemRow } from '../db/schema'
+import { items, connectorState, type Item as ItemRow } from '../db/schema'
 import { chunkText } from '../pipeline/chunk'
 import { embedder } from '../pipeline/embed'
 import { detectContentType, extract, extractMedia, suffixOf } from '../pipeline/extract'
@@ -24,6 +24,9 @@ function toItem(row: ItemRow): Item {
     sizeBytes: row.sizeBytes,
     status: row.status as ItemStatus,
     text: row.text,
+    connector: row.connector ?? undefined,
+    externalId: row.externalId ?? undefined,
+    uri: row.uri ?? undefined,
     createdAt: row.createdAt
   }
 }
@@ -104,6 +107,12 @@ async function indexItem(id: string, text: string): Promise<void> {
   }
 }
 
+export interface ExternalProvenance {
+  connector: string
+  externalId: string
+  uri?: string
+}
+
 export const pipelineService = {
   captureText(text: string, name = 'note.md'): Promise<CaptureResult> {
     return capture(new TextEncoder().encode(text), name, 'text/markdown')
@@ -111,6 +120,117 @@ export const pipelineService = {
 
   captureFile(bytes: Uint8Array, name: string, mime?: string): Promise<CaptureResult> {
     return capture(bytes, name, mime)
+  },
+
+  /**
+   * Ingest text from an external connector (Gmail, Calendar).
+   *
+   * Dedup strategy:
+   *   - Email (immutable): skip if `externalId` already exists.
+   *   - Calendar (mutable): upsert — re-index with fresh text if `externalId` already exists.
+   *
+   * Provenance (`connector`, `externalId`, `uri`) is stored alongside the item
+   * so `memoryKindOf` can emit the correct UI kind (email / calendar / event).
+   */
+  async captureExternal(
+    text: string,
+    name: string,
+    provenance: ExternalProvenance
+  ): Promise<CaptureResult> {
+    const { connector, externalId, uri } = provenance
+
+    // Check for an existing item with this externalId.
+    const existing = await db
+      .select()
+      .from(items)
+      .where(eq(items.externalId, externalId))
+      .limit(1)
+
+    if (existing[0]) {
+      const isCalendar = connector === 'gcal'
+      if (isCalendar) {
+        // Calendar events mutate — upsert text + re-index.
+        await db
+          .update(items)
+          .set({ text, status: 'extracted', uri: uri ?? null })
+          .where(eq(items.externalId, externalId))
+        if (text) await indexItem(existing[0].id, text)
+        const refreshed = await db.select().from(items).where(eq(items.id, existing[0].id)).limit(1)
+        return { memory: toMemory(toItem(refreshed[0]!)), created: false }
+      }
+      // Email is immutable — skip.
+      return { memory: toMemory(toItem(existing[0])), created: false }
+    }
+
+    // New item: encode text as bytes, store in the raw store, then index.
+    const bytes = new TextEncoder().encode(text)
+    const { id, storedPath, sizeBytes } = putRaw(bytes, '.txt')
+
+    // Content-hash dedup (same bytes, different externalId — very unlikely but safe).
+    const byHash = await db.select().from(items).where(eq(items.id, id)).limit(1)
+    if (byHash[0]) {
+      // Patch provenance onto the existing content-hash row.
+      await db.update(items).set({ connector, externalId, uri: uri ?? null }).where(eq(items.id, id))
+      return { memory: toMemory(toItem({ ...byHash[0], connector, externalId, uri: uri ?? null })), created: false }
+    }
+
+    const [created] = await db
+      .insert(items)
+      .values({
+        id,
+        sourceName: name,
+        contentType: 'text',
+        sizeBytes,
+        storedPath,
+        text,
+        status: 'extracted',
+        connector,
+        externalId,
+        uri: uri ?? null
+      })
+      .returning()
+
+    if (text) await indexItem(id, text)
+    return { memory: toMemory(toItem(created!)), created: true }
+  },
+
+  /** Read the sync cursor for a provider (Gmail historyId / Calendar syncToken). */
+  async getConnectorCursor(provider: string): Promise<string | null> {
+    const row = await db.select().from(connectorState).where(eq(connectorState.provider, provider)).limit(1)
+    return row[0]?.cursor ?? null
+  },
+
+  /** Persist the sync cursor + item count after a successful sync run. */
+  async setConnectorCursor(provider: string, cursor: string | null, deltaCount: number): Promise<void> {
+    await db
+      .insert(connectorState)
+      .values({ provider, cursor, itemCount: deltaCount, lastSyncAt: new Date() })
+      .onConflictDoUpdate({
+        target: connectorState.provider,
+        set: {
+          cursor,
+          itemCount: sql`${connectorState.itemCount} + ${deltaCount}`,
+          lastSyncAt: new Date()
+        }
+      })
+  },
+
+  /** Return the current item count for a provider (for the ConnectorsState UI). */
+  async getConnectorItemCount(provider: string): Promise<number> {
+    const row = await db.select().from(connectorState).where(eq(connectorState.provider, provider)).limit(1)
+    return row[0]?.itemCount ?? 0
+  },
+
+  /** Return the last sync timestamp for a provider (ISO string or null). */
+  async getConnectorLastSync(provider: string): Promise<string | null> {
+    const row = await db.select().from(connectorState).where(eq(connectorState.provider, provider)).limit(1)
+    const d = row[0]?.lastSyncAt
+    return d ? d.toISOString() : null
+  },
+
+  /** Reset a provider's cursor (forces a full re-sync on next run). */
+  async resetConnectorCursor(provider: string): Promise<void> {
+    await db.delete(connectorState).where(eq(connectorState.provider, provider))
   },
 
   async search(query: string, topK = 8): Promise<SearchHit[]> {

--- a/apps/desktop/src/main/services/project.ts
+++ b/apps/desktop/src/main/services/project.ts
@@ -41,8 +41,12 @@ export function relativeWhen(date: Date): string {
   return date.toISOString().slice(0, 10)
 }
 
-/** Map the pipeline's coarse contentType (+ filename) to the UI's richer kind. */
-function memoryKindOf(contentType: string, sourceName: string): MemoryKind {
+/** Map the pipeline's coarse contentType (+ filename + connector) to the UI's richer kind. */
+function memoryKindOf(contentType: string, sourceName: string, connector?: string): MemoryKind {
+  // Connector provenance takes precedence over content-type inference.
+  if (connector === 'gmail') return 'email'
+  if (connector === 'gcal') return 'calendar'
+
   const ext = sourceName.includes('.') ? sourceName.split('.').pop()!.toLowerCase() : ''
   switch (contentType) {
     case 'pdf':
@@ -77,10 +81,10 @@ function deriveSnip(text: string): string {
 export function toMemory(item: Item): Memory {
   return {
     id: item.id,
-    kind: memoryKindOf(item.contentType, item.sourceName),
+    kind: memoryKindOf(item.contentType, item.sourceName, item.connector),
     title: deriveTitle(item),
     snip: deriveSnip(item.text),
-    src: item.sourceName,
+    src: item.uri ?? item.sourceName,
     when: relativeWhen(item.createdAt)
   }
 }
@@ -89,7 +93,7 @@ export function toFedItem(item: Item): FedItem {
   const done: ItemStatus[] = ['captured', 'extracted']
   return {
     id: item.id,
-    kind: memoryKindOf(item.contentType, item.sourceName),
+    kind: memoryKindOf(item.contentType, item.sourceName, item.connector),
     title: deriveTitle(item),
     when: relativeWhen(item.createdAt),
     status: done.includes(item.status) ? 'done' : 'pending'

--- a/apps/desktop/src/main/worker/index.ts
+++ b/apps/desktop/src/main/worker/index.ts
@@ -10,10 +10,12 @@
  *   worker → parent : { ready: true }  (once the schema is up)  | { fatal }
  */
 import { IPC } from '@nimi/contract/ipc'
+import type { ConnectorId } from '@nimi/contract/ipc'
 import { initDb } from '../db'
 import { pipelineService } from '../services/pipeline-service'
 import { todoService } from '../services/todo-service'
 import { uncoverService } from '../services/uncover-service'
+import { connectorService } from '../services/connector-service'
 
 type Handler = (args: unknown[]) => unknown | Promise<unknown>
 
@@ -39,7 +41,25 @@ const handlers: Record<string, Handler> = {
   [IPC.todoContextSearch]: ([id]) => todoService.searchMoreContext(id as string),
   [IPC.todoContextPin]: ([id, itemId]) => todoService.pinContext(id as string, itemId as string),
   [IPC.todoContextDismiss]: ([id, itemId]) =>
-    todoService.dismissContext(id as string, itemId as string)
+    todoService.dismissContext(id as string, itemId as string),
+
+  // Connector sync: main passes a fresh access token; worker fetches + ingests.
+  [IPC.connectorsIngest]: ([provider, accessToken]) =>
+    connectorService.ingest(provider as ConnectorId, accessToken as string),
+
+  // DB stats for ConnectorsState (item count + last sync per provider).
+  [IPC.connectorsGetStats]: async () => {
+    const [gmailCount, gmailSync, gcalCount, gcalSync] = await Promise.all([
+      pipelineService.getConnectorItemCount('gmail'),
+      pipelineService.getConnectorLastSync('gmail'),
+      pipelineService.getConnectorItemCount('gcal'),
+      pipelineService.getConnectorLastSync('gcal')
+    ])
+    return {
+      gmail: { itemCount: gmailCount, lastSyncAt: gmailSync },
+      gcal: { itemCount: gcalCount, lastSyncAt: gcalSync }
+    }
+  }
 }
 
 interface CallMessage {

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -1,6 +1,6 @@
 import { contextBridge, ipcRenderer, type IpcRendererEvent } from 'electron'
 import { electronAPI } from '@electron-toolkit/preload'
-import { IPC, type AuthState, type NimiApi } from '@nimi/contract/ipc'
+import { IPC, type AuthState, type ConnectorsState, type ConnectorId, type NimiApi } from '@nimi/contract/ipc'
 
 // Custom APIs for renderer — the only data surface the renderer can reach.
 const api: NimiApi = {
@@ -40,6 +40,17 @@ const api: NimiApi = {
       ): void => cb(payload.state, payload.accessToken)
       ipcRenderer.on(IPC.authChanged, handler)
       return () => ipcRenderer.removeListener(IPC.authChanged, handler)
+    }
+  },
+  connectors: {
+    connect: (provider: ConnectorId) => ipcRenderer.invoke(IPC.connectorsConnect, provider),
+    disconnect: (provider: ConnectorId) => ipcRenderer.invoke(IPC.connectorsDisconnect, provider),
+    getState: () => ipcRenderer.invoke(IPC.connectorsGetState),
+    syncNow: (provider: ConnectorId) => ipcRenderer.invoke(IPC.connectorsSyncNow, provider),
+    onChanged: (cb: (state: ConnectorsState) => void) => {
+      const handler = (_e: IpcRendererEvent, state: ConnectorsState): void => cb(state)
+      ipcRenderer.on(IPC.connectorsChanged, handler)
+      return (): void => { ipcRenderer.removeListener(IPC.connectorsChanged, handler) }
     }
   },
   ui: {

--- a/apps/desktop/src/renderer/src/hooks/useConnectors.ts
+++ b/apps/desktop/src/renderer/src/hooks/useConnectors.ts
@@ -1,0 +1,72 @@
+import { useEffect, useState } from 'react'
+import type { ConnectorsState, ConnectorId } from '@nimi/contract/ipc'
+import { isElectron } from '../nimi/api'
+
+const EMPTY: ConnectorsState = {
+  configured: false,
+  gmail: { connected: false, lastSyncAt: null, itemCount: 0 },
+  gcal: { connected: false, lastSyncAt: null, itemCount: 0 }
+}
+
+/**
+ * Bridges the renderer to the main-process Google connector flow.
+ * Outside Electron (browser preview) returns a static unconfigured state
+ * and no-op actions — mirrors the `useAuth` pattern.
+ */
+export function useConnectors(): {
+  state: ConnectorsState
+  connect: (provider: ConnectorId) => void
+  disconnect: (provider: ConnectorId) => void
+  syncNow: (provider: ConnectorId) => void
+  syncing: ConnectorId | null
+} {
+  const [state, setState] = useState<ConnectorsState>(EMPTY)
+  const [syncing, setSyncing] = useState<ConnectorId | null>(null)
+
+  useEffect(() => {
+    if (!isElectron) return
+    let active = true
+
+    window.api.connectors.getState().then((s) => { if (active) setState(s) })
+
+    const unsubscribe = window.api.connectors.onChanged((s) => {
+      if (active) setState(s)
+    })
+
+    return () => {
+      active = false
+      unsubscribe()
+    }
+  }, [])
+
+  if (!isElectron) {
+    return { state: EMPTY, connect: () => {}, disconnect: () => {}, syncNow: () => {}, syncing: null }
+  }
+
+  return {
+    state,
+    syncing,
+    connect: (provider) =>
+      void window.api.connectors
+        .connect(provider)
+        .then(() => window.api.connectors.getState())
+        .then(setState)
+        .catch((e) => console.error(`connector connect failed (${provider})`, e)),
+    disconnect: (provider) =>
+      void window.api.connectors
+        .disconnect(provider)
+        .then(() => window.api.connectors.getState())
+        .then(setState)
+        .catch((e) => console.error(`connector disconnect failed (${provider})`, e)),
+    syncNow: (provider) => {
+      if (syncing) return
+      setSyncing(provider)
+      window.api.connectors
+        .syncNow(provider)
+        .then(() => window.api.connectors.getState())
+        .then(setState)
+        .catch((e) => console.error(`connector syncNow failed (${provider})`, e))
+        .finally(() => setSyncing(null))
+    }
+  }
+}

--- a/apps/desktop/src/renderer/src/nimi/connectors.tsx
+++ b/apps/desktop/src/renderer/src/nimi/connectors.tsx
@@ -1,0 +1,132 @@
+// connectors.tsx — Gmail + Google Calendar connector controls.
+//
+// Self-contained: drives its own `useConnectors` hook (connectors live outside
+// the `data` seam, straight on `window.api.connectors`). Renders nothing until
+// MAIN_VITE_GOOGLE_CLIENT_ID is set — matching the "inert until configured" contract.
+import type { JSX } from 'react'
+import { NIcon } from './icons'
+import { useConnectors } from '../hooks/useConnectors'
+import type { ConnectorId } from '@nimi/contract/ipc'
+
+interface ProviderRowProps {
+  id: ConnectorId
+  label: string
+  icon: 'mail' | 'calendar'
+  connected: boolean
+  lastSyncAt: string | null
+  itemCount: number
+  syncing: boolean
+  onConnect: () => void
+  onDisconnect: () => void
+  onSync: () => void
+}
+
+function formatSync(lastSyncAt: string | null): string {
+  if (!lastSyncAt) return 'never synced'
+  const diff = Date.now() - new Date(lastSyncAt).getTime()
+  const mins = Math.floor(diff / 60_000)
+  if (mins < 1) return 'just now'
+  if (mins < 60) return `${mins}m ago`
+  const hrs = Math.floor(mins / 60)
+  if (hrs < 24) return `${hrs}h ago`
+  return `${Math.floor(hrs / 24)}d ago`
+}
+
+function ProviderRow({
+  label,
+  icon,
+  connected,
+  lastSyncAt,
+  itemCount,
+  syncing,
+  onConnect,
+  onDisconnect,
+  onSync
+}: ProviderRowProps): JSX.Element {
+  return (
+    <div className="connector-row" data-connected={connected}>
+      <span className="connector-icon">
+        <NIcon name={icon} size={15} />
+      </span>
+      <div className="connector-info">
+        <span className="connector-label">{label}</span>
+        {connected && (
+          <span className="connector-meta">
+            {itemCount > 0 ? `${itemCount} captured` : 'connected'} · {formatSync(lastSyncAt)}
+          </span>
+        )}
+      </div>
+      <div className="connector-actions">
+        {connected ? (
+          <>
+            <button
+              className="hdr-btn"
+              title={syncing ? 'Syncing…' : 'Sync now'}
+              disabled={syncing}
+              onClick={onSync}
+              aria-label={`Sync ${label}`}
+            >
+              <NIcon name="refresh" size={14} />
+            </button>
+            <button
+              className="hdr-btn connector-disconnect"
+              title={`Disconnect ${label}`}
+              onClick={onDisconnect}
+              aria-label={`Disconnect ${label}`}
+            >
+              <NIcon name="close" size={14} />
+            </button>
+          </>
+        ) : (
+          <button
+            className="hdr-btn connector-connect"
+            title={`Connect ${label}`}
+            onClick={onConnect}
+            aria-label={`Connect ${label}`}
+          >
+            Connect
+          </button>
+        )}
+      </div>
+    </div>
+  )
+}
+
+/**
+ * Renders the connector panel (Gmail + Google Calendar rows).
+ * Returns null until `MAIN_VITE_GOOGLE_CLIENT_ID` is set — inert by default.
+ */
+export function ConnectorsControl(): JSX.Element | null {
+  const { state, connect, disconnect, syncNow, syncing } = useConnectors()
+
+  if (!state.configured) return null
+
+  return (
+    <div className="connectors-panel">
+      <ProviderRow
+        id="gmail"
+        label="Gmail"
+        icon="mail"
+        connected={state.gmail.connected}
+        lastSyncAt={state.gmail.lastSyncAt}
+        itemCount={state.gmail.itemCount}
+        syncing={syncing === 'gmail'}
+        onConnect={() => connect('gmail')}
+        onDisconnect={() => disconnect('gmail')}
+        onSync={() => syncNow('gmail')}
+      />
+      <ProviderRow
+        id="gcal"
+        label="Google Calendar"
+        icon="calendar"
+        connected={state.gcal.connected}
+        lastSyncAt={state.gcal.lastSyncAt}
+        itemCount={state.gcal.itemCount}
+        syncing={syncing === 'gcal'}
+        onConnect={() => connect('gcal')}
+        onDisconnect={() => disconnect('gcal')}
+        onSync={() => syncNow('gcal')}
+      />
+    </div>
+  )
+}

--- a/apps/desktop/src/renderer/src/nimi/nimi.css
+++ b/apps/desktop/src/renderer/src/nimi/nimi.css
@@ -4279,3 +4279,80 @@ html[data-density='compact'] .mem {
     animation-duration: 0.01ms !important;
   }
 }
+
+/* ── Connectors panel ──────────────────────────────────────────────────────── */
+
+.connectors-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  margin-right: 4px;
+}
+
+.connector-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 3px 6px;
+  border-radius: 7px;
+  transition: background 0.12s;
+}
+
+.connector-row[data-connected='true'] {
+  background: color-mix(in srgb, var(--accent, #7c6aff) 10%, transparent);
+}
+
+.connector-icon {
+  flex-shrink: 0;
+  opacity: 0.6;
+  display: flex;
+  align-items: center;
+}
+
+.connector-info {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.connector-label {
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--text-1, #e8e8ed);
+  white-space: nowrap;
+}
+
+.connector-meta {
+  font-size: 10px;
+  color: var(--text-3, #888);
+  white-space: nowrap;
+}
+
+.connector-actions {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  margin-left: auto;
+}
+
+.connector-connect {
+  font-size: 11px;
+  padding: 2px 8px;
+  border-radius: 5px;
+  background: color-mix(in srgb, var(--accent, #7c6aff) 20%, transparent);
+  color: var(--text-1, #e8e8ed);
+  height: auto;
+  width: auto;
+}
+
+.connector-connect:hover {
+  background: color-mix(in srgb, var(--accent, #7c6aff) 35%, transparent);
+}
+
+.connector-disconnect {
+  opacity: 0.5;
+}
+
+.connector-disconnect:hover {
+  opacity: 1;
+}

--- a/apps/desktop/src/renderer/src/nimi/today.tsx
+++ b/apps/desktop/src/renderer/src/nimi/today.tsx
@@ -5,6 +5,7 @@ import { NIcon } from './icons'
 import { kindIcon } from './iconKind'
 import { NimiMark, NimiNote } from './mark'
 import { AuthControl } from './auth'
+import { ConnectorsControl } from './connectors'
 import { MemoryContext } from './api'
 import type { Task } from '@nimi/contract/views'
 import type { NimiMarkState } from './types'
@@ -49,6 +50,7 @@ function AppHeader({
         </div>
       </div>
       <div className="hdr-r">
+        <ConnectorsControl />
         <AuthControl />
         <button className="hdr-btn" aria-label="Plan tomorrow" onClick={onTomorrow}>
           <NIcon name="dayNext" size={18} />

--- a/apps/desktop/test/connectors/normalizers.test.ts
+++ b/apps/desktop/test/connectors/normalizers.test.ts
@@ -1,0 +1,245 @@
+/**
+ * Unit tests for Gmail + Calendar normalization helpers.
+ * Pure functions — no DB, no network, no Electron.
+ */
+import { describe, it, expect } from 'vitest'
+import {
+  extractGmailText,
+  gmailToText,
+  gmailTitle,
+  calendarToText,
+  type GmailMessage,
+  type GmailPayload,
+  type CalendarEvent
+} from '../../src/main/connectors/normalizers'
+
+// ── extractGmailText ──────────────────────────────────────────────────────────
+
+describe('extractGmailText', () => {
+  function b64(text: string): string {
+    return Buffer.from(text).toString('base64url')
+  }
+
+  it('decodes a top-level text/plain part', () => {
+    const payload: GmailPayload = {
+      mimeType: 'text/plain',
+      body: { data: b64('Hello from Gmail') }
+    }
+    expect(extractGmailText(payload)).toBe('Hello from Gmail')
+  })
+
+  it('strips HTML tags from a top-level text/html part', () => {
+    const payload: GmailPayload = {
+      mimeType: 'text/html',
+      body: { data: b64('<p>Hello <b>world</b></p>') }
+    }
+    expect(extractGmailText(payload)).toBe('Hello world')
+  })
+
+  it('prefers text/plain over text/html in multipart', () => {
+    const payload: GmailPayload = {
+      mimeType: 'multipart/alternative',
+      parts: [
+        { mimeType: 'text/html', body: { data: b64('<p>HTML version</p>') } },
+        { mimeType: 'text/plain', body: { data: b64('Plain version') } }
+      ]
+    }
+    expect(extractGmailText(payload)).toBe('Plain version')
+  })
+
+  it('falls back to text/html when no text/plain in multipart', () => {
+    const payload: GmailPayload = {
+      mimeType: 'multipart/alternative',
+      parts: [{ mimeType: 'text/html', body: { data: b64('<b>HTML only</b>') } }]
+    }
+    expect(extractGmailText(payload)).toBe('HTML only')
+  })
+
+  it('recurses into nested multipart containers', () => {
+    const payload: GmailPayload = {
+      mimeType: 'multipart/mixed',
+      parts: [
+        {
+          mimeType: 'multipart/alternative',
+          parts: [{ mimeType: 'text/plain', body: { data: b64('Nested plain text') } }]
+        }
+      ]
+    }
+    expect(extractGmailText(payload)).toBe('Nested plain text')
+  })
+
+  it('returns empty string for an empty payload', () => {
+    expect(extractGmailText({})).toBe('')
+  })
+
+  it('returns empty string when body has no data', () => {
+    expect(extractGmailText({ mimeType: 'text/plain', body: {} })).toBe('')
+  })
+})
+
+// ── gmailTitle ────────────────────────────────────────────────────────────────
+
+describe('gmailTitle', () => {
+  function makeMsg(subject?: string, from?: string): GmailMessage {
+    const headers: Array<{ name: string; value: string }> = []
+    if (subject) headers.push({ name: 'Subject', value: subject })
+    if (from) headers.push({ name: 'From', value: from })
+    return { id: 'msg1', payload: { headers } }
+  }
+
+  it('formats as "subject — from sender" when both are present', () => {
+    expect(gmailTitle(makeMsg('Hello', 'alice@example.com'))).toBe(
+      'Hello — from alice@example.com'
+    )
+  })
+
+  it('returns just the subject when From is missing', () => {
+    expect(gmailTitle(makeMsg('Just a subject'))).toBe('Just a subject')
+  })
+
+  it('uses "(no subject)" when Subject header is absent', () => {
+    expect(gmailTitle(makeMsg(undefined, 'bob@example.com'))).toBe(
+      '(no subject) — from bob@example.com'
+    )
+  })
+
+  it('falls back to "Gmail message <id>" when payload is absent', () => {
+    expect(gmailTitle({ id: 'abc123' })).toBe('Gmail message abc123')
+  })
+})
+
+// ── gmailToText ───────────────────────────────────────────────────────────────
+
+describe('gmailToText', () => {
+  it('includes Subject / From / To / Date headers and body', () => {
+    const msg: GmailMessage = {
+      id: 'msg1',
+      payload: {
+        mimeType: 'text/plain',
+        headers: [
+          { name: 'Subject', value: 'Meeting notes' },
+          { name: 'From', value: 'alice@example.com' },
+          { name: 'To', value: 'bob@example.com' },
+          { name: 'Date', value: 'Mon, 1 Jun 2026' }
+        ],
+        body: { data: Buffer.from('Body text here').toString('base64url') }
+      }
+    }
+    const text = gmailToText(msg)
+    expect(text).toContain('Subject: Meeting notes')
+    expect(text).toContain('From: alice@example.com')
+    expect(text).toContain('To: bob@example.com')
+    expect(text).toContain('Date: Mon, 1 Jun 2026')
+    expect(text).toContain('Body text here')
+  })
+
+  it('omits missing headers from the output', () => {
+    const msg: GmailMessage = {
+      id: 'msg1',
+      payload: {
+        mimeType: 'text/plain',
+        headers: [{ name: 'Subject', value: 'Sparse email' }],
+        body: { data: Buffer.from('sparse body').toString('base64url') }
+      }
+    }
+    const text = gmailToText(msg)
+    expect(text).not.toContain('From:')
+    expect(text).not.toContain('To:')
+    expect(text).toContain('Subject: Sparse email')
+  })
+
+  it('falls back to snippet when payload is absent', () => {
+    const msg: GmailMessage = { id: 'msg1', snippet: 'Preview snippet text' }
+    expect(gmailToText(msg)).toBe('Preview snippet text')
+  })
+
+  it('uses snippet as body when payload has no text part', () => {
+    const msg: GmailMessage = {
+      id: 'msg1',
+      snippet: 'fallback snippet',
+      payload: { mimeType: 'multipart/mixed', parts: [] }
+    }
+    const text = gmailToText(msg)
+    expect(text).toContain('fallback snippet')
+  })
+})
+
+// ── calendarToText ────────────────────────────────────────────────────────────
+
+describe('calendarToText', () => {
+  it('renders all core fields', () => {
+    const event: CalendarEvent = {
+      id: 'evt1',
+      summary: 'Team standup',
+      start: { dateTime: '2026-06-01T09:00:00Z' },
+      end: { dateTime: '2026-06-01T09:30:00Z' },
+      location: 'Zoom',
+      organizer: { displayName: 'Alice', email: 'alice@example.com' }
+    }
+    const text = calendarToText(event)
+    expect(text).toContain('Event: Team standup')
+    expect(text).toContain('Start: 2026-06-01T09:00:00Z')
+    expect(text).toContain('End: 2026-06-01T09:30:00Z')
+    expect(text).toContain('Location: Zoom')
+    expect(text).toContain('Organizer: Alice')
+  })
+
+  it('falls back to organizer email when displayName is absent', () => {
+    const event: CalendarEvent = {
+      id: 'evt1',
+      summary: 'Meeting',
+      organizer: { email: 'org@example.com' }
+    }
+    expect(calendarToText(event)).toContain('Organizer: org@example.com')
+  })
+
+  it('renders up to 10 attendees by displayName', () => {
+    const attendees = Array.from({ length: 12 }, (_, i) => ({
+      displayName: `Person ${i + 1}`,
+      email: `p${i + 1}@example.com`
+    }))
+    const text = calendarToText({ id: 'evt1', summary: 'Big meeting', attendees })
+    expect(text).toContain('Person 1')
+    expect(text).toContain('Person 10')
+    // 11th and 12th are truncated
+    expect(text).not.toContain('Person 11')
+  })
+
+  it('falls back to email when attendee displayName is absent', () => {
+    const event: CalendarEvent = {
+      id: 'evt1',
+      summary: 'Mtg',
+      attendees: [{ email: 'noname@example.com' }]
+    }
+    expect(calendarToText(event)).toContain('noname@example.com')
+  })
+
+  it('strips HTML tags from description', () => {
+    const event: CalendarEvent = {
+      id: 'evt1',
+      summary: 'HTML desc',
+      description: '<p>Agenda:<br/><b>1.</b> Review</p>'
+    }
+    const text = calendarToText(event)
+    expect(text).not.toContain('<p>')
+    expect(text).toContain('Agenda:')
+    expect(text).toContain('1.')
+    expect(text).toContain('Review')
+  })
+
+  it('uses all-day date when dateTime is absent', () => {
+    const event: CalendarEvent = {
+      id: 'evt1',
+      summary: 'All-day',
+      start: { date: '2026-06-15' },
+      end: { date: '2026-06-16' }
+    }
+    const text = calendarToText(event)
+    expect(text).toContain('Start: 2026-06-15')
+    expect(text).toContain('End: 2026-06-16')
+  })
+
+  it('returns empty string for a minimal event with no renderable fields', () => {
+    expect(calendarToText({ id: 'evt1' })).toBe('')
+  })
+})

--- a/apps/desktop/test/helpers.ts
+++ b/apps/desktop/test/helpers.ts
@@ -9,6 +9,6 @@ import { client } from '../src/main/db/index'
 export async function clearTables(): Promise<void> {
   // Delete in dependency order (FKs may or may not be enforced, but order is safe)
   await client.executeMultiple(
-    'DELETE FROM todo_ai; DELETE FROM todo_context; DELETE FROM todos; DELETE FROM chunks; DELETE FROM items; DELETE FROM meta;'
+    'DELETE FROM todo_ai; DELETE FROM todo_context; DELETE FROM todos; DELETE FROM chunks; DELETE FROM items; DELETE FROM meta; DELETE FROM connector_state;'
   )
 }

--- a/apps/desktop/test/services/pipeline-service-connectors.test.ts
+++ b/apps/desktop/test/services/pipeline-service-connectors.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Integration tests for connector-specific pipelineService methods:
+ *   captureExternal  — externalId dedup, email immutability, calendar upsert
+ *   connector cursor helpers — get/set/reset cursor, item count, last sync
+ */
+import { describe, it, expect, beforeAll, beforeEach } from 'vitest'
+import { initDb } from '../../src/main/db/index'
+import { pipelineService } from '../../src/main/services/pipeline-service'
+import { clearTables } from '../helpers'
+
+beforeAll(async () => {
+  await initDb()
+})
+
+beforeEach(async () => {
+  await clearTables()
+})
+
+// ── captureExternal — new items ───────────────────────────────────────────────
+
+describe('pipelineService.captureExternal — new items', () => {
+  it('creates a new item and returns created:true', async () => {
+    const result = await pipelineService.captureExternal(
+      'Subject: Hello\nFrom: alice@example.com\n\nBody text',
+      'Hello — from alice@example.com',
+      { connector: 'gmail', externalId: 'msg-001' }
+    )
+    expect(result.created).toBe(true)
+    expect(result.memory.id).toBeTruthy()
+    expect(result.memory.kind).toBe('email')
+  })
+
+  it('sets kind to "email" for gmail connector', async () => {
+    const result = await pipelineService.captureExternal('Email body', 'email.txt', {
+      connector: 'gmail',
+      externalId: 'msg-kind-test'
+    })
+    expect(result.memory.kind).toBe('email')
+  })
+
+  it('sets kind to "calendar" for gcal connector', async () => {
+    const result = await pipelineService.captureExternal(
+      'Event: Standup\nStart: 2026-06-01T09:00:00Z',
+      'Standup',
+      { connector: 'gcal', externalId: 'evt-kind-test' }
+    )
+    expect(result.memory.kind).toBe('calendar')
+  })
+
+  it('stores uri when provided', async () => {
+    const result = await pipelineService.captureExternal(
+      'Email with link',
+      'linked email',
+      {
+        connector: 'gmail',
+        externalId: 'msg-uri-test',
+        uri: 'https://mail.google.com/mail/u/0/#inbox/msg-uri-test'
+      }
+    )
+    expect(result.created).toBe(true)
+    expect(result.memory.src).toBe('https://mail.google.com/mail/u/0/#inbox/msg-uri-test')
+  })
+})
+
+// ── captureExternal — email dedup (immutable) ─────────────────────────────────
+
+describe('pipelineService.captureExternal — Gmail dedup (immutable)', () => {
+  it('returns created:false for the same externalId on second call', async () => {
+    const provenance = { connector: 'gmail', externalId: 'msg-dedup-001' }
+    const r1 = await pipelineService.captureExternal('First body', 'email', provenance)
+    const r2 = await pipelineService.captureExternal('First body', 'email', provenance)
+    expect(r1.created).toBe(true)
+    expect(r2.created).toBe(false)
+    expect(r2.memory.id).toBe(r1.memory.id)
+  })
+
+  it('does NOT update text when the same Gmail externalId is re-ingested', async () => {
+    const provenance = { connector: 'gmail', externalId: 'msg-immutable-001' }
+    const r1 = await pipelineService.captureExternal('Original body', 'email', provenance)
+    const r2 = await pipelineService.captureExternal('Updated body', 'email', provenance)
+    // Should return the original memory unchanged
+    expect(r2.memory.id).toBe(r1.memory.id)
+    const items = await pipelineService.listItems()
+    const stored = items.find((i) => i.id === r1.memory.id)
+    expect(stored?.text).toBe('Original body')
+  })
+
+  it('different externalIds are treated as separate items', async () => {
+    const r1 = await pipelineService.captureExternal('Email one', 'e1', {
+      connector: 'gmail',
+      externalId: 'msg-001'
+    })
+    const r2 = await pipelineService.captureExternal('Email two', 'e2', {
+      connector: 'gmail',
+      externalId: 'msg-002'
+    })
+    expect(r1.created).toBe(true)
+    expect(r2.created).toBe(true)
+    expect(r1.memory.id).not.toBe(r2.memory.id)
+  })
+})
+
+// ── captureExternal — calendar upsert (mutable) ───────────────────────────────
+
+describe('pipelineService.captureExternal — Calendar upsert (mutable)', () => {
+  it('returns created:false but updates text on second call for gcal', async () => {
+    const provenance = { connector: 'gcal', externalId: 'evt-upsert-001' }
+    const r1 = await pipelineService.captureExternal(
+      'Event: Standup\nStart: 2026-06-01T09:00:00Z',
+      'Standup',
+      provenance
+    )
+    const r2 = await pipelineService.captureExternal(
+      'Event: Standup RESCHEDULED\nStart: 2026-06-02T10:00:00Z',
+      'Standup RESCHEDULED',
+      provenance
+    )
+    expect(r1.created).toBe(true)
+    expect(r2.created).toBe(false)
+    expect(r2.memory.id).toBe(r1.memory.id)
+
+    // Text should have been updated
+    const items = await pipelineService.listItems()
+    const stored = items.find((i) => i.id === r1.memory.id)
+    expect(stored?.text).toContain('RESCHEDULED')
+  })
+
+  it('updated calendar event is findable via search', async () => {
+    const provenance = { connector: 'gcal', externalId: 'evt-search-001' }
+    await pipelineService.captureExternal('Event: Morning sync\nStart: 2026-06-01', 'sync', provenance)
+    await pipelineService.captureExternal(
+      'Event: Afternoon sync UPDATED\nStart: 2026-06-01',
+      'sync updated',
+      provenance
+    )
+    const hits = await pipelineService.search('Afternoon sync UPDATED', 5)
+    expect(hits.length).toBeGreaterThan(0)
+  })
+})
+
+// ── connector cursor helpers ──────────────────────────────────────────────────
+
+describe('pipelineService connector cursor helpers', () => {
+  it('getConnectorCursor returns null when no cursor is set', async () => {
+    const cursor = await pipelineService.getConnectorCursor('gmail')
+    expect(cursor).toBeNull()
+  })
+
+  it('setConnectorCursor + getConnectorCursor round-trip', async () => {
+    await pipelineService.setConnectorCursor('gmail', 'historyId-abc123', 0)
+    const cursor = await pipelineService.getConnectorCursor('gmail')
+    expect(cursor).toBe('historyId-abc123')
+  })
+
+  it('setConnectorCursor is idempotent (upsert)', async () => {
+    await pipelineService.setConnectorCursor('gmail', 'v1', 0)
+    await pipelineService.setConnectorCursor('gmail', 'v2', 5)
+    expect(await pipelineService.getConnectorCursor('gmail')).toBe('v2')
+  })
+
+  it('gmail and gcal cursors are independent', async () => {
+    await pipelineService.setConnectorCursor('gmail', 'gmail-cursor', 0)
+    await pipelineService.setConnectorCursor('gcal', 'gcal-sync-token', 0)
+    expect(await pipelineService.getConnectorCursor('gmail')).toBe('gmail-cursor')
+    expect(await pipelineService.getConnectorCursor('gcal')).toBe('gcal-sync-token')
+  })
+
+  it('resetConnectorCursor clears the cursor to null', async () => {
+    await pipelineService.setConnectorCursor('gcal', 'sync-token-xyz', 0)
+    await pipelineService.resetConnectorCursor('gcal')
+    expect(await pipelineService.getConnectorCursor('gcal')).toBeNull()
+  })
+
+  it('getConnectorItemCount returns 0 when no rows exist', async () => {
+    expect(await pipelineService.getConnectorItemCount('gmail')).toBe(0)
+  })
+
+  it('getConnectorItemCount reflects the stored count', async () => {
+    await pipelineService.setConnectorCursor('gmail', 'h1', 42)
+    expect(await pipelineService.getConnectorItemCount('gmail')).toBe(42)
+  })
+
+  it('getConnectorLastSync returns null when not set', async () => {
+    expect(await pipelineService.getConnectorLastSync('gmail')).toBeNull()
+  })
+})

--- a/apps/desktop/test/services/project.test.ts
+++ b/apps/desktop/test/services/project.test.ts
@@ -103,6 +103,35 @@ describe('toMemory', () => {
     expect(m.kind).toBe('voice')
   })
 
+  it('maps connector=gmail to kind "email" regardless of contentType', () => {
+    const m = toMemory(makeItem({ connector: 'gmail', contentType: 'text', sourceName: 'msg.txt' }))
+    expect(m.kind).toBe('email')
+  })
+
+  it('maps connector=gcal to kind "calendar" regardless of contentType', () => {
+    const m = toMemory(makeItem({ connector: 'gcal', contentType: 'text', sourceName: 'evt.txt' }))
+    expect(m.kind).toBe('calendar')
+  })
+
+  it('connector kind takes precedence over extension-based inference', () => {
+    // A .md file ingested via gmail should still be "email"
+    const m = toMemory(makeItem({ connector: 'gmail', contentType: 'text', sourceName: 'note.md' }))
+    expect(m.kind).toBe('email')
+  })
+
+  it('uses item.uri as src when present', () => {
+    const m = toMemory(makeItem({
+      connector: 'gmail',
+      uri: 'https://mail.google.com/mail/u/0/#inbox/abc123'
+    }))
+    expect(m.src).toBe('https://mail.google.com/mail/u/0/#inbox/abc123')
+  })
+
+  it('falls back to sourceName as src when uri is absent', () => {
+    const m = toMemory(makeItem({ connector: 'gmail', uri: undefined }))
+    expect(m.src).toBe('note.md')
+  })
+
   it('derives title from the first non-empty line of text', () => {
     const m = toMemory(makeItem({ text: '\nFirst line\nSecond line' }))
     expect(m.title).toBe('First line')

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -31,7 +31,7 @@ Shared punch list. **Baseline:** `main` @ #12–#15 merged. Lanes: **back** = `a
 | 5   | ~~Image + audio extraction (OCR / transcription)~~ ✅                                                    | back         | screenshots & voice memos as memories            | M–L  | ✅ shipped  |
 | 6   | ~~Feed view + uncovered-todos (Nimi proposes todos from the feed)~~ ✅ **done**                            | back + front | the `FedItem` / `UncoveredTodo` surfaces         | M    | ✅ shipped  |
 | 7   | ~~**Worker-service tests (vitest)**~~ ✅ **done**                                                        | back         | guards pipeline/todo logic                       | M    | ✅ shipped  |
-| 8   | Connectors / ingest (email, calendar, …)                                                                 | back         | automatic capture vs manual                      | L    | P2         |
+| 8   | **Connectors / ingest (email, calendar, …)** 🚧 in progress                                              | back         | automatic capture vs manual                      | L    | P2         |
 | 9   | Auth end-to-end (Logto **Native** app + PKCE, id_token JWKS-verified) — **login verified** ✅; PR #35 open  | back + front | real accounts                                    | M    | P2         |
 | 10  | Sync / cloud offload (Turso), multi-user                                                                 | back         | multi-device                                     | L    | P3         |
 | 11  | Vuln cleanup + CSP tighten                                                                               | back         | the dependabot alerts + hardening                | S    | P1 (quick) |

--- a/docs/adr/0007-connectors-ingest.md
+++ b/docs/adr/0007-connectors-ingest.md
@@ -1,0 +1,99 @@
+# ADR 0007 — Connectors / ingest (email + calendar)
+
+**Status:** Accepted — implemented (ROADMAP #8)
+**Date:** 2026-06-01
+**Context owners:** back lane (`apps/desktop/src/main/**`)
+**Related:** [ADR 0002 auth](0002-authentication.md) · [ADR 0003 pipeline](0003-all-typescript-on-device-pipeline.md) · [ADR 0004 drafting](0004-ai-drafting-model.md) · [setup guide](../google-connectors-setup.md)
+
+## Problem
+
+Nimi captures context manually (typed notes, drag-dropped files). "Automatic capture" means pulling existing email + calendar data into the on-device pipeline without asking the user to re-paste it. We need an OAuth grant to read Gmail + Google Calendar, a sync engine that fetches deltas, and idempotent ingest into the existing capture pipeline.
+
+## Options considered
+
+| # | Option | OAuth approach | Token owner | Runtime deps | Verdict |
+|---|--------|---------------|-------------|--------------|---------|
+| A | **Standalone Google client (chosen)** | PKCE + loopback in main | main (`safeStorage`) | none | ✅ |
+| B | Logto social connector | Logto brokers Google token | Logto Management API | Logto configured + signed in | ⚠️ |
+| C | Google SDK (`googleapis` npm) | PKCE or service account | varies | large package | ⚠️ |
+
+### Notes
+
+**A — Standalone (chosen):** Plain `fetch` against Google REST APIs; PKCE helpers reused from
+`auth/oidc.ts` (PR #35). Decoupled from Logto — works whether or not app-login (#9) is configured.
+Follows the "inert until configured" pattern of `NEEME_ANTHROPIC_KEY` / `MAIN_VITE_LOGTO_*`.
+Google **Desktop app** OAuth client type allows loopback redirect to any port, so no registered
+redirect URI is needed. `access_type=offline` + `prompt=consent` in the authorize URL reliably
+yields a refresh token.
+
+**B — Logto-brokered:** Logto's social connector is oriented toward identity federation (sign-in),
+not durable data-API access. Getting a long-lived Google access token out of Logto requires the
+Management API (`/api/users/{id}/identities/google/access-token`), M2M credentials, and couples
+connectors to the user being signed in to Logto. Rejected: unnecessary coupling, more complexity.
+
+**C — Google SDK:** `googleapis` npm brings a large dependency tree and gRPC transports. The REST
+APIs are simple enough (a few `fetch` calls); no SDK needed.
+
+## Decision
+
+**Option A.** A new `apps/desktop/src/main/connectors/google-auth.ts` mirrors `auth/logto.ts`:
+- PKCE (S256) using `oidc.ts` helpers; `shell.openExternal` to Google; ephemeral loopback `http.createServer` catches the `?code`.
+- Refresh token sealed in `safeStorage` (`neeme-connectors.bin`).
+- `isConfigured()` gates everything on `MAIN_VITE_GOOGLE_CLIENT_ID`.
+- Tokens never reach the renderer (only connect/disconnect/state cross the IPC boundary).
+
+The worker (`connector-service.ts`) runs all network I/O and DB writes: Gmail delta via
+`historyId`, Calendar delta via `syncToken` (410 → full re-list). Each message/event is
+normalised to plain text and fed to `pipelineService.captureExternal()`, which deduplicates by
+`external_id` (skip for email; upsert for calendar events which mutate).
+
+A `setInterval` in main (every `NEEME_CONNECTOR_SYNC_MINUTES`, default 15) plus sync-on-connect
+drive background polling. No new runtime dependencies added.
+
+## Consequences
+
+**Easier:**
+- Connectors work without Logto configured (local-first, BYO-key pattern).
+- The existing capture pipeline (chunk → embed → vector search) handles connector content automatically.
+- `memoryKindOf` emits `email` / `calendar` UI kinds using the new `connector` column — existing `MemoryKind` union and icons already covered.
+
+**Harder:**
+- Each user must create a Google Cloud Desktop app OAuth client and add test users (unverified app limit: 100).
+- Refresh-token rotation: Google may not return a new `refresh_token` on every refresh; the stored one is reused until revoked.
+- Calendar `syncToken` expiry (410) triggers a full re-list; large calendars are slow on recovery.
+
+## Env knobs
+
+| Variable | Kind | Effect |
+|----------|------|--------|
+| `MAIN_VITE_GOOGLE_CLIENT_ID` | `import.meta.env` (baked) | Required — Desktop app OAuth client id |
+| `MAIN_VITE_GOOGLE_CLIENT_SECRET` | `import.meta.env` (baked) | Required — Desktop app OAuth client secret (non-confidential) |
+| `MAIN_VITE_GOOGLE_SCOPES` | `import.meta.env` (baked) | Optional scope override (space-separated) |
+| `NEEME_CONNECTORS=off` | `process.env` (runtime) | Force-disable all connectors |
+| `NEEME_CONNECTOR_SYNC_MINUTES` | `process.env` (runtime) | Polling interval in minutes (default: 15) |
+
+## Open questions
+
+- **Webhook push vs polling:** Gmail supports push notifications via Cloud Pub/Sub; Calendar via
+  watch channels. V1 uses polling (simpler, no infra). V2 can add push to reduce latency.
+- **Attachment capture:** Email attachments (PDFs, images) could be routed through `captureFile`.
+  Not in scope for v1 (text body only).
+- **Multi-account:** V1 assumes one Google account per device. A future account-picker UI would
+  store separate `neeme-connectors-{sub}.bin` files.
+
+## Action items
+
+- [x] `apps/desktop/src/main/connectors/google-auth.ts` — OAuth flow
+- [x] `apps/desktop/src/main/services/connector-service.ts` — Gmail + Calendar sync engine
+- [x] `apps/desktop/src/main/db/schema.ts` — `connector`, `external_id`, `uri` on `items`; `connector_state` table
+- [x] `apps/desktop/src/main/db/index.ts` — `CREATE TABLE IF NOT EXISTS connector_state` + guarded `ALTER TABLE`
+- [x] `apps/desktop/src/main/services/pipeline-service.ts` — `captureExternal`, cursor helpers
+- [x] `apps/desktop/src/main/services/project.ts` — `memoryKindOf` connector branch
+- [x] `apps/desktop/src/main/index.ts` — IPC handlers + scheduler
+- [x] `apps/desktop/src/main/worker/index.ts` — `connectorsIngest` + `connectorsGetStats` handlers
+- [x] `packages/contract/src/ipc.ts` — `ConnectorsApi`, `ConnectorId`, `ConnectorsState`, IPC channels
+- [x] `apps/desktop/src/preload/index.ts` — bridge
+- [x] `apps/desktop/src/renderer/src/nimi/connectors.tsx` + `useConnectors.ts` — UI
+- [x] `docs/google-connectors-setup.md` — setup guide
+- [x] `docs/INTEGRATION.md` — updated
+- [x] `docs/ROADMAP.md` — #8 marked in-progress

--- a/docs/google-connectors-setup.md
+++ b/docs/google-connectors-setup.md
@@ -1,0 +1,110 @@
+# Google Connectors Setup
+
+This guide walks through creating the Google Cloud OAuth client that backs
+Gmail + Google Calendar ingest in nimi (ROADMAP #8, ADR 0007).
+
+## 1. Create a Google Cloud project (or use an existing one)
+
+1. Go to [Google Cloud Console](https://console.cloud.google.com/).
+2. Create a new project or select an existing one.
+
+## 2. Enable the required APIs
+
+In **APIs & Services → Library**, enable:
+- **Gmail API**
+- **Google Calendar API**
+
+## 3. Create an OAuth consent screen
+
+1. **APIs & Services → OAuth consent screen**.
+2. Choose **External** (works for test users without domain verification).
+3. Fill in the required fields (App name, support email). Logo and links are optional for testing.
+4. Under **Scopes**, add:
+   - `https://www.googleapis.com/auth/gmail.readonly`
+   - `https://www.googleapis.com/auth/calendar.readonly`
+   - `openid`, `email`, `profile` (these are pre-listed)
+5. Under **Test users**, add every Google account that will connect to nimi.
+   Unverified apps can have up to 100 test users without going through Google verification.
+6. Save and continue.
+
+## 4. Create OAuth credentials
+
+1. **APIs & Services → Credentials → Create Credentials → OAuth client ID**.
+2. Application type: **Desktop app**.
+3. Name it anything (e.g. "nimi local").
+4. Click **Create**.
+5. Copy the **Client ID** and **Client Secret**.
+
+> **Why Desktop app?**
+> Google's Desktop app client type allows loopback redirects (`http://127.0.0.1:<any-port>`)
+> without pre-registering the exact port. nimi uses a random OS-assigned port for each OAuth
+> flow, so Desktop app is the right type. Web app clients require exact URI pre-registration.
+>
+> The client secret for a Desktop app is **non-confidential** — Google's documentation
+> acknowledges it can't be kept secret in a native app binary. It is safe to put in `.env`.
+
+## 5. Configure nimi
+
+Add to `apps/desktop/.env` (create if it doesn't exist — git-ignored):
+
+```bash
+MAIN_VITE_GOOGLE_CLIENT_ID=<your-client-id>.apps.googleusercontent.com
+MAIN_VITE_GOOGLE_CLIENT_SECRET=GOCSPX-<your-secret>
+```
+
+Optional overrides:
+
+```bash
+# Force-disable connectors (overrides credentials):
+NEEME_CONNECTORS=off
+
+# Polling interval in minutes (default 15):
+NEEME_CONNECTOR_SYNC_MINUTES=15
+
+# Override the OAuth scopes (space-separated, baked into the build):
+MAIN_VITE_GOOGLE_SCOPES=openid email profile https://www.googleapis.com/auth/gmail.readonly https://www.googleapis.com/auth/calendar.readonly
+```
+
+## 6. Test the flow
+
+```bash
+NEEME_EMBEDDER=hash pnpm dev
+```
+
+1. The connector panel appears in the header (Gmail + Google Calendar rows).
+2. Click **Connect** next to Gmail → your system browser opens to Google's consent screen.
+3. Sign in with a **test user** account, grant the scopes.
+4. The browser shows "Connected to nimi — you can close this tab."
+5. nimi starts an immediate sync; messages appear in the Feed and Archive.
+6. Repeat for Google Calendar.
+
+## Two OAuth flows in nimi
+
+nimi has two separate, independent OAuth flows:
+
+| Flow | Module | Redirect | Token owner | Purpose |
+|------|--------|----------|-------------|---------|
+| **Logto app login** | `auth/logto.ts` | `neeme://callback` (custom scheme) | `neeme-auth.bin` | Identifies the user to nimi |
+| **Google connectors** | `connectors/google-auth.ts` | `http://127.0.0.1:<port>` (loopback) | `neeme-connectors.bin` | Grants nimi read access to Gmail + Calendar |
+
+These are independent: connecting Gmail does not require being signed in to Logto,
+and vice versa.
+
+## Troubleshooting
+
+**"This app is blocked" / "Access denied"**
+→ The Google account is not in the test user list. Add it in the OAuth consent screen.
+
+**"redirect_uri_mismatch"**
+→ You accidentally created a **Web app** client instead of a **Desktop app** client.
+   Web app clients need exact redirect URIs pre-registered. Create a Desktop app client instead.
+
+**"Google did not return a refresh_token"**
+→ The account previously authorized this client and Google is reusing the existing grant.
+   Go to [myaccount.google.com/permissions](https://myaccount.google.com/permissions),
+   revoke nimi's access, then try connecting again. The `prompt=consent` + `access_type=offline`
+   flags in the authorize URL ensure a fresh refresh token is issued.
+
+**Sync not starting**
+→ Check that `MAIN_VITE_GOOGLE_CLIENT_ID` and `MAIN_VITE_GOOGLE_CLIENT_SECRET` are set and that
+   `NEEME_CONNECTORS` is not `off`. Check the Electron DevTools console for `[connectors]` logs.

--- a/packages/contract/src/ipc.ts
+++ b/packages/contract/src/ipc.ts
@@ -38,6 +38,17 @@ export const IPC = {
   authGetState: 'auth:get-state',
   /** main → renderer event: auth state / token changed (login, refresh, logout). */
   authChanged: 'auth:changed',
+  // Connectors (Google OAuth + ingest; lives in main; see src/main/connectors/google-auth.ts)
+  connectorsConnect: 'connectors:connect',
+  connectorsDisconnect: 'connectors:disconnect',
+  connectorsGetState: 'connectors:get-state',
+  connectorsSyncNow: 'connectors:sync-now',
+  /** main → renderer event: connector state changed (connected, synced, disconnected). */
+  connectorsChanged: 'connectors:changed',
+  /** Internal channel forwarded to the worker for actual API sync. */
+  connectorsIngest: 'connectors:ingest',
+  /** Internal channel to read per-provider DB stats (item count + last sync). */
+  connectorsGetStats: 'connectors:get-stats',
   // UI shell (tray/menu-bar window — see src/main/window/tray-window.ts)
   traySetBadge: 'tray:set-badge'
 } as const
@@ -55,6 +66,10 @@ export interface Item {
   sizeBytes: number
   status: ItemStatus
   text: string
+  /** Connector provenance — set for connector-ingested items, absent for manual captures. */
+  connector?: string
+  externalId?: string
+  uri?: string
   createdAt: Date
 }
 
@@ -182,9 +197,48 @@ export interface UiApi {
   setBadge: (count: number) => Promise<void>
 }
 
+// --- Connectors (Google OAuth + ingest — main-process concern) -----------
+
+/** The connector providers currently supported. */
+export type ConnectorId = 'gmail' | 'gcal'
+
+/** State of a single provider. */
+export interface ProviderState {
+  connected: boolean
+  lastSyncAt: string | null
+  itemCount: number
+}
+
+/** State surfaced to the renderer. `configured` is false until NEEME_GOOGLE_CLIENT_ID is set. */
+export interface ConnectorsState {
+  configured: boolean
+  gmail: ProviderState
+  gcal: ProviderState
+}
+
+/** Result returned by a sync run (worker-internal, surfaced via connectorsChanged). */
+export interface IngestResult {
+  ingested: number
+  lastSyncAt: string
+}
+
+export interface ConnectorsApi {
+  /** Open the system browser to authorize a provider (PKCE + loopback). */
+  connect: (provider: ConnectorId) => Promise<void>
+  /** Revoke stored tokens and clear all sync state for a provider. */
+  disconnect: (provider: ConnectorId) => Promise<void>
+  /** Snapshot of connector state for all providers. */
+  getState: () => Promise<ConnectorsState>
+  /** Trigger an immediate incremental sync (returns after the sync completes). */
+  syncNow: (provider: ConnectorId) => Promise<IngestResult>
+  /** Subscribe to state changes; returns an unsubscribe fn. */
+  onChanged: (cb: (state: ConnectorsState) => void) => () => void
+}
+
 export interface NimiApi {
   pipeline: PipelineApi
   todos: TodoApi
   auth: AuthApi
+  connectors: ConnectorsApi
   ui: UiApi
 }


### PR DESCRIPTION
## Summary

nimi can now automatically pull email and calendar data into the on-device capture pipeline — no manual paste, no server, no Logto dependency. Users click Connect, authorize via their system browser (Google OAuth PKCE + loopback), and their Gmail messages and Calendar events are indexed and searchable alongside every other memory.

Smoke test: **200 Gmail messages + 499 Calendar events** ingested in first sync.

## Architecture

```
Renderer (ConnectorsControl)
  → main IPC: connectors:connect / :disconnect / :sync-now / :get-state
      → google-auth.ts (PKCE, safeStorage refresh token)
      → worker IPC: connectors:ingest (access token)
          → connector-service.ts (Gmail historyId delta / Calendar syncToken delta)
              → pipelineService.captureExternal (externalId dedup → index)
```

## Design decisions

**Standalone Google client, not Logto-brokered.** Logto's social connector is designed for identity federation, not durable data-API access. A standalone Desktop-app OAuth client (loopback redirect, any port, no pre-registration) keeps connectors independent of whether Logto is configured. Reuses PKCE helpers from `auth/oidc.ts` (PR retrospct/nimi#35).

**Worker owns all API I/O and DB writes.** The main process only holds tokens and drives the scheduler. `connector-service.ts` in the utilityProcess fetches Gmail/Calendar REST APIs, normalises to plain text, and calls `captureExternal` — keeping the main thread unblocked.

**Email is immutable, Calendar upserts.** Gmail messages never change after delivery — second ingest of the same `external_id` is a no-op. Calendar events mutate (reschedules, edits) so the same `external_id` triggers a text update and re-index. Both share `captureExternal` with different branch logic.

**Inert until configured.** `ConnectorsControl` renders `null` and the scheduler never starts unless `MAIN_VITE_GOOGLE_CLIENT_ID` is set — matching the `MAIN_VITE_LOGTO_*` pattern. Zero behaviour change for installs without Google credentials.

## What's in the diff

| Area | Change |
|------|--------|
| `packages/contract/src/ipc.ts` | `ConnectorsApi`, `ConnectorId`, `ConnectorsState`, `IngestResult` types; IPC channels |
| `apps/desktop/src/main/connectors/google-auth.ts` | Standalone Google OAuth (PKCE, loopback, safeStorage) |
| `apps/desktop/src/main/connectors/normalizers.ts` | Pure Gmail + Calendar → plain text (extracted for testability) |
| `apps/desktop/src/main/services/connector-service.ts` | Gmail historyId + Calendar syncToken incremental sync |
| `apps/desktop/src/main/services/pipeline-service.ts` | `captureExternal` + cursor CRUD on `connector_state` |
| `apps/desktop/src/main/db/schema.ts` + `index.ts` | `connector`/`external_id`/`uri` on `items` (guarded ALTER); `connector_state` table |
| `apps/desktop/src/main/services/project.ts` | `memoryKindOf` emits `email`/`calendar` from connector field |
| `apps/desktop/src/main/index.ts` | IPC handlers, `setInterval` scheduler, sync-on-connect |
| `apps/desktop/src/preload/index.ts` | `ConnectorsApi` bridge |
| `apps/desktop/src/renderer/src/nimi/connectors.tsx` + `useConnectors.ts` | Gmail + Calendar rows with Connect / Sync / Disconnect |
| `docs/adr/0007-connectors-ingest.md` | Decision record |
| `docs/google-connectors-setup.md` | Setup guide (GCP project, APIs, consent screen, test users) |

## Tests

216 tests passing (up from 152):

- **22 unit tests** — `extractGmailText` (base64 decode, HTML strip, multipart nesting), `gmailToText`, `gmailTitle`, `calendarToText` (field rendering, attendee truncation, HTML strip, all-day dates)
- **14 integration tests** — `captureExternal` new item, email immutability, calendar upsert + re-search, all cursor helpers
- **+7 project tests** — `connector=gmail` → `email` kind, `connector=gcal` → `calendar` kind, connector precedence over extension, `uri` as `src`

## Setup

See `docs/google-connectors-setup.md`. Requires a Google Cloud Desktop app OAuth client with Gmail API + Calendar API enabled and the connecting account added as a test user. Add to `apps/desktop/.env`:

```
MAIN_VITE_GOOGLE_CLIENT_ID=…
MAIN_VITE_GOOGLE_CLIENT_SECRET=…
```

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Cursor](https://img.shields.io/badge/Sonnet_4.6_%28200K%29-D97757?logo=claude&logoColor=white)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Introduces OAuth token handling, loopback auth, and automated ingestion of mailbox and calendar data into local storage—security- and privacy-sensitive surface area across main, worker, and DB.
> 
> **Overview**
> Adds **automatic Gmail and Google Calendar ingest** into the existing on-device capture pipeline (ROADMAP #8), gated on `MAIN_VITE_GOOGLE_*` so installs without credentials behave unchanged.
> 
> **Main process** gets a standalone Google OAuth client (`google-auth.ts`): PKCE + ephemeral loopback redirect, refresh tokens in `safeStorage`, connect/disconnect/sync IPC, periodic background sync, and token handoff to the worker. **Worker** runs `connector-service.ts` (Gmail `historyId` / Calendar `syncToken` deltas, normalizers → plain text) and **`captureExternal`** with `external_id` dedup (Gmail skip, Calendar upsert/re-index).
> 
> **Data model**: `items` gains `connector` / `external_id` / `uri`; new `connector_state` table for cursors and UI stats. **Projection** maps connector items to `email` / `calendar` kinds and uses `uri` as `src`. **Renderer**: header connector panel + `useConnectors`; contract/preload expose `ConnectorsApi`. Docs: ADR 0007, setup guide; tests for normalizers, `captureExternal`, and projection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit daafe544789a272ef75489635a1d1e379d519785. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->