### PR TITLE
feat(dist): wire auto-updater + GitHub Releases release pipeline (#12/#13)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,67 @@
+name: Release
+
+# Triggered by a version tag: v0.x.y or v0.x.y-alpha.N
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+      - 'v[0-9]+.[0-9]+.[0-9]+-*'
+
+jobs:
+  build-mac:
+    name: Build & publish macOS
+    runs-on: macos-latest
+    env:
+      NEEME_EMBEDDER: hash
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # Code-signing (Developer ID Application cert as base64-encoded .p12)
+      CSC_LINK: ${{ secrets.CSC_LINK }}
+      CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
+      # Notarization (App Store Connect API key — preferred over Apple ID + password)
+      APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+      APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
+      APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+      APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Typecheck
+        run: pnpm typecheck
+
+      - name: Build & publish (macOS)
+        # electron-builder publish reads CSC_LINK for signing and APPLE_* for notarytool.
+        # GH_TOKEN lets it upload artifacts to the GitHub Release created by the tag.
+        # notarize in electron-builder.yml must be set to true once secrets are ready.
+        run: pnpm --filter @nimi/desktop build:mac --publish always
+
+  # Windows canary is deferred for the friends-and-family alpha.
+  # Uncomment and add Azure Trusted Signing secrets when Windows is revisited.
+  # build-win:
+  #   name: Build & publish Windows
+  #   runs-on: windows-latest
+  #   env:
+  #     GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - uses: pnpm/action-setup@v4
+  #       with:
+  #         run_install: false
+  #     - uses: actions/setup-node@v4
+  #       with:
+  #         node-version: '22'
+  #         cache: pnpm
+  #     - run: pnpm install --frozen-lockfile
+  #     - run: pnpm --filter @nimi/desktop build:win --publish always

--- a/apps/desktop/dev-app-update.yml
+++ b/apps/desktop/dev-app-update.yml
@@ -1,3 +1,4 @@
-provider: generic
-url: https://example.com/auto-updates
+provider: github
+owner: retrospct
+repo: nimi
 updaterCacheDirName: nimi-updater

--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -21,12 +21,16 @@ nsis:
   createDesktopShortcut: always
 mac:
   entitlementsInherit: build/entitlements.mac.plist
+  hardenedRuntime: true
+  gatekeeperAssess: false
   extendInfo:
     - NSCameraUsageDescription: Application requests access to the device's camera.
     - NSMicrophoneUsageDescription: Application requests access to the device's microphone.
     - NSDocumentsFolderUsageDescription: Application requests access to the user's Documents folder.
     - NSDownloadsFolderUsageDescription: Application requests access to the user's Downloads folder.
     - NSSpeechRecognitionUsageDescription: Nimi uses on-device speech recognition to transcribe voice memos into searchable memories.
+  # notarize: true requires CSC_LINK + APPLE_TEAM_ID + APPLE_API_KEY* secrets.
+  # Set to true in CI once those secrets are configured (see docs/plans/distribution-hardening.plan.md).
   notarize: false
 dmg:
   artifactName: nimi-${version}.${ext}
@@ -41,5 +45,8 @@ appImage:
   artifactName: nimi-${version}.${ext}
 npmRebuild: false
 publish:
-  provider: generic
-  url: https://example.com/auto-updates
+  provider: github
+  owner: retrospct
+  repo: nimi
+  # releaseType: draft — set to 'release' once signing is configured and tested.
+  releaseType: draft

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -6,7 +6,7 @@ import { initTrayWindow, showWindow, setBadge } from './window/tray-window'
 import * as auth from './auth/logto'
 import * as googleAuth from './connectors/google-auth'
 import { IPC } from '@nimi/contract/ipc'
-import type { ConnectorId, ConnectorsState, IngestResult } from '@nimi/contract/ipc'
+import type { ConnectorId, ConnectorsState, IngestResult, UpdateStatus } from '@nimi/contract/ipc'
 
 // Register `neeme://` as the OAuth callback scheme. In dev (electron launched
 // with a script arg) we must pass execPath + the project dir so the OS routes
@@ -225,6 +225,13 @@ app.whenReady().then(async () => {
   // UI-only: renderer pushes the "waiting" count → tray + Dock badge.
   ipcMain.handle(IPC.traySetBadge, (_e, count: number) => setBadge(count))
 
+  // Auto-updater (ROADMAP #12) — only active in packaged builds; silently no-ops
+  // in dev (app.isPackaged = false). Main owns the lifecycle (quit-and-install);
+  // the renderer receives status pushes and can show a "restart to update" affordance.
+  if (app.isPackaged) {
+    setupAutoUpdater()
+  }
+
   initTrayWindow()
 
   app.on('activate', function () {
@@ -241,6 +248,66 @@ app.on('window-all-closed', () => {
     app.quit()
   }
 })
+
+// --- Auto-updater (ROADMAP #12) ------------------------------------------
+// Wires electron-updater (GitHub Releases feed) into the thin-main-router
+// pattern. All update state is tracked locally and pushed to the renderer;
+// the renderer only ever calls `update:get-status` or `update:quit-and-install`.
+// Errors are logged but never crash the app.
+function setupAutoUpdater(): void {
+  // Dynamic import keeps electron-updater out of the critical startup path and
+  // avoids loading it at all in dev (this fn is only called when app.isPackaged).
+  import('electron-updater')
+    .then(({ autoUpdater }) => {
+      let status: UpdateStatus = {
+        stage: 'idle',
+        version: null,
+        progress: null,
+        error: null
+      }
+
+      function push(next: Partial<UpdateStatus>): void {
+        status = { ...status, ...next }
+        for (const win of BrowserWindow.getAllWindows()) {
+          win.webContents.send(IPC.updateChanged, status)
+        }
+      }
+
+      autoUpdater.autoDownload = true
+      autoUpdater.autoInstallOnAppQuit = true
+
+      autoUpdater.on('checking-for-update', () => push({ stage: 'checking', error: null }))
+      autoUpdater.on('update-available', (info) =>
+        push({ stage: 'available', version: info.version, error: null })
+      )
+      autoUpdater.on('update-not-available', () => push({ stage: 'idle', error: null }))
+      autoUpdater.on('download-progress', (p) =>
+        push({ stage: 'downloading', progress: Math.round(p.percent) })
+      )
+      autoUpdater.on('update-downloaded', (info) =>
+        push({ stage: 'ready', version: info.version, progress: null, error: null })
+      )
+      autoUpdater.on('error', (err) => {
+        console.error('[updater]', err)
+        push({ stage: 'error', error: err.message, progress: null })
+      })
+
+      ipcMain.handle(IPC.updateGetStatus, () => status)
+      ipcMain.handle(IPC.updateQuitAndInstall, () => autoUpdater.quitAndInstall())
+
+      // Check on startup; daily re-check keeps long-running instances up-to-date.
+      autoUpdater.checkForUpdatesAndNotify().catch((err) =>
+        console.error('[updater] initial check failed', err)
+      )
+      const dailyMs = 24 * 60 * 60 * 1000
+      const timer = setInterval(
+        () => autoUpdater.checkForUpdatesAndNotify().catch(() => {}),
+        dailyMs
+      )
+      timer.unref()
+    })
+    .catch((err) => console.error('[updater] failed to load electron-updater', err))
+}
 
 // In this file you can include the rest of your app's specific main process
 // code. You can also put them in separate files and require them here.

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -1,6 +1,13 @@
 import { contextBridge, ipcRenderer, type IpcRendererEvent } from 'electron'
 import { electronAPI } from '@electron-toolkit/preload'
-import { IPC, type AuthState, type ConnectorsState, type ConnectorId, type NimiApi } from '@nimi/contract/ipc'
+import {
+  IPC,
+  type AuthState,
+  type ConnectorsState,
+  type ConnectorId,
+  type NimiApi,
+  type UpdateStatus
+} from '@nimi/contract/ipc'
 
 // Custom APIs for renderer — the only data surface the renderer can reach.
 const api: NimiApi = {
@@ -55,6 +62,17 @@ const api: NimiApi = {
   },
   ui: {
     setBadge: (count: number) => ipcRenderer.invoke(IPC.traySetBadge, count)
+  },
+  update: {
+    getStatus: () => ipcRenderer.invoke(IPC.updateGetStatus),
+    quitAndInstall: () => ipcRenderer.invoke(IPC.updateQuitAndInstall),
+    onChanged: (cb: (status: UpdateStatus) => void) => {
+      const handler = (_e: IpcRendererEvent, status: UpdateStatus): void => cb(status)
+      ipcRenderer.on(IPC.updateChanged, handler)
+      return (): void => {
+        ipcRenderer.removeListener(IPC.updateChanged, handler)
+      }
+    }
   }
 }
 

--- a/packages/contract/src/ipc.ts
+++ b/packages/contract/src/ipc.ts
@@ -55,7 +55,14 @@ export const IPC = {
   /** Query current sync status from the worker (request-response). */
   syncGetStatus: 'sync:get-status',
   /** Trigger an immediate sync; resolves when complete (request-response). */
-  syncNow: 'sync:now'
+  syncNow: 'sync:now',
+  // Auto-updater (ROADMAP #12 — electron-updater via GitHub Releases)
+  /** Query current updater state (request-response). */
+  updateGetStatus: 'update:get-status',
+  /** Apply the downloaded update: quit and install. */
+  updateQuitAndInstall: 'update:quit-and-install',
+  /** main → renderer push: update state changed (checking, available, downloading, ready). */
+  updateChanged: 'update:changed'
 } as const
 
 // --- Pipeline data model (worker-internal vocabulary) ---------------------
@@ -246,6 +253,35 @@ export interface NimiApi {
   auth: AuthApi
   connectors: ConnectorsApi
   ui: UiApi
+  update: UpdateApi
+}
+
+// --- Auto-updater (ROADMAP #12 — electron-updater via GitHub Releases) ----
+
+export type UpdateStage = 'idle' | 'checking' | 'available' | 'downloading' | 'ready' | 'error'
+
+/**
+ * Snapshot of the auto-updater state pushed to the renderer via `update:changed`
+ * and returned by `update:get-status`. The renderer surfaces a subtle "restart
+ * to update" affordance only when `stage === 'ready'`.
+ */
+export interface UpdateStatus {
+  stage: UpdateStage
+  /** Version string of the available/downloaded update, or null if none found yet. */
+  version: string | null
+  /** Download progress 0–100, or null when not downloading. */
+  progress: number | null
+  /** Human-readable error message, or null when healthy. */
+  error: string | null
+}
+
+export interface UpdateApi {
+  /** Current updater snapshot. */
+  getStatus: () => Promise<UpdateStatus>
+  /** Quit the app and apply the downloaded update. Only meaningful when stage === 'ready'. */
+  quitAndInstall: () => Promise<void>
+  /** Subscribe to state changes; returns an unsubscribe fn. */
+  onChanged: (cb: (status: UpdateStatus) => void) => () => void
 }
 
 // --- Sync (ROADMAP #10 — cloud offload via Turso embedded replicas) -------


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implements ROADMAP #12 (auto-updater) and the code-only parts of #13 (macOS packaging/release pipeline). Does not require any Apple credentials to merge — notarization stays `false` until secrets are configured.

## What's in this PR

### `electron-builder.yml` — publish config + mac hardening
- Switches `publish` from `provider: generic` / `https://example.com/auto-updates` to `provider: github` (`retrospct/nimi`)
- `releaseType: draft` — CI creates draft releases so you can review before publishing
- Adds `hardenedRuntime: true` + `gatekeeperAssess: false` (required for notarization when that's enabled)
- `notarize: false` preserved — flip to `true` once Apple Developer secrets are in place (see `docs/plans/distribution-hardening.plan.md` for the exact steps)

### `dev-app-update.yml` — local updater dev config
- Updated to match the new `github` provider (was `generic/example.com`)

### `.github/workflows/release.yml` — tag-triggered release workflow
- Triggers on `v*.*.*` and `v*.*.*-alpha.N` tags
- `build-mac` job: `macos-latest`, pnpm setup, typecheck, then `build:mac --publish always`
- Consumes `CSC_LINK`, `CSC_KEY_PASSWORD`, `APPLE_TEAM_ID`, `APPLE_API_KEY*` from repo secrets (harmless no-ops until secrets are added)
- Windows job present but commented out — uncomment when Windows is revisited post-alpha

### `@nimi/contract/ipc.ts` — `UpdateApi` + channels
- `UpdateStatus` type (`stage`, `version`, `progress`, `error`)
- `UpdateApi` interface (`getStatus`, `quitAndInstall`, `onChanged`)
- `update:get-status`, `update:quit-and-install`, `update:changed` channel names
- `update: UpdateApi` added to `NimiApi`

### `preload/index.ts` — contextBridge bridge
- Bridges `update.getStatus()`, `update.quitAndInstall()`, `update.onChanged(cb)`

### `main/index.ts` — auto-updater wiring
- `setupAutoUpdater()` called after `app.whenReady()`, only when `app.isPackaged` (no-op in dev)
- Dynamic `import('electron-updater')` keeps it out of the startup critical path
- Stage machine: `idle → checking → available → downloading → ready / error`
- Pushes `update:changed` to all renderer windows on every state transition
- `checkForUpdatesAndNotify()` on startup + daily re-check timer (`.unref()`'d)

## Human steps to activate

1. Enroll in Apple Developer Program ($99/yr) — see `docs/plans/distribution-hardening.plan.md` §"Apple Developer steps"
2. Create Developer ID Application cert + App Store Connect API key
3. Add 6 GitHub repo secrets: `CSC_LINK`, `CSC_KEY_PASSWORD`, `APPLE_TEAM_ID`, `APPLE_API_KEY`, `APPLE_API_KEY_ID`, `APPLE_API_ISSUER`
4. Flip `notarize: false` → `true` in `electron-builder.yml`
5. Push a `v0.1.0-alpha.1` tag — the workflow takes it from there

## Verify
- ✅ `pnpm typecheck` — clean
- ✅ `pnpm --filter @nimi/desktop test` — 233/233 passing

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-577cb7a7-7151-49b8-aee2-0479e15b0c94"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-577cb7a7-7151-49b8-aee2-0479e15b0c94"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

