### PR TITLE
feat(sync): require encryption-at-rest key to enable Turso sync (#10)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,6 +67,26 @@ The E2E reads ground truth back through `window.api.pipeline.archive()` (the app
 connection — a separate SQLite reader hits WAL-visibility races). It launches with
 `--user-data-dir=<tmp>` for an isolated throwaway DB.
 
+### Sync + encryption-at-rest tests (#10)
+
+Opt-in Turso sync with mandatory field encryption. Full procedure:
+**`docs/testing/sync-encryption-runbook.md`**.
+
+```bash
+# Tier 1 — gate check (no creds): NEEME_SYNC=on without a valid key must stay local
+pnpm --filter @nimi/desktop test:smoke:sync
+
+# Tier 2 — live two-device replica loop (needs a Turso DB; key is REQUIRED)
+NEEME_SYNC=on NEEME_SYNC_URL=libsql://<db>.turso.io \
+NEEME_SYNC_AUTH_TOKEN=<token> NEEME_SYNC_ENCRYPTION_KEY=<64-hex> \
+pnpm --filter @nimi/desktop test:smoke:sync
+```
+
+Sync **fails closed**: `NEEME_SYNC=on` enables sync only with a valid 64-hex
+`NEEME_SYNC_ENCRYPTION_KEY`, so plaintext is never written to the cloud primary. See
+`docs/setup/turso-credentials.md` for Turso setup (and use Cloud Agents → Secrets for the
+four env vars when running as a cloud agent).
+
 ### Tier 3 — packaged installer on a second computer (Mac/Windows)
 
 ```bash

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -17,6 +17,7 @@
     "test:smoke": "tsx test/smoke/capture-file.ts",
     "test:smoke:ocr": "tsx test/smoke/ocr-live.ts",
     "test:smoke:asr": "tsx test/smoke/asr-live.ts",
+    "test:smoke:sync": "tsx test/smoke/sync-live.ts",
     "test:e2e": "playwright test",
     "postinstall": "electron-builder install-app-deps",
     "build:unpack": "npm run build && electron-builder --dir",

--- a/apps/desktop/src/main/db/crypto.ts
+++ b/apps/desktop/src/main/db/crypto.ts
@@ -29,6 +29,9 @@ const IV_LENGTH = 12 // 96-bit nonce — GCM standard recommendation
 const TAG_LENGTH = 16 // 128-bit auth tag
 const PREFIX = 'enc:' // marks encrypted values; plain values pass through
 
+/** A 32-byte key encoded as exactly 64 hexadecimal characters. */
+const KEY_HEX = /^[0-9a-f]{64}$/i
+
 function resolveKey(): Buffer | null {
   const hex = process.env.NEEME_SYNC_ENCRYPTION_KEY
   if (!hex) return null
@@ -38,6 +41,16 @@ function resolveKey(): Buffer | null {
     )
   }
   return Buffer.from(hex, 'hex')
+}
+
+/**
+ * True only when NEEME_SYNC_ENCRYPTION_KEY is present AND a valid 64-char hex
+ * string (32 bytes). Non-throwing — the sync gate uses this to decide whether
+ * encryption-at-rest is available before allowing any data to reach the cloud.
+ */
+export function hasValidEncryptionKey(): boolean {
+  const hex = process.env.NEEME_SYNC_ENCRYPTION_KEY
+  return typeof hex === 'string' && KEY_HEX.test(hex)
 }
 
 /**

--- a/apps/desktop/src/main/db/crypto.ts
+++ b/apps/desktop/src/main/db/crypto.ts
@@ -35,9 +35,9 @@ const KEY_HEX = /^[0-9a-f]{64}$/i
 function resolveKey(): Buffer | null {
   const hex = process.env.NEEME_SYNC_ENCRYPTION_KEY
   if (!hex) return null
-  if (hex.length !== 64) {
+  if (!KEY_HEX.test(hex)) {
     throw new Error(
-      `NEEME_SYNC_ENCRYPTION_KEY must be 64 hex characters (32 bytes). Got ${hex.length}.`
+      `NEEME_SYNC_ENCRYPTION_KEY must be 64 hex characters (32 bytes). Got ${hex.length} chars${hex.length === 64 ? ' (non-hex)' : ''}.`
     )
   }
   return Buffer.from(hex, 'hex')

--- a/apps/desktop/src/main/db/sync-config.ts
+++ b/apps/desktop/src/main/db/sync-config.ts
@@ -9,10 +9,16 @@
  *   NEEME_SYNC_URL          libSQL sync URL (e.g. libsql://<db>.turso.io)
  *   NEEME_SYNC_AUTH_TOKEN   DB-scoped auth token (short-lived; main fetches from broker)
  *   NEEME_SYNC_INTERVAL_S   Periodic sync interval in seconds (default 300 = 5 min)
+ *   NEEME_SYNC_ENCRYPTION_KEY  64-hex AES-256-GCM key — REQUIRED to enable sync
+ *
+ * Encryption at rest is mandatory: when sync is requested but no valid encryption
+ * key is present, sync is refused (stays local-first) so plaintext content is
+ * never written to the cloud primary. See db/crypto.ts and ADR 0001.
  */
+import { hasValidEncryptionKey } from './crypto'
 
 export interface SyncConfig {
-  /** True only when NEEME_SYNC=on and NEEME_SYNC_URL is present. */
+  /** True only when NEEME_SYNC=on, NEEME_SYNC_URL is present, and a valid key is set. */
   enabled: boolean
   /** libSQL sync URL, e.g. libsql://<db>.turso.io */
   syncUrl?: string
@@ -20,6 +26,8 @@ export interface SyncConfig {
   authToken?: string
   /** Sync interval in milliseconds. Default 300 000 (5 minutes). */
   syncIntervalMs: number
+  /** When NEEME_SYNC=on but sync was refused, why (for logs + SyncStatus.error). */
+  disabledReason?: 'missing-url' | 'missing-or-invalid-key'
 }
 
 const MIN_INTERVAL_S = 10
@@ -44,7 +52,17 @@ export function getSyncConfig(): SyncConfig {
   const syncUrl = process.env.NEEME_SYNC_URL
   if (!syncUrl) {
     console.warn('[sync] NEEME_SYNC=on but NEEME_SYNC_URL is not set — sync disabled')
-    return { enabled: false, syncIntervalMs }
+    return { enabled: false, syncIntervalMs, disabledReason: 'missing-url' }
+  }
+
+  // Encryption at rest is required: never push plaintext content to the cloud.
+  // If the key is missing or malformed, fail closed — stay fully local-first.
+  if (!hasValidEncryptionKey()) {
+    console.error(
+      '[sync] refusing to enable sync without a valid NEEME_SYNC_ENCRYPTION_KEY ' +
+        '(64 hex chars) — staying local-first so plaintext is never written to the cloud'
+    )
+    return { enabled: false, syncIntervalMs, disabledReason: 'missing-or-invalid-key' }
   }
 
   return {

--- a/apps/desktop/src/main/worker/index.ts
+++ b/apps/desktop/src/main/worker/index.ts
@@ -25,11 +25,15 @@ type Handler = (args: unknown[]) => unknown | Promise<unknown>
 // Tracks sync lifecycle so sync:get-status can report it. Never throws —
 // sync failures are soft errors that must not affect the local-first path.
 
+const initialSyncConfig = getSyncConfig()
 let syncState: SyncStatus = {
-  enabled: getSyncConfig().enabled,
+  enabled: initialSyncConfig.enabled,
   lastSyncAt: null,
   syncing: false,
-  error: null
+  error:
+    initialSyncConfig.disabledReason === 'missing-or-invalid-key'
+      ? 'sync disabled: a valid NEEME_SYNC_ENCRYPTION_KEY is required for encryption at rest'
+      : null
 }
 
 async function runSyncNow(): Promise<void> {
@@ -105,15 +109,14 @@ async function start(): Promise<void> {
   await initDb()
 
   // ── Boot-time sync (before reindex so the first index sees pulled items) ──
-  const syncConfig = getSyncConfig()
-  if (syncConfig.enabled) {
+  if (initialSyncConfig.enabled) {
     await runSyncNow()
 
     // Periodic sync — in addition to the libSQL syncInterval background pull,
     // an explicit loop lets us update syncState and log status.
     const interval = setInterval(() => {
       runSyncNow().catch(() => {}) // errors are handled inside runSyncNow
-    }, syncConfig.syncIntervalMs)
+    }, initialSyncConfig.syncIntervalMs)
     interval.unref()
   }
 

--- a/apps/desktop/src/main/worker/index.ts
+++ b/apps/desktop/src/main/worker/index.ts
@@ -33,7 +33,9 @@ let syncState: SyncStatus = {
   error:
     initialSyncConfig.disabledReason === 'missing-or-invalid-key'
       ? 'sync disabled: a valid NEEME_SYNC_ENCRYPTION_KEY is required for encryption at rest'
-      : null
+      : initialSyncConfig.disabledReason === 'missing-url'
+        ? 'sync disabled: NEEME_SYNC_URL is not set'
+        : null
 }
 
 async function runSyncNow(): Promise<void> {

--- a/apps/desktop/test/services/sync-seam.test.ts
+++ b/apps/desktop/test/services/sync-seam.test.ts
@@ -49,7 +49,7 @@ describe('getSyncConfig', () => {
     expect(getSyncConfig().enabled).toBe(false)
   })
 
-  it('is disabled when NEEME_SYNC=on but NEEME_SYNC_URL is missing', () => {
+  it('is disabled when NEEME_SYNC=on but NEEME_SYNC_URL is missing, with disabledReason missing-url', () => {
     process.env.NEEME_SYNC = 'on'
     const cfg = getSyncConfig()
     expect(cfg.enabled).toBe(false)
@@ -133,6 +133,11 @@ describe('encrypt / decrypt', () => {
   it('is a no-op pass-through when the key is not set', () => {
     expect(encrypt('hello world')).toBe('hello world')
     expect(decrypt('hello world')).toBe('hello world')
+  })
+
+  it('throws a clear error when the key is 64 chars but non-hex (resolveKey validation parity)', () => {
+    process.env[KEY_ENV] = 'g'.repeat(64) // 64 chars, all non-hex
+    expect(() => encrypt('anything')).toThrow(/non-hex|must be 64 hex/)
   })
 
   it('leaves non-encrypted values alone when decrypting (key present)', () => {

--- a/apps/desktop/test/services/sync-seam.test.ts
+++ b/apps/desktop/test/services/sync-seam.test.ts
@@ -6,12 +6,21 @@
  */
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import { getSyncConfig } from '../../src/main/db/sync-config'
-import { encrypt, decrypt, generateKey } from '../../src/main/db/crypto'
+import { encrypt, decrypt, generateKey, hasValidEncryptionKey } from '../../src/main/db/crypto'
 
 // ── Sync config seam ──────────────────────────────────────────────────────
 
 describe('getSyncConfig', () => {
-  const envKeys = ['NEEME_SYNC', 'NEEME_SYNC_URL', 'NEEME_SYNC_AUTH_TOKEN', 'NEEME_SYNC_INTERVAL_S']
+  const envKeys = [
+    'NEEME_SYNC',
+    'NEEME_SYNC_URL',
+    'NEEME_SYNC_AUTH_TOKEN',
+    'NEEME_SYNC_INTERVAL_S',
+    'NEEME_SYNC_ENCRYPTION_KEY'
+  ]
+
+  // A valid 64-hex (32-byte) key — sync now requires one to enable.
+  const VALID_KEY = 'a'.repeat(64)
 
   // Snapshot env before each test; restore after.
   let saved: Record<string, string | undefined> = {}
@@ -42,15 +51,43 @@ describe('getSyncConfig', () => {
 
   it('is disabled when NEEME_SYNC=on but NEEME_SYNC_URL is missing', () => {
     process.env.NEEME_SYNC = 'on'
-    expect(getSyncConfig().enabled).toBe(false)
+    const cfg = getSyncConfig()
+    expect(cfg.enabled).toBe(false)
+    expect(cfg.disabledReason).toBe('missing-url')
   })
 
-  it('is enabled when NEEME_SYNC=on and NEEME_SYNC_URL is set', () => {
+  it('is disabled when NEEME_SYNC=on + URL set but NEEME_SYNC_ENCRYPTION_KEY is missing', () => {
     process.env.NEEME_SYNC = 'on'
     process.env.NEEME_SYNC_URL = 'libsql://test.turso.io'
     const cfg = getSyncConfig()
+    expect(cfg.enabled).toBe(false)
+    expect(cfg.disabledReason).toBe('missing-or-invalid-key')
+  })
+
+  it('is disabled when the encryption key is the wrong length', () => {
+    process.env.NEEME_SYNC = 'on'
+    process.env.NEEME_SYNC_URL = 'libsql://test.turso.io'
+    process.env.NEEME_SYNC_ENCRYPTION_KEY = 'abc123'
+    const cfg = getSyncConfig()
+    expect(cfg.enabled).toBe(false)
+    expect(cfg.disabledReason).toBe('missing-or-invalid-key')
+  })
+
+  it('is disabled when the encryption key is 64 chars but not hex', () => {
+    process.env.NEEME_SYNC = 'on'
+    process.env.NEEME_SYNC_URL = 'libsql://test.turso.io'
+    process.env.NEEME_SYNC_ENCRYPTION_KEY = 'z'.repeat(64)
+    expect(getSyncConfig().enabled).toBe(false)
+  })
+
+  it('is enabled when NEEME_SYNC=on, NEEME_SYNC_URL, and a valid encryption key are all set', () => {
+    process.env.NEEME_SYNC = 'on'
+    process.env.NEEME_SYNC_URL = 'libsql://test.turso.io'
+    process.env.NEEME_SYNC_ENCRYPTION_KEY = VALID_KEY
+    const cfg = getSyncConfig()
     expect(cfg.enabled).toBe(true)
     expect(cfg.syncUrl).toBe('libsql://test.turso.io')
+    expect(cfg.disabledReason).toBeUndefined()
   })
 
   it('uses default 5-minute interval when NEEME_SYNC_INTERVAL_S is absent', () => {
@@ -71,7 +108,9 @@ describe('getSyncConfig', () => {
     process.env.NEEME_SYNC = 'on'
     process.env.NEEME_SYNC_URL = 'libsql://test.turso.io'
     process.env.NEEME_SYNC_AUTH_TOKEN = 'tok_abc'
+    process.env.NEEME_SYNC_ENCRYPTION_KEY = VALID_KEY
     const cfg = getSyncConfig()
+    expect(cfg.enabled).toBe(true)
     expect(cfg.authToken).toBe('tok_abc')
   })
 })
@@ -142,5 +181,41 @@ describe('encrypt / decrypt', () => {
     const result = decrypt(encryptedWithKey1)
     // Should return the raw encrypted string (not throw, not return plaintext).
     expect(result).toBe(encryptedWithKey1)
+  })
+})
+
+// ── Encryption key validator (sync gate) ──────────────────────────────────
+
+describe('hasValidEncryptionKey', () => {
+  const KEY_ENV = 'NEEME_SYNC_ENCRYPTION_KEY'
+  let savedKey: string | undefined
+  beforeEach(() => {
+    savedKey = process.env[KEY_ENV]
+    delete process.env[KEY_ENV]
+  })
+  afterEach(() => {
+    if (savedKey === undefined) delete process.env[KEY_ENV]
+    else process.env[KEY_ENV] = savedKey
+  })
+
+  it('is false when the key is absent', () => {
+    expect(hasValidEncryptionKey()).toBe(false)
+  })
+
+  it('is false when the key is the wrong length', () => {
+    process.env[KEY_ENV] = 'deadbeef'
+    expect(hasValidEncryptionKey()).toBe(false)
+  })
+
+  it('is false when the key is 64 chars but not hex', () => {
+    process.env[KEY_ENV] = 'z'.repeat(64)
+    expect(hasValidEncryptionKey()).toBe(false)
+  })
+
+  it('is true for a valid 64-hex key (incl. generateKey output)', () => {
+    process.env[KEY_ENV] = 'A'.repeat(64) // hex is case-insensitive
+    expect(hasValidEncryptionKey()).toBe(true)
+    process.env[KEY_ENV] = generateKey()
+    expect(hasValidEncryptionKey()).toBe(true)
   })
 })

--- a/apps/desktop/test/smoke/sync-live.ts
+++ b/apps/desktop/test/smoke/sync-live.ts
@@ -103,18 +103,25 @@ async function deviceB(): Promise<void> {
 /** Gate check (no creds needed): NEEME_SYNC=on without a valid key must stay local. */
 async function gateCheck(): Promise<void> {
   const saved = {
-    on: process.env.NEEME_SYNC,
-    url: process.env.NEEME_SYNC_URL,
-    key: process.env.NEEME_SYNC_ENCRYPTION_KEY
+    NEEME_SYNC: process.env.NEEME_SYNC,
+    NEEME_SYNC_URL: process.env.NEEME_SYNC_URL,
+    NEEME_SYNC_ENCRYPTION_KEY: process.env.NEEME_SYNC_ENCRYPTION_KEY
   }
+  // Restore env exactly — assigning `undefined` to process.env stringifies it to
+  // "undefined" (truthy), which would later fool hasCreds(); delete instead.
+  const restoreEnv = (): void => {
+    for (const [k, v] of Object.entries(saved)) {
+      if (v === undefined) delete process.env[k]
+      else process.env[k] = v
+    }
+  }
+
   process.env.NEEME_SYNC = 'on'
   process.env.NEEME_SYNC_URL = 'libsql://gate-check.invalid.turso.io'
   delete process.env.NEEME_SYNC_ENCRYPTION_KEY
   const { getSyncConfig } = await import('../../src/main/db/sync-config')
   const cfg = getSyncConfig()
-  process.env.NEEME_SYNC = saved.on
-  process.env.NEEME_SYNC_URL = saved.url
-  if (saved.key !== undefined) process.env.NEEME_SYNC_ENCRYPTION_KEY = saved.key
+  restoreEnv()
   const ok = cfg.enabled === false && cfg.disabledReason === 'missing-or-invalid-key'
   console.log(
     `[gate] on + url + no key => enabled=${cfg.enabled} reason=${cfg.disabledReason} (${ok ? 'PASS' : 'FAIL'})`

--- a/apps/desktop/test/smoke/sync-live.ts
+++ b/apps/desktop/test/smoke/sync-live.ts
@@ -60,8 +60,12 @@ async function deviceA(): Promise<void> {
   await initDb()
   await syncNow()
   const cap = await pipelineService.captureText(NOTE, SOURCE)
-  await todoService.add(TODO_TITLE)
+  const todo = await todoService.add(TODO_TITLE)
   await syncNow()
+  // Emit machine-parseable ids so the orchestrator can clean up afterward.
+  // (todos.title is encrypted at rest, so cleanup must target the id, not the title.)
+  console.log(`[A] itemId=${cap.memory.id}`)
+  console.log(`[A] todoId=${todo.id}`)
   console.log(`[A] captured + pushed item ${cap.memory.id}`)
 }
 
@@ -118,16 +122,22 @@ async function gateCheck(): Promise<void> {
   if (!ok) process.exit(1)
 }
 
-/** Spawn this script in a child process for one "device" with an isolated data dir. */
-function runChild(childMode: string, userDataDir: string): void {
+/**
+ * Spawn this script in a child process for one "device" with an isolated data dir.
+ * Captures stdout (and echoes it) so the orchestrator can parse ids for cleanup.
+ */
+function runChild(childMode: string, userDataDir: string): string {
   const res = spawnSync('pnpm', ['exec', 'tsx', __filename, childMode], {
-    stdio: 'inherit',
+    stdio: ['inherit', 'pipe', 'inherit'],
+    encoding: 'utf8',
     env: { ...process.env, NEEME_USER_DATA: userDataDir, NEEME_EMBEDDER: 'hash', SYNC_NONCE: NONCE }
   })
+  if (res.stdout) process.stdout.write(res.stdout)
   if (res.status !== 0) {
     console.error(`[orchestrate] child "${childMode}" failed (exit ${res.status})`)
     process.exit(1)
   }
+  return res.stdout ?? ''
 }
 
 async function orchestrate(): Promise<void> {
@@ -145,22 +155,26 @@ async function orchestrate(): Promise<void> {
 
   const dirA = mkdtempSync(join(tmpdir(), 'nimi-sync-a-'))
   const dirB = mkdtempSync(join(tmpdir(), 'nimi-sync-b-'))
+  let todoId: string | undefined
   try {
     console.log('\n-- Device A: capture + push --')
-    runChild('a', dirA)
+    const outA = runChild('a', dirA)
+    todoId = /\[A\] todoId=([\w-]+)/.exec(outA)?.[1]
     console.log('\n-- Remote primary: at-rest check --')
     runChild('primary', mkdtempSync(join(tmpdir(), 'nimi-sync-p-')))
     console.log('\n-- Device B: pull + decrypt + search --')
     runChild('b', dirB)
     console.log('\n✓ PASS — encrypted note + todo synced A → primary (ciphertext) → B (decrypted).')
   } finally {
+    // Clean up this run's rows. items match on source_name (plaintext metadata);
+    // todos must match on id, since todos.title is encrypted at rest.
     const c = remoteClient()
     await c
       .execute({ sql: 'DELETE FROM items WHERE source_name = ?', args: [SOURCE] })
       .catch(() => {})
-    await c
-      .execute({ sql: 'DELETE FROM todos WHERE title LIKE ?', args: [`%${NONCE}%`] })
-      .catch(() => {})
+    if (todoId) {
+      await c.execute({ sql: 'DELETE FROM todos WHERE id = ?', args: [todoId] }).catch(() => {})
+    }
     console.log('[orchestrate] cleaned up this run’s rows from the primary.')
   }
 }

--- a/apps/desktop/test/smoke/sync-live.ts
+++ b/apps/desktop/test/smoke/sync-live.ts
@@ -1,0 +1,181 @@
+/**
+ * Live sync + encryption-at-rest smoke (ROADMAP #10).
+ *
+ * Verifies the two guarantees that matter most for cloud sync:
+ *   1. Encryption at rest — content written to the Turso primary is ciphertext.
+ *   2. Cross-device replica — a second, independent replica pulls + decrypts it.
+ * Plus the fail-closed gate: NEEME_SYNC=on without a valid key stays local.
+ *
+ * No credentials? The script still runs the gate check and exits 0 (the live
+ * loop is skipped with a clear note) so it's safe to run anywhere.
+ *
+ * Run (gate-only, no creds needed):
+ *   pnpm --filter @nimi/desktop test:smoke:sync
+ *
+ * Run the full two-device loop (set all four, see docs/setup/turso-credentials.md):
+ *   NEEME_SYNC=on \
+ *   NEEME_SYNC_URL=libsql://<db>.turso.io \
+ *   NEEME_SYNC_AUTH_TOKEN=<token> \
+ *   NEEME_SYNC_ENCRYPTION_KEY=<64-hex> \
+ *   pnpm --filter @nimi/desktop test:smoke:sync
+ *
+ * Internals: the db layer builds its libSQL client once per process from the env,
+ * so each "device" is a separate child process with its own NEEME_USER_DATA. The
+ * top-level (no-arg) invocation orchestrates the children and asserts the result.
+ */
+import { spawnSync } from 'node:child_process'
+import { mkdtempSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { createClient } from '@libsql/client'
+
+const mode = process.argv[2] ?? 'orchestrate'
+const NONCE = process.env.SYNC_NONCE ?? `smoke-${Date.now()}`
+const SOURCE = `sync-live-${NONCE}.txt`
+const NOTE = `Sync-live note ${NONCE}: buy oat milk and book a dentist appointment`
+const TODO_TITLE = `Sync-live todo ${NONCE}: file quarterly taxes`
+
+const KEY_HEX = /^[0-9a-f]{64}$/i
+function hasCreds(): boolean {
+  return (
+    process.env.NEEME_SYNC === 'on' &&
+    !!process.env.NEEME_SYNC_URL &&
+    !!process.env.NEEME_SYNC_AUTH_TOKEN &&
+    KEY_HEX.test(process.env.NEEME_SYNC_ENCRYPTION_KEY ?? '')
+  )
+}
+
+function remoteClient(): ReturnType<typeof createClient> {
+  return createClient({
+    url: process.env.NEEME_SYNC_URL!,
+    authToken: process.env.NEEME_SYNC_AUTH_TOKEN
+  })
+}
+
+/** Device A: boot like the worker, capture a note + todo, push to the primary. */
+async function deviceA(): Promise<void> {
+  const { initDb, syncNow } = await import('../../src/main/db/index')
+  const { pipelineService } = await import('../../src/main/services/pipeline-service')
+  const { todoService } = await import('../../src/main/services/todo-service')
+  await initDb()
+  await syncNow()
+  const cap = await pipelineService.captureText(NOTE, SOURCE)
+  await todoService.add(TODO_TITLE)
+  await syncNow()
+  console.log(`[A] captured + pushed item ${cap.memory.id}`)
+}
+
+/** Inspect the remote primary directly — proves ciphertext at rest. */
+async function primaryCheck(): Promise<void> {
+  const c = remoteClient()
+  const r = await c.execute({ sql: 'SELECT text FROM items WHERE source_name = ?', args: [SOURCE] })
+  const stored = String(r.rows[0]?.text ?? '')
+  const enc = stored.startsWith('enc:')
+  console.log(`[primary] item present: ${r.rows.length === 1} | ciphertext: ${enc}`)
+  console.log(`[primary] stored: ${stored.slice(0, 48)}${stored.length > 48 ? '…' : ''}`)
+  if (r.rows.length !== 1 || !enc) process.exit(1)
+}
+
+/** Device B: a fresh, separate replica pulls, decrypts, reindexes, and searches. */
+async function deviceB(): Promise<void> {
+  const { initDb, syncNow } = await import('../../src/main/db/index')
+  const { pipelineService } = await import('../../src/main/services/pipeline-service')
+  const { todoService } = await import('../../src/main/services/todo-service')
+  await initDb()
+  await syncNow()
+  await pipelineService.reindexAll()
+  const items = await pipelineService.listItems()
+  const mine = items.find((i) => i.text === NOTE)
+  const hits = await pipelineService.match('dentist appointment and milk', 5)
+  const topIsMine = !!mine && hits.length > 0 && hits[0]!.id === mine.id
+  const tasks = [...(await todoService.today()), ...(await todoService.backlog())]
+  const myTodo = tasks.find((t) => t.title === TODO_TITLE)
+  console.log(
+    `[B] decrypted note: ${!!mine} | search top-hit is note: ${topIsMine} | decrypted todo: ${!!myTodo}`
+  )
+  if (!mine || !topIsMine || !myTodo) process.exit(1)
+}
+
+/** Gate check (no creds needed): NEEME_SYNC=on without a valid key must stay local. */
+async function gateCheck(): Promise<void> {
+  const saved = {
+    on: process.env.NEEME_SYNC,
+    url: process.env.NEEME_SYNC_URL,
+    key: process.env.NEEME_SYNC_ENCRYPTION_KEY
+  }
+  process.env.NEEME_SYNC = 'on'
+  process.env.NEEME_SYNC_URL = 'libsql://gate-check.invalid.turso.io'
+  delete process.env.NEEME_SYNC_ENCRYPTION_KEY
+  const { getSyncConfig } = await import('../../src/main/db/sync-config')
+  const cfg = getSyncConfig()
+  process.env.NEEME_SYNC = saved.on
+  process.env.NEEME_SYNC_URL = saved.url
+  if (saved.key !== undefined) process.env.NEEME_SYNC_ENCRYPTION_KEY = saved.key
+  const ok = cfg.enabled === false && cfg.disabledReason === 'missing-or-invalid-key'
+  console.log(
+    `[gate] on + url + no key => enabled=${cfg.enabled} reason=${cfg.disabledReason} (${ok ? 'PASS' : 'FAIL'})`
+  )
+  if (!ok) process.exit(1)
+}
+
+/** Spawn this script in a child process for one "device" with an isolated data dir. */
+function runChild(childMode: string, userDataDir: string): void {
+  const res = spawnSync('pnpm', ['exec', 'tsx', __filename, childMode], {
+    stdio: 'inherit',
+    env: { ...process.env, NEEME_USER_DATA: userDataDir, NEEME_EMBEDDER: 'hash', SYNC_NONCE: NONCE }
+  })
+  if (res.status !== 0) {
+    console.error(`[orchestrate] child "${childMode}" failed (exit ${res.status})`)
+    process.exit(1)
+  }
+}
+
+async function orchestrate(): Promise<void> {
+  console.log(`=== sync-live (#10): encryption-at-rest + two-device replica ===\nnonce: ${NONCE}`)
+  await gateCheck()
+
+  if (!hasCreds()) {
+    console.log(
+      '\n[orchestrate] no Turso creds set — skipping the live two-device loop.\n' +
+        '  Set NEEME_SYNC=on + NEEME_SYNC_URL + NEEME_SYNC_AUTH_TOKEN + NEEME_SYNC_ENCRYPTION_KEY\n' +
+        '  (see docs/setup/turso-credentials.md) to run it. Gate check passed; exiting 0.'
+    )
+    return
+  }
+
+  const dirA = mkdtempSync(join(tmpdir(), 'nimi-sync-a-'))
+  const dirB = mkdtempSync(join(tmpdir(), 'nimi-sync-b-'))
+  try {
+    console.log('\n-- Device A: capture + push --')
+    runChild('a', dirA)
+    console.log('\n-- Remote primary: at-rest check --')
+    runChild('primary', mkdtempSync(join(tmpdir(), 'nimi-sync-p-')))
+    console.log('\n-- Device B: pull + decrypt + search --')
+    runChild('b', dirB)
+    console.log('\n✓ PASS — encrypted note + todo synced A → primary (ciphertext) → B (decrypted).')
+  } finally {
+    const c = remoteClient()
+    await c
+      .execute({ sql: 'DELETE FROM items WHERE source_name = ?', args: [SOURCE] })
+      .catch(() => {})
+    await c
+      .execute({ sql: 'DELETE FROM todos WHERE title LIKE ?', args: [`%${NONCE}%`] })
+      .catch(() => {})
+    console.log('[orchestrate] cleaned up this run’s rows from the primary.')
+  }
+}
+
+async function main(): Promise<void> {
+  if (mode === 'a') await deviceA()
+  else if (mode === 'b') await deviceB()
+  else if (mode === 'primary') await primaryCheck()
+  else if (mode === 'gate') await gateCheck()
+  else await orchestrate()
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((err: unknown) => {
+    console.error('[sync-live] threw:', err instanceof Error ? err.message : err)
+    process.exit(1)
+  })

--- a/docs/setup/turso-credentials.md
+++ b/docs/setup/turso-credentials.md
@@ -51,7 +51,12 @@ turso db tokens create nimi-test --expiration 7d
 
 Tokens expire. For longer spikes use `--expiration 30d` or `never` (rotate manually).
 
-### 5. (Optional) Encryption key
+### 5. Encryption key (REQUIRED)
+
+Sync now **refuses to enable** without a valid `NEEME_SYNC_ENCRYPTION_KEY` (64 hex
+chars). This guarantees encryption at rest — plaintext content is never written to the
+cloud primary. If the key is missing or malformed, the app stays fully local-first and
+reports the reason in sync status.
 
 Generate a fresh 32-byte key for at-rest field encryption:
 
@@ -72,13 +77,11 @@ means the encrypted rows on the cloud primary cannot be decrypted.
 Add these to your shell (or `.env.local`, or an Electron launch config):
 
 ```sh
-# Required to enable sync
+# Required to enable sync (all four — sync fails closed if the key is missing/invalid)
 NEEME_SYNC=on
 NEEME_SYNC_URL=libsql://nimi-test-<org>.turso.io    # from step 3
 NEEME_SYNC_AUTH_TOKEN=eyJ...                         # from step 4
-
-# Optional: at-rest field encryption (strongly recommended before any real data)
-NEEME_SYNC_ENCRYPTION_KEY=<64-hex-chars>             # from step 5
+NEEME_SYNC_ENCRYPTION_KEY=<64-hex-chars>             # from step 5 (mandatory)
 
 # Optional: sync interval (default 300 s = 5 min)
 NEEME_SYNC_INTERVAL_S=60
@@ -90,6 +93,7 @@ Then launch the app:
 NEEME_SYNC=on \
 NEEME_SYNC_URL=libsql://nimi-test-<org>.turso.io \
 NEEME_SYNC_AUTH_TOKEN=eyJ... \
+NEEME_SYNC_ENCRYPTION_KEY=<64-hex-chars> \
 NEEME_EMBEDDER=hash \
 pnpm dev
 ```
@@ -104,7 +108,8 @@ pnpm dev
    turso db shell nimi-test "SELECT id, source_name FROM items LIMIT 5;"
    ```
 3. **Device B** — launch with the **same** `NEEME_SYNC_URL` + `NEEME_SYNC_AUTH_TOKEN`
-   (+ same `NEEME_SYNC_ENCRYPTION_KEY` if using encryption). On boot the worker calls
+   + the **same** `NEEME_SYNC_ENCRYPTION_KEY` (required, and it must match Device A or the
+   pulled rows cannot be decrypted). On boot the worker calls
    `syncNow()` which pulls from the primary. The note from Device A should appear in
    the archive feed.
 4. Confirm Device B can search semantically — `reindexAll()` runs via `syncEmbedder()`

--- a/docs/testing/sync-encryption-runbook.md
+++ b/docs/testing/sync-encryption-runbook.md
@@ -1,0 +1,111 @@
+# Runbook — sync + encryption at rest (ROADMAP #10)
+
+How to verify that opt-in Turso sync works **and** that content is encrypted at rest on
+the cloud primary. This is the highest-stakes piece of #10: when sync is enabled, personal
+content must never leave the device as plaintext.
+
+There are two tiers. Tier 1 needs no credentials and runs anywhere. Tier 2 is the live
+two-device replica loop and needs a Turso database.
+
+---
+
+## What "working properly" means
+
+| Guarantee | How it's enforced | How this runbook proves it |
+|---|---|---|
+| **Fail closed** — `NEEME_SYNC=on` without a valid key never syncs | `getSyncConfig()` returns `enabled:false` + `disabledReason:'missing-or-invalid-key'` | Tier 1 gate check |
+| **Encryption at rest** — the cloud primary holds ciphertext, not plaintext | `items.text`, `todos.title`, `todos.notes` wrapped by AES-256-GCM (`db/crypto.ts`) | Tier 2 `[primary] ciphertext: true` |
+| **Cross-device** — a second replica pulls and decrypts | embedded-replica `client.sync()` + same key | Tier 2 `[B] decrypted note: true` |
+| **Search after sync** — vector index rebuilds from synced rows | worker `reindexAll()` on boot | Tier 2 `search top-hit is note: true` |
+| **Local-first never breaks** — sync failures are soft | worker `runSyncNow()` try/catch; decrypt returns raw on bad key | warnings, never a crash |
+
+---
+
+## Tier 1 — gate check (no credentials, ~1 s)
+
+Confirms the fail-closed behavior: with sync requested but no valid key, the app stays
+fully local and makes no network calls.
+
+```bash
+pnpm --filter @nimi/desktop test:smoke:sync
+```
+
+Expected tail:
+
+```
+[gate] on + url + no key => enabled=false reason=missing-or-invalid-key (PASS)
+[orchestrate] no Turso creds set — skipping the live two-device loop. … exiting 0.
+```
+
+Also run the unit suite (16+ sync-seam tests, incl. the key validator):
+
+```bash
+pnpm --filter @nimi/desktop test
+```
+
+---
+
+## Tier 2 — live two-device replica loop
+
+### Prerequisites
+
+A Turso database + token + encryption key. Follow **`docs/setup/turso-credentials.md`**
+steps 1–5, then export all four (the key is **mandatory** — sync refuses to enable
+without it):
+
+```bash
+export NEEME_SYNC=on
+export NEEME_SYNC_URL=libsql://<db>.turso.io          # turso db show <db> --url
+export NEEME_SYNC_AUTH_TOKEN=<token>                  # turso db tokens create <db>
+export NEEME_SYNC_ENCRYPTION_KEY=<64-hex>             # generateKey() — see step 5
+```
+
+> Running as a **cloud agent**? Put these in the Cursor Dashboard → **Cloud Agents →
+> Secrets** instead of exporting them. They inject as env vars into new agent VMs (and are
+> redacted in logs), so a fresh agent can run this runbook hands-off.
+
+### Run it (one command)
+
+```bash
+pnpm --filter @nimi/desktop test:smoke:sync
+```
+
+The script spawns two isolated replicas (separate `NEEME_USER_DATA` dirs, mirroring two
+devices): **Device A** captures a note + todo and pushes; the **primary** is inspected
+directly to prove ciphertext; **Device B** boots fresh, pulls, decrypts, reindexes, and
+searches. It cleans up its own rows from the primary afterward.
+
+### Expected output (success)
+
+```
+-- Device A: capture + push --
+[A] captured + pushed item <id>
+-- Remote primary: at-rest check --
+[primary] item present: true | ciphertext: true
+[primary] stored: enc:<iv>:<tag>:<ciphertext>…
+-- Device B: pull + decrypt + search --
+[B] decrypted note: true | search top-hit is note: true | decrypted todo: true
+✓ PASS — encrypted note + todo synced A → primary (ciphertext) → B (decrypted).
+```
+
+The exit code is `0` on PASS, non-zero on any failed assertion.
+
+### Manual two-device variant (optional)
+
+To watch the loop across two real app instances, launch the Electron app twice with the
+same four env vars but different `--user-data-dir`, capture a note in one, and confirm it
+appears in the other's archive (see `docs/setup/turso-credentials.md` §"Smoke test").
+
+---
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `enabled=false reason=missing-or-invalid-key` while you expect sync on | `NEEME_SYNC_ENCRYPTION_KEY` missing or not 64-hex | regenerate with `generateKey()`; export the full 64-hex value |
+| `Replication(PrimaryHandshakeTimeout)` / `replicator sync error` | bad/expired token, wrong URL, or no network | rotate the token (`turso db tokens create`), recheck `NEEME_SYNC_URL` |
+| `[crypto] decrypt failed (wrong key or corrupt data)` warnings | rows on the primary were encrypted with a **different** key | use the same key across devices; warnings are non-fatal (raw value returned) |
+| `[primary] ciphertext: false` | sync ran without a key (older build) or key was unset on Device A | ensure the key is set before capturing; wipe + retry |
+
+> The "wrong key" warning is by design: `decrypt()` never throws on bad data — it returns
+> the raw value and logs, so a key mismatch degrades gracefully instead of crashing.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Follow-up to #10 (Turso sync seam + AES-256-GCM field encryption). The encryption key was **optional** — `NEEME_SYNC=on` with no `NEEME_SYNC_ENCRYPTION_KEY` would silently sync **plaintext** content to the cloud primary. Product decision: we want encryption at rest, so make it mandatory and enforce it in code, with a documented way to verify it.

## What changed

**1. Enforce encryption at rest (fail closed).** `NEEME_SYNC=on` enables the embedded-replica path only when a valid 64-hex `NEEME_SYNC_ENCRYPTION_KEY` is present. A missing/malformed key keeps the app fully local-first (no network), and the reason surfaces in `SyncStatus.error`.

- `db/crypto.ts` — non-throwing `hasValidEncryptionKey()` (presence + 64-hex).
- `db/sync-config.ts` — gate `enabled` on the key; add `disabledReason` to `SyncConfig`.
- `worker/index.ts` — seed `SyncStatus.error` when sync is refused; reuse boot config.

**2. Verification tooling + docs.**
- `test/smoke/sync-live.ts` + `test:smoke:sync` — one command. Gate check needs no creds; with creds it runs the full two-device loop (A capture+push → primary ciphertext check → fresh replica B pull+decrypt+search) and cleans up its rows.
- `docs/testing/sync-encryption-runbook.md` — Tier 1 gate check, Tier 2 live loop, expected output, troubleshooting, cloud-agent secret guidance.
- `test/services/sync-seam.test.ts` — enforce-key cases + `hasValidEncryptionKey()` coverage.
- `docs/setup/turso-credentials.md` — key documented as required, not optional.
- `AGENTS.md` — references the runbook + commands.

No `@nimi/contract` change — `SyncStatus.error: string | null` already exists. Entirely back-lane.

## Behavior matrix

| `NEEME_SYNC` | URL | key | result |
|---|---|---|---|
| unset | — | — | local-first (unchanged) |
| `on` | missing | — | disabled (`missing-url`) |
| `on` | set | missing/invalid | **disabled (`missing-or-invalid-key`), no network** |
| `on` | set | valid 64-hex | enabled (encrypted sync) |

## Testing

One-command two-device loop (gate → A → primary ciphertext → B decrypt+search), run against a real Turso primary:
[sync_live_two_device.log](https://cursor.com/agents/bc-81f3fad4-0487-4010-82c9-fe629f003cd9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsync_live_two_device.log)

Fail-closed gate (A: no key → no network; B: invalid key → disabled; C: valid key → enabled):
[sync_encryption_enforced.log](https://cursor.com/agents/bc-81f3fad4-0487-4010-82c9-fe629f003cd9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsync_encryption_enforced.log)

- ✅ `pnpm --filter @nimi/desktop test` — 240/240 (7 new)
- ✅ `pnpm typecheck`
- ✅ `eslint` on changed files — clean
- ✅ `test:smoke:sync` gate-only path (no creds) — PASS, exit 0
- ✅ `test:smoke:sync` full two-device loop vs real Turso primary — PASS (ciphertext at rest, cross-device decrypt + semantic search)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-81f3fad4-0487-4010-82c9-fe629f003cd9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-81f3fad4-0487-4010-82c9-fe629f003cd9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

