### PR TITLE
test: add CSP e2e suite, CI workflow, and GUI smoke runbooks

### DIFF
--- a/.cursor/skills/gui-smoke/SKILL.md
+++ b/.cursor/skills/gui-smoke/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: gui-smoke
+description: >-
+  Smoke-test a nimi desktop (Electron) feature end-to-end and produce
+  reviewable artifacts (screenshot + short video) plus a pass/fail report. Use
+  when asked to "smoke test", "follow the runbook", "verify this PR in the UI",
+  or to test any GUI-facing change in apps/desktop. Encodes the standing SOP so
+  the agent does not need the procedure re-pasted each run.
+paths:
+  - apps/desktop/**
+  - docs/testing/**
+---
+
+# GUI smoke (nimi desktop)
+
+The SOP for verifying a GUI-facing change in the Electron app and returning
+consistent evidence. Two tiers: a deterministic tier that just passes/fails,
+and a visual tier that produces a screenshot + a short demo video.
+
+## 0. Orient
+
+- Read `AGENTS.md` (root) → "Cursor Cloud specific instructions" and the
+  "GUI feature tests" runbook table. If a runbook in `docs/testing/` matches the
+  feature under test, follow it; it is the source of truth for steps + artifacts.
+- Default offline env for every command below: `NEEME_EMBEDDER=hash`
+  (skips the model download). Add `NEEME_EXTRACTOR=off` for capture/CSP smokes.
+- If the Electron binary is missing (`Error: Electron uninstall`), run once:
+  `node node_modules/electron/install.js`.
+
+## 1. Deterministic tier (always run first — no judgement)
+
+```bash
+pnpm typecheck && pnpm --filter @nimi/desktop build
+xvfb-run -a -s "-screen 0 1280x1024x24" pnpm --filter @nimi/desktop test:e2e
+```
+
+If a spec exists for the feature (e.g. `test/e2e/csp.spec.ts`), this is the
+authoritative check. A failure here is a hard stop — fix it before the visual
+tier. If you add behaviour that can be asserted programmatically, add/extend an
+`_electron` spec under `apps/desktop/test/e2e/` rather than relying on eyeballs.
+
+## 2. Visual tier (the judgement + artifacts half)
+
+Launch the app: `NEEME_EMBEDDER=hash pnpm dev` (wait for the Vite line + the
+Electron window). Then follow the matching runbook's GUI steps.
+
+Capture exactly what the runbook's "Artifacts to capture" section lists —
+typically:
+- one **screenshot** of the relevant rendered screen, and
+- one **short screen recording** of the behaviour working end-to-end.
+
+Save artifacts to `/opt/cursor/artifacts/` and reference them in the report.
+
+### Gotcha: DevTools / off-screen window
+
+The tray-anchored window can spawn off-screen in headless VMs, so driving
+DevTools via the GUI (F12) is unreliable. To inspect the renderer
+deterministically, prefer the `_electron` spec (tier 1). If you must capture
+runtime console / CSP data from a live `pnpm dev`, temporarily add a
+`webContents.on('console-message', …)` forwarder + a `did-finish-load`
+`executeJavaScript` probe in `apps/desktop/src/main/index.ts` (it logs to the
+dev terminal and survives the off-screen window), and a `webContents.capturePage()`
+to grab a screenshot of the real renderer. **Revert this instrumentation before
+committing.**
+
+## 3. Report
+
+Return a terse report: each command prefixed ✅ / ⚠️ / ❌, the pass/fail of the
+deterministic tier, and inline `<img>` / `<video>` references to the captured
+artifacts. State explicitly if any expected artifact could not be produced and why.
+
+## 4. Don't
+
+- Don't loosen the security invariants in `docs/SECURITY.md` to make a test pass.
+- Don't commit temporary debug instrumentation.
+- Don't claim a clean result from code reading alone — the evidence must come
+  from actually running the app (test output, terminal logs, or screenshots).

--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -1,0 +1,77 @@
+name: Desktop E2E smoke
+
+# Deterministic, no-human tier of our GUI runbooks: builds the Electron app and
+# runs the Playwright `_electron` smoke suite (CSP + local fonts + capture-file)
+# headlessly under Xvfb. This is the half of "follow the runbook" that needs no
+# agent and no judgement — it just passes or fails on every PR.
+#
+# The visual/judgement half (screenshots + demo video) is handled separately by
+# a Cursor Automation that launches a cloud agent on PR events; see
+# docs/testing/automation-setup.md.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'apps/desktop/**'
+      - 'packages/contract/**'
+      - '.github/workflows/e2e-smoke.yml'
+  pull_request:
+    paths:
+      - 'apps/desktop/**'
+      - 'packages/contract/**'
+      - '.github/workflows/e2e-smoke.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: e2e-smoke-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      # Skip the ONNX/MiniLM model download — the smoke suite never needs the
+      # real embedder, and the network fetch is slow + flaky in CI.
+      NEEME_EMBEDDER: hash
+      NEEME_EXTRACTOR: off
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Electron/Chromium system libraries + Xvfb
+        # Electron shares Chromium's shared-library set; `playwright install-deps
+        # chromium` resolves the right apt packages across Ubuntu versions so we
+        # don't hand-maintain a brittle libnss3/libgbm1/... list.
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y xvfb
+          pnpm --filter @nimi/desktop exec playwright install-deps chromium
+
+      - name: Build desktop app
+        run: pnpm --filter @nimi/desktop build
+
+      - name: Run Electron E2E smoke (Xvfb)
+        run: xvfb-run -a -s "-screen 0 1280x1024x24" pnpm --filter @nimi/desktop test:e2e
+
+      - name: Upload Playwright artifacts on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-results
+          path: apps/desktop/test-results/
+          retention-days: 7
+          if-no-files-found: ignore

--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -27,6 +27,9 @@ concurrency:
   group: e2e-smoke-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   e2e:
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,6 +91,14 @@ Features that require `NEEME_ANTHROPIC_KEY` + a display are covered by runbooks 
 | Runbook | Feature | Needs |
 |---|---|---|
 | `docs/testing/uncovered-todos-gui-runbook.md` | Feed → "I spotted these to-dos" | `NEEME_ANTHROPIC_KEY`, `DISPLAY` |
+| `docs/testing/csp-smoke-runbook.md` | CSP hardening + local fonts (#11) | `DISPLAY` (deterministic tier needs neither) |
+
+Runbooks follow `docs/testing/RUNBOOK-TEMPLATE.md`; the `gui-smoke` skill
+(`.cursor/skills/gui-smoke/SKILL.md`) is the SOP for running them + capturing
+artifacts. The deterministic tier (`pnpm --filter @nimi/desktop test:e2e` under
+Xvfb) runs automatically on PRs via `.github/workflows/e2e-smoke.yml`; see
+`docs/testing/automation-setup.md` for wiring an auto-launched cloud agent for the
+visual tier.
 
 ### Scoped commands
 

--- a/apps/desktop/test/e2e/app-fixture.ts
+++ b/apps/desktop/test/e2e/app-fixture.ts
@@ -12,19 +12,26 @@ export async function launchBuiltApp(tempPrefix: string): Promise<{
   cleanupUserDataDir: () => void
 }> {
   const userDataDir = mkdtempSync(join(tmpdir(), tempPrefix))
-  const app = await electron.launch({
-    args: [MAIN, `--user-data-dir=${userDataDir}`],
-    env: { ...process.env, NEEME_EMBEDDER: 'hash', NEEME_EXTRACTOR: 'off' }
-  })
-  const page = await app.firstWindow()
-  await page.waitForLoadState('domcontentloaded')
-  await app.evaluate(({ BrowserWindow }) => BrowserWindow.getAllWindows()[0]?.show())
-  // BottomNav appears once the app finishes its initial load (phase: 'ready').
-  await page.locator('.nav').waitFor({ state: 'visible' })
-  return {
-    app,
-    page,
-    userDataDir,
-    cleanupUserDataDir: () => rmSync(userDataDir, { recursive: true, force: true })
+  let app: ElectronApplication | undefined
+  try {
+    app = await electron.launch({
+      args: [MAIN, `--user-data-dir=${userDataDir}`],
+      env: { ...process.env, NEEME_EMBEDDER: 'hash', NEEME_EXTRACTOR: 'off' }
+    })
+    const page = await app.firstWindow()
+    await page.waitForLoadState('domcontentloaded')
+    await app.evaluate(({ BrowserWindow }) => BrowserWindow.getAllWindows()[0]?.show())
+    // BottomNav appears once the app finishes its initial load (phase: 'ready').
+    await page.locator('.nav').waitFor({ state: 'visible' })
+    return {
+      app,
+      page,
+      userDataDir,
+      cleanupUserDataDir: () => rmSync(userDataDir, { recursive: true, force: true })
+    }
+  } catch (error) {
+    await app?.close().catch(() => undefined)
+    rmSync(userDataDir, { recursive: true, force: true })
+    throw error
   }
 }

--- a/apps/desktop/test/e2e/app-fixture.ts
+++ b/apps/desktop/test/e2e/app-fixture.ts
@@ -1,13 +1,16 @@
 import { _electron as electron, type ElectronApplication, type Page } from '@playwright/test'
-import { mkdtempSync } from 'node:fs'
+import { mkdtempSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
 const MAIN = join(__dirname, '..', '..', 'out', 'main', 'index.js')
 
-export async function launchBuiltApp(
-  tempPrefix: string
-): Promise<{ app: ElectronApplication; page: Page }> {
+export async function launchBuiltApp(tempPrefix: string): Promise<{
+  app: ElectronApplication
+  page: Page
+  userDataDir: string
+  cleanupUserDataDir: () => void
+}> {
   const userDataDir = mkdtempSync(join(tmpdir(), tempPrefix))
   const app = await electron.launch({
     args: [MAIN, `--user-data-dir=${userDataDir}`],
@@ -18,5 +21,10 @@ export async function launchBuiltApp(
   await app.evaluate(({ BrowserWindow }) => BrowserWindow.getAllWindows()[0]?.show())
   // BottomNav appears once the app finishes its initial load (phase: 'ready').
   await page.locator('.nav').waitFor({ state: 'visible' })
-  return { app, page }
+  return {
+    app,
+    page,
+    userDataDir,
+    cleanupUserDataDir: () => rmSync(userDataDir, { recursive: true, force: true })
+  }
 }

--- a/apps/desktop/test/e2e/app-fixture.ts
+++ b/apps/desktop/test/e2e/app-fixture.ts
@@ -1,0 +1,22 @@
+import { _electron as electron, type ElectronApplication, type Page } from '@playwright/test'
+import { mkdtempSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+const MAIN = join(__dirname, '..', '..', 'out', 'main', 'index.js')
+
+export async function launchBuiltApp(
+  tempPrefix: string
+): Promise<{ app: ElectronApplication; page: Page }> {
+  const userDataDir = mkdtempSync(join(tmpdir(), tempPrefix))
+  const app = await electron.launch({
+    args: [MAIN, `--user-data-dir=${userDataDir}`],
+    env: { ...process.env, NEEME_EMBEDDER: 'hash', NEEME_EXTRACTOR: 'off' }
+  })
+  const page = await app.firstWindow()
+  await page.waitForLoadState('domcontentloaded')
+  await app.evaluate(({ BrowserWindow }) => BrowserWindow.getAllWindows()[0]?.show())
+  // BottomNav appears once the app finishes its initial load (phase: 'ready').
+  await page.locator('.nav').waitFor({ state: 'visible' })
+  return { app, page }
+}

--- a/apps/desktop/test/e2e/capture-file.spec.ts
+++ b/apps/desktop/test/e2e/capture-file.spec.ts
@@ -11,19 +11,11 @@
  * Prereq:  pnpm --filter @nimi/desktop build   (produces out/main/index.js)
  * Run:     pnpm --filter @nimi/desktop test:e2e
  */
-import {
-  test,
-  expect,
-  _electron as electron,
-  type ElectronApplication,
-  type Page
-} from '@playwright/test'
-import { mkdtempSync } from 'node:fs'
-import { tmpdir } from 'node:os'
+import { test, expect, type ElectronApplication, type Page } from '@playwright/test'
 import { join } from 'node:path'
+import { launchBuiltApp } from './app-fixture'
 
 const FIXTURES = join(__dirname, '..', 'fixtures')
-const MAIN = join(__dirname, '..', '..', 'out', 'main', 'index.js')
 
 let app: ElectronApplication
 let page: Page
@@ -64,16 +56,9 @@ async function gotoFeed(): Promise<void> {
 }
 
 test.beforeAll(async () => {
-  const userDataDir = mkdtempSync(join(tmpdir(), 'nimi-e2e-'))
-  app = await electron.launch({
-    args: [MAIN, `--user-data-dir=${userDataDir}`],
-    env: { ...process.env, NEEME_EMBEDDER: 'hash', NEEME_EXTRACTOR: 'off' }
-  })
-  page = await app.firstWindow()
-  await page.waitForLoadState('domcontentloaded')
-  await app.evaluate(({ BrowserWindow }) => BrowserWindow.getAllWindows()[0]?.show())
-  // BottomNav appears once the app finishes its initial load (phase: 'ready').
-  await page.locator('.nav').waitFor({ state: 'visible' })
+  const launched = await launchBuiltApp('nimi-e2e-')
+  app = launched.app
+  page = launched.page
 })
 
 test.afterAll(async () => {

--- a/apps/desktop/test/e2e/capture-file.spec.ts
+++ b/apps/desktop/test/e2e/capture-file.spec.ts
@@ -19,6 +19,7 @@ const FIXTURES = join(__dirname, '..', 'fixtures')
 
 let app: ElectronApplication
 let page: Page
+let cleanupUserDataDir = (): void => {}
 
 /** Source names currently in the archive (the persisted `items` table). */
 async function archiveSrcs(): Promise<string[]> {
@@ -59,10 +60,15 @@ test.beforeAll(async () => {
   const launched = await launchBuiltApp('nimi-e2e-')
   app = launched.app
   page = launched.page
+  cleanupUserDataDir = launched.cleanupUserDataDir
 })
 
 test.afterAll(async () => {
-  await app?.close()
+  try {
+    await app?.close()
+  } finally {
+    cleanupUserDataDir()
+  }
 })
 
 test('picker: choosing a PDF captures + extracts it (renderer → IPC → worker → DB)', async () => {

--- a/apps/desktop/test/e2e/csp.spec.ts
+++ b/apps/desktop/test/e2e/csp.spec.ts
@@ -26,23 +26,28 @@
 import {
   test,
   expect,
-  _electron as electron,
   type ElectronApplication,
   type Page,
   type ConsoleMessage
 } from '@playwright/test'
-import { mkdtempSync } from 'node:fs'
-import { tmpdir } from 'node:os'
+import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
+import { launchBuiltApp } from './app-fixture'
 
-const MAIN = join(__dirname, '..', '..', 'out', 'main', 'index.js')
+const RENDERER_INDEX_HTML = join(__dirname, '..', '..', 'out', 'renderer', 'index.html')
 
 /** Matches the CSP violation text Chromium logs to the console. */
 const CSP_VIOLATION = /Refused to|violates the following Content Security Policy/i
 
-const STRICT_PROD_CSP =
-  "default-src 'self'; script-src 'self'; style-src 'self'; " +
-  "font-src 'self' data:; img-src 'self' data:; connect-src 'self'"
+function readBuiltMetaCsp(): string {
+  const html = readFileSync(RENDERER_INDEX_HTML, 'utf-8')
+  const meta = html.match(/<meta\s+[^>]*http-equiv=["']Content-Security-Policy["'][^>]*>/i)?.[0]
+  const content =
+    meta?.match(/\scontent="([^"]+)"/i)?.[1] ?? meta?.match(/\scontent='([^']+)'/i)?.[1]
+  if (!content)
+    throw new Error(`could not find Content-Security-Policy meta in ${RENDERER_INDEX_HTML}`)
+  return content
+}
 
 let app: ElectronApplication
 let page: Page
@@ -52,12 +57,9 @@ let page: Page
 const cspViolations: string[] = []
 
 test.beforeAll(async () => {
-  const userDataDir = mkdtempSync(join(tmpdir(), 'nimi-csp-e2e-'))
-  app = await electron.launch({
-    args: [MAIN, `--user-data-dir=${userDataDir}`],
-    env: { ...process.env, NEEME_EMBEDDER: 'hash', NEEME_EXTRACTOR: 'off' }
-  })
-  page = await app.firstWindow()
+  const launched = await launchBuiltApp('nimi-csp-e2e-')
+  app = launched.app
+  page = launched.page
 
   // Attach listeners, THEN reload so any load-time CSP violation is captured
   // under the listener (the first load already happened before firstWindow()).
@@ -70,6 +72,7 @@ test.beforeAll(async () => {
 
   await page.reload()
   await page.waitForLoadState('domcontentloaded')
+  await page.waitForLoadState('networkidle')
   await app.evaluate(({ BrowserWindow }) => BrowserWindow.getAllWindows()[0]?.show())
   await page.locator('.nav').waitFor({ state: 'visible' })
 })
@@ -79,8 +82,6 @@ test.afterAll(async () => {
 })
 
 test('renderer boots with ZERO CSP violations', async () => {
-  // Give late async resources (fonts, chunks) a beat to either load or be refused.
-  await page.waitForTimeout(1500)
   expect(cspViolations, `unexpected CSP violations:\n${cspViolations.join('\n')}`).toEqual([])
 })
 
@@ -111,5 +112,7 @@ test('shipped <meta> CSP is the strict production policy', async () => {
     const el = document.querySelector('meta[http-equiv="Content-Security-Policy"]')
     return el?.getAttribute('content') ?? null
   })
-  expect(metaCsp).toBe(STRICT_PROD_CSP)
+  expect(metaCsp).toBe(readBuiltMetaCsp())
+  expect(metaCsp).not.toContain("'unsafe-inline'")
+  expect(metaCsp).not.toContain('https://')
 })

--- a/apps/desktop/test/e2e/csp.spec.ts
+++ b/apps/desktop/test/e2e/csp.spec.ts
@@ -1,0 +1,115 @@
+/**
+ * Playwright Electron E2E: Content-Security-Policy + local-font smoke (#11).
+ *
+ * Codifies the manual "run `pnpm dev`, open DevTools, look for CSP violations"
+ * runbook into a deterministic pass/fail check. Launches the BUILT renderer and
+ * asserts:
+ *   - the renderer boots with ZERO CSP violations ("Refused to …" console errors
+ *     / securitypolicyviolation events) and no uncaught page errors,
+ *   - the bundled UI fonts (Hanken Grotesk + JetBrains Mono via @fontsource) are
+ *     actually loaded — i.e. font bundling works offline,
+ *   - the renderer makes NO request to Google Fonts (fonts.googleapis.com /
+ *     fonts.gstatic.com),
+ *   - the shipped <meta> CSP is the strict production policy (no 'unsafe-inline',
+ *     no remote origins).
+ *
+ * NOTE on coverage: the E2E launches the built-but-NOT-packaged app, so
+ * `app.isPackaged` is false. That means this exercises the strict PRODUCTION
+ * <meta> CSP (the dev relaxation only applies in electron-vite `serve`, not
+ * `build`), but NOT the defense-in-depth response header in src/main/index.ts,
+ * which is gated on `app.isPackaged`. The header path needs a packaged-artifact
+ * tier (Tier 3) to exercise.
+ *
+ * Prereq:  pnpm --filter @nimi/desktop build   (produces out/main/index.js)
+ * Run:     pnpm --filter @nimi/desktop test:e2e
+ */
+import {
+  test,
+  expect,
+  _electron as electron,
+  type ElectronApplication,
+  type Page,
+  type ConsoleMessage
+} from '@playwright/test'
+import { mkdtempSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+const MAIN = join(__dirname, '..', '..', 'out', 'main', 'index.js')
+
+/** Matches the CSP violation text Chromium logs to the console. */
+const CSP_VIOLATION = /Refused to|violates the following Content Security Policy/i
+
+const STRICT_PROD_CSP =
+  "default-src 'self'; script-src 'self'; style-src 'self'; " +
+  "font-src 'self' data:; img-src 'self' data:; connect-src 'self'"
+
+let app: ElectronApplication
+let page: Page
+
+/** Console errors + page errors that look like CSP violations, collected from
+ *  the moment listeners attach through the reload below. */
+const cspViolations: string[] = []
+
+test.beforeAll(async () => {
+  const userDataDir = mkdtempSync(join(tmpdir(), 'nimi-csp-e2e-'))
+  app = await electron.launch({
+    args: [MAIN, `--user-data-dir=${userDataDir}`],
+    env: { ...process.env, NEEME_EMBEDDER: 'hash', NEEME_EXTRACTOR: 'off' }
+  })
+  page = await app.firstWindow()
+
+  // Attach listeners, THEN reload so any load-time CSP violation is captured
+  // under the listener (the first load already happened before firstWindow()).
+  page.on('console', (msg: ConsoleMessage) => {
+    if (CSP_VIOLATION.test(msg.text())) cspViolations.push(`console:${msg.text()}`)
+  })
+  page.on('pageerror', (err: Error) => {
+    if (CSP_VIOLATION.test(err.message)) cspViolations.push(`pageerror:${err.message}`)
+  })
+
+  await page.reload()
+  await page.waitForLoadState('domcontentloaded')
+  await app.evaluate(({ BrowserWindow }) => BrowserWindow.getAllWindows()[0]?.show())
+  await page.locator('.nav').waitFor({ state: 'visible' })
+})
+
+test.afterAll(async () => {
+  await app?.close()
+})
+
+test('renderer boots with ZERO CSP violations', async () => {
+  // Give late async resources (fonts, chunks) a beat to either load or be refused.
+  await page.waitForTimeout(1500)
+  expect(cspViolations, `unexpected CSP violations:\n${cspViolations.join('\n')}`).toEqual([])
+})
+
+test('bundled fonts load locally (offline-first)', async () => {
+  const fonts = await page.evaluate(async () => {
+    await (document.fonts.ready ?? Promise.resolve())
+    return {
+      hanken: document.fonts.check('16px "Hanken Grotesk"'),
+      mono: document.fonts.check('16px "JetBrains Mono"')
+    }
+  })
+  expect(fonts.hanken, 'Hanken Grotesk should be loaded from @fontsource').toBe(true)
+  expect(fonts.mono, 'JetBrains Mono should be loaded from @fontsource').toBe(true)
+})
+
+test('no Google Fonts network requests', async () => {
+  const googleFontReqs = await page.evaluate(() =>
+    performance
+      .getEntriesByType('resource')
+      .map((r) => r.name)
+      .filter((n) => n.includes('fonts.googleapis.com') || n.includes('fonts.gstatic.com'))
+  )
+  expect(googleFontReqs, 'renderer must not fetch from Google Fonts').toEqual([])
+})
+
+test('shipped <meta> CSP is the strict production policy', async () => {
+  const metaCsp = await page.evaluate(() => {
+    const el = document.querySelector('meta[http-equiv="Content-Security-Policy"]')
+    return el?.getAttribute('content') ?? null
+  })
+  expect(metaCsp).toBe(STRICT_PROD_CSP)
+})

--- a/apps/desktop/test/e2e/csp.spec.ts
+++ b/apps/desktop/test/e2e/csp.spec.ts
@@ -51,6 +51,7 @@ function readBuiltMetaCsp(): string {
 
 let app: ElectronApplication
 let page: Page
+let cleanupUserDataDir = (): void => {}
 
 /** Console errors + page errors that look like CSP violations, collected from
  *  the moment listeners attach through the reload below. */
@@ -60,6 +61,7 @@ test.beforeAll(async () => {
   const launched = await launchBuiltApp('nimi-csp-e2e-')
   app = launched.app
   page = launched.page
+  cleanupUserDataDir = launched.cleanupUserDataDir
 
   // Attach listeners, THEN reload so any load-time CSP violation is captured
   // under the listener (the first load already happened before firstWindow()).
@@ -73,12 +75,15 @@ test.beforeAll(async () => {
   await page.reload()
   await page.waitForLoadState('domcontentloaded')
   await page.waitForLoadState('networkidle')
-  await app.evaluate(({ BrowserWindow }) => BrowserWindow.getAllWindows()[0]?.show())
   await page.locator('.nav').waitFor({ state: 'visible' })
 })
 
 test.afterAll(async () => {
-  await app?.close()
+  try {
+    await app?.close()
+  } finally {
+    cleanupUserDataDir()
+  }
 })
 
 test('renderer boots with ZERO CSP violations', async () => {
@@ -98,6 +103,8 @@ test('bundled fonts load locally (offline-first)', async () => {
 })
 
 test('no Google Fonts network requests', async () => {
+  // Resource Timing proves no remote font request reached the network; the CSP
+  // violation test above catches blocked Google Fonts links before they load.
   const googleFontReqs = await page.evaluate(() =>
     performance
       .getEntriesByType('resource')

--- a/apps/desktop/test/e2e/csp.spec.ts
+++ b/apps/desktop/test/e2e/csp.spec.ts
@@ -121,5 +121,8 @@ test('shipped <meta> CSP is the strict production policy', async () => {
   })
   expect(metaCsp).toBe(readBuiltMetaCsp())
   expect(metaCsp).not.toContain("'unsafe-inline'")
+  expect(metaCsp).not.toContain("'unsafe-eval'")
   expect(metaCsp).not.toContain('https://')
+  expect(metaCsp).not.toContain('http://')
+  expect(metaCsp).not.toMatch(/script-src[^;]*\bblob:/)
 })

--- a/docs/testing/RUNBOOK-TEMPLATE.md
+++ b/docs/testing/RUNBOOK-TEMPLATE.md
@@ -1,0 +1,58 @@
+<!--
+Clone this file to docs/testing/<feature>-runbook.md for any GUI-facing feature,
+then add a row to the "GUI feature tests" table in AGENTS.md so agents discover it.
+Keep the section order below — the `gui-smoke` skill expects it.
+-->
+
+# Runbook: <Feature> — GUI Test (<PR/issue ref>)
+
+One-paragraph description of what the feature does and what "working" looks like.
+
+## Test pyramid
+
+| Tier | Command | Needs secret? | Needs display? | Covers |
+|---|---|---|---|---|
+| **1 — Static** | `pnpm typecheck && pnpm --filter @nimi/desktop build` | No | No | Types, build |
+| **2 — E2E smoke** | `xvfb-run -a pnpm --filter @nimi/desktop test:e2e` | No | Xvfb | Deterministic `_electron` assertions |
+| **3 — GUI/visual** | This runbook (§ below) | <key or "No"> | Yes | Judgement + artifacts |
+
+Tiers 1–2 are the automated half (run by `.github/workflows/e2e-smoke.yml` on every
+PR). Tier 3 is the agent/human half that produces the screenshot + video.
+
+## Prerequisites
+
+- Node ≥ 20, pnpm 10.x, an X11 display (`DISPLAY=:1` in cloud VMs).
+- Offline env: `NEEME_EMBEDDER=hash` (+ `NEEME_EXTRACTOR=off` where relevant).
+- `<any secret, e.g. NEEME_ANTHROPIC_KEY>` — required for: <what>.
+- Electron binary missing? `node node_modules/electron/install.js`.
+
+## 1. Launch
+
+```bash
+NEEME_EMBEDDER=hash pnpm dev
+```
+
+## 2. Steps (happy path)
+
+1. …
+2. …
+
+**Expected:** …
+
+## 3. Edge / degradation cases
+
+- …
+
+## Artifacts to capture
+
+> The `gui-smoke` skill captures exactly what's listed here. Be specific.
+
+- [ ] **Screenshot:** <which screen / state>.
+- [ ] **Video (≤ ~15s):** <the behaviour to record end-to-end>.
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| App window never opens | display not set | `export DISPLAY=:1` |
+| `Error: Electron uninstall` | binary not downloaded | `node node_modules/electron/install.js` |

--- a/docs/testing/automation-setup.md
+++ b/docs/testing/automation-setup.md
@@ -1,0 +1,65 @@
+# Automating the runbooks (stop hand-dispatching agents)
+
+Goal: a PR event drives verification, not a human. Each GUI runbook splits into a
+**deterministic tier** (CI, no agent) and a **visual/judgement tier** (an
+auto-launched cloud agent). Once both are wired, you review results instead of
+dispatching agents.
+
+## The three pieces
+
+```
+PR opened/pushed ─┬─▶ GitHub Actions  (e2e-smoke.yml)  → deterministic pass/fail check
+                  └─▶ Cursor Automation → cloud agent  → reads gui-smoke skill, runs
+                                                          the runbook, posts screenshot
+                                                          + video as a PR comment
+```
+
+### 1. Deterministic tier — already committed
+
+`.github/workflows/e2e-smoke.yml` builds the app and runs the Playwright
+`_electron` suite under Xvfb on every PR touching `apps/desktop/**` or
+`packages/contract/**`. No agent, no secrets. Add an `_electron` spec under
+`apps/desktop/test/e2e/` for each feature whose checks can be made objective
+(`csp.spec.ts` is the reference).
+
+### 2. The SOP the agent follows — already committed
+
+`.cursor/skills/gui-smoke/SKILL.md`. Cursor cloud agents auto-discover skills
+from `.cursor/skills/` at startup (they clone the repo), so you never re-paste the
+procedure. Likewise `AGENTS.md` is read automatically. Keep standing conventions
+in those files and keep the trigger prompt about the *task*, not the process.
+
+### 3. The trigger — one-time dashboard setup (manual)
+
+This is the only step not committable to the repo. At
+[cursor.com/automations](https://cursor.com/automations):
+
+1. **New automation**, scope it to this repo (requires the Cursor GitHub app
+   installed with repo access: Dashboard → Integrations → Connect GitHub).
+2. **Triggers:** `Pull request opened` + `Pull request pushed`. (Optionally add
+   `CI completed` so the agent runs only after `e2e-smoke.yml` is green.)
+3. **Tools:** enable **Comment on pull request** (so it posts results inline) and
+   leave **artifacts** on (screenshots/video are uploaded + linked).
+4. **Prompt** (task-only — the skill supplies the how):
+
+   > Smoke-test this PR's desktop changes using the `gui-smoke` skill. Run the
+   > deterministic tier, then follow the matching runbook in `docs/testing/` for
+   > the changed feature, capture the artifacts it specifies, and post a concise
+   > pass/fail report with the screenshot and video as a PR comment.
+
+### Programmatic alternative
+
+If you'd rather trigger from CI than the dashboard, the same launch is available
+via `POST https://api.cursor.com/v1/agents` (Cursor cloud VM) or the Cursor CLI
+`agent -p "…"` inside a runner. Store `CURSOR_API_KEY` as a repo secret. Use the
+API/CLI when you want the launch tied to a specific workflow step rather than a
+GitHub event.
+
+## Adding a new feature to the loop
+
+1. Write/extend an `_electron` spec under `apps/desktop/test/e2e/` (tier 1/2).
+2. Clone `docs/testing/RUNBOOK-TEMPLATE.md` → `docs/testing/<feature>-runbook.md`,
+   filling in the **Artifacts to capture** section precisely.
+3. Add a row to the **GUI feature tests** table in `AGENTS.md`.
+
+No automation change needed — the skill + runbook discovery handle the rest.

--- a/docs/testing/csp-smoke-runbook.md
+++ b/docs/testing/csp-smoke-runbook.md
@@ -1,0 +1,78 @@
+# Runbook: CSP hardening + local fonts — GUI Test (#11)
+
+Verifies the production Content-Security-Policy and offline font bundling from
+commit `f522bab`: the renderer must boot with **zero CSP violations**, load the
+bundled Hanken Grotesk + JetBrains Mono fonts locally (no Google Fonts), and ship
+the strict production CSP. See `docs/SECURITY.md` for the policy rationale.
+
+## Test pyramid
+
+| Tier | Command | Needs secret? | Needs display? | Covers |
+|---|---|---|---|---|
+| **1 — Static** | `pnpm typecheck && pnpm --filter @nimi/desktop build` | No | No | Types, build, font assets emitted |
+| **2 — E2E smoke** | `xvfb-run -a pnpm --filter @nimi/desktop test:e2e` | No | Xvfb | `test/e2e/csp.spec.ts`: violations, fonts, no Google Fonts, strict meta |
+| **3 — GUI/visual** | This runbook (§1–§2) | No | Yes | Renders correctly with bundled fonts; artifact capture |
+
+Tiers 1–2 are automated by `.github/workflows/e2e-smoke.yml` on every PR.
+
+> **Coverage note.** The E2E launches the built-but-not-packaged app, so
+> `app.isPackaged` is `false`. That exercises the strict production `<meta>` CSP
+> (the dev relaxation only applies under electron-vite `serve`), but **not** the
+> defense-in-depth response header in `apps/desktop/src/main/index.ts`, which is
+> gated on `app.isPackaged`. Verify the header against a packaged artifact (Tier 3
+> packaging in `AGENTS.md`).
+
+## Prerequisites
+
+- Node ≥ 20, pnpm 10.x, X11 display (`DISPLAY=:1` in cloud VMs).
+- Offline env: `NEEME_EMBEDDER=hash` (and `NEEME_EXTRACTOR=off`).
+- Electron binary missing? `node node_modules/electron/install.js`.
+
+## 1. Launch
+
+```bash
+NEEME_EMBEDDER=hash pnpm dev
+```
+
+Wait for the Vite line and the Electron window. In **dev**, a serve-only Vite
+plugin rewrites the meta CSP to `DEV_CSP` (adds `style-src 'unsafe-inline'` for
+HMR + `connect-src http://localhost:8000`). That relaxation is expected and is
+**not** present in the built app.
+
+## 2. Verify no CSP violations + local fonts
+
+Open DevTools → Console and confirm **no** `Refused to …` / "Content Security
+Policy" messages.
+
+> If the tray window is off-screen and DevTools won't open (common in headless
+> VMs), don't fight it — rely on Tier 2 (`csp.spec.ts`), or use the
+> console-forwarder instrumentation described in the `gui-smoke` skill.
+
+Confirm fonts loaded (DevTools console):
+
+```js
+document.fonts.check('16px "Hanken Grotesk"')   // → true
+document.fonts.check('16px "JetBrains Mono"')    // → true
+performance.getEntriesByType('resource').map(r => r.name).filter(n => n.includes('fonts.g'))  // → []
+```
+
+**Expected:** both font checks `true`; no `fonts.googleapis.com` / `fonts.gstatic.com`
+requests; the UI renders with the correct sans (Hanken Grotesk) + mono (JetBrains
+Mono) typefaces (not the system fallback).
+
+## Artifacts to capture
+
+- [ ] **Screenshot:** the rendered Today screen showing the bundled fonts (e.g.
+      "Up late" in Hanken Grotesk, mono labels like `PICK ONE MORE THING`).
+- [ ] **Video (≤ ~10s):** boot → tab through Today/Feed showing fonts render and
+      no visual fallback flash. (Optional when Tier 2 is green; the screenshot +
+      passing `csp.spec.ts` are sufficient evidence.)
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| Fonts look like system default | `@fontsource` imports missing in `main.tsx` | confirm imports; rebuild |
+| `Refused to load the font …` in console | a remote font origin crept back into the CSP/HTML | remove it; fonts must be local |
+| DevTools won't open | off-screen tray window in VM | use Tier 2 `csp.spec.ts` |
+| `Error: Electron uninstall` | binary not downloaded | `node node_modules/electron/install.js` |

--- a/docs/testing/csp-smoke-runbook.md
+++ b/docs/testing/csp-smoke-runbook.md
@@ -1,17 +1,17 @@
 # Runbook: CSP hardening + local fonts — GUI Test (#11)
 
-Verifies the production Content-Security-Policy and offline font bundling from
-commit `f522bab`: the renderer must boot with **zero CSP violations**, load the
+Verifies the production Content-Security-Policy and offline font bundling for
+GUI hardening #11: the renderer must boot with **zero CSP violations**, load the
 bundled Hanken Grotesk + JetBrains Mono fonts locally (no Google Fonts), and ship
 the strict production CSP. See `docs/SECURITY.md` for the policy rationale.
 
 ## Test pyramid
 
-| Tier | Command | Needs secret? | Needs display? | Covers |
-|---|---|---|---|---|
-| **1 — Static** | `pnpm typecheck && pnpm --filter @nimi/desktop build` | No | No | Types, build, font assets emitted |
-| **2 — E2E smoke** | `xvfb-run -a pnpm --filter @nimi/desktop test:e2e` | No | Xvfb | `test/e2e/csp.spec.ts`: violations, fonts, no Google Fonts, strict meta |
-| **3 — GUI/visual** | This runbook (§1–§2) | No | Yes | Renders correctly with bundled fonts; artifact capture |
+| Tier               | Command                                               | Needs secret? | Needs display? | Covers                                                                  |
+| ------------------ | ----------------------------------------------------- | ------------- | -------------- | ----------------------------------------------------------------------- |
+| **1 — Static**     | `pnpm typecheck && pnpm --filter @nimi/desktop build` | No            | No             | Types, build, font assets emitted                                       |
+| **2 — E2E smoke**  | `xvfb-run -a pnpm --filter @nimi/desktop test:e2e`    | No            | Xvfb           | `test/e2e/csp.spec.ts`: violations, fonts, no Google Fonts, strict meta |
+| **3 — GUI/visual** | This runbook (§1–§2)                                  | No            | Yes            | Renders correctly with bundled fonts; artifact capture                  |
 
 Tiers 1–2 are automated by `.github/workflows/e2e-smoke.yml` on every PR.
 
@@ -51,9 +51,12 @@ Policy" messages.
 Confirm fonts loaded (DevTools console):
 
 ```js
-document.fonts.check('16px "Hanken Grotesk"')   // → true
-document.fonts.check('16px "JetBrains Mono"')    // → true
-performance.getEntriesByType('resource').map(r => r.name).filter(n => n.includes('fonts.g'))  // → []
+document.fonts.check('16px "Hanken Grotesk"') // → true
+document.fonts.check('16px "JetBrains Mono"') // → true
+performance
+  .getEntriesByType('resource')
+  .map((r) => r.name)
+  .filter((n) => n.includes('fonts.g')) // → []
 ```
 
 **Expected:** both font checks `true`; no `fonts.googleapis.com` / `fonts.gstatic.com`
@@ -70,9 +73,9 @@ Mono) typefaces (not the system fallback).
 
 ## Troubleshooting
 
-| Symptom | Likely cause | Fix |
-|---|---|---|
-| Fonts look like system default | `@fontsource` imports missing in `main.tsx` | confirm imports; rebuild |
-| `Refused to load the font …` in console | a remote font origin crept back into the CSP/HTML | remove it; fonts must be local |
-| DevTools won't open | off-screen tray window in VM | use Tier 2 `csp.spec.ts` |
-| `Error: Electron uninstall` | binary not downloaded | `node node_modules/electron/install.js` |
+| Symptom                                 | Likely cause                                      | Fix                                     |
+| --------------------------------------- | ------------------------------------------------- | --------------------------------------- |
+| Fonts look like system default          | `@fontsource` imports missing in `main.tsx`       | confirm imports; rebuild                |
+| `Refused to load the font …` in console | a remote font origin crept back into the CSP/HTML | remove it; fonts must be local          |
+| DevTools won't open                     | off-screen tray window in VM                      | use Tier 2 `csp.spec.ts`                |
+| `Error: Electron uninstall`             | binary not downloaded                             | `node node_modules/electron/install.js` |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

We've been verifying GUI changes by manually dispatching cloud agents and telling each one to "follow the runbook." That makes a human the orchestration layer for work that's mostly mechanical. This PR codifies the runbook so the deterministic half runs itself in CI and the visual half can be auto-launched by a Cursor Automation — turning the dispatcher into a reviewer.

Built as a vertical slice using the **#11 CSP hardening + font bundling** smoke as the worked example + a reusable template.

## What's here

**1. Deterministic tier → a test** — `apps/desktop/test/e2e/csp.spec.ts`
Playwright `_electron` spec mirroring the existing `capture-file.spec.ts` launch pattern. Asserts:
- renderer boots with **zero CSP violations** (`Refused to …` console errors / page errors),
- bundled Hanken Grotesk + JetBrains Mono fonts load locally (`document.fonts.check`),
- **no** `fonts.googleapis.com` / `fonts.gstatic.com` requests,
- the shipped `<meta>` CSP is the strict production policy.

> Coverage note: the E2E launches the built-but-not-packaged app (`app.isPackaged === false`), so it exercises the strict production `<meta>` CSP but **not** the `onHeadersReceived` response header (gated on `app.isPackaged`). That needs a packaged-artifact tier — documented in the runbook.

**2. CI → no agent needed** — `.github/workflows/e2e-smoke.yml`
Builds the app and runs the `_electron` suite under Xvfb on every PR touching `apps/desktop/**` / `packages/contract/**`. Uses `NEEME_EMBEDDER=hash` to skip the model download and `playwright install-deps chromium` for Electron's shared libs.

**3. The SOP agents auto-read** — `.cursor/skills/gui-smoke/SKILL.md`
Encodes the runbook-following + artifact-capture procedure (including the off-screen-window DevTools gotcha and the console-forwarder workaround) so cloud agents don't need it re-pasted each run.

**4. Templates + wiring** — `docs/testing/`
- `RUNBOOK-TEMPLATE.md` — clone per feature.
- `csp-smoke-runbook.md` — the #11 runbook in that shape.
- `automation-setup.md` — how to wire a Cursor Automation (PR-opened/pushed trigger → cloud agent → posts screenshot/video as a PR comment), plus the API/CLI alternative.
- `AGENTS.md` — registers the new runbook + points at the skill/template/workflow.

## Testing

- ✅ `pnpm --filter @nimi/desktop build`
- ✅ `xvfb-run -a pnpm --filter @nimi/desktop test:e2e` — **7 passed** (3 existing capture-file + 4 new CSP)
- ✅ Negative control: injecting a Google Fonts `<link>` + remote `<script>` into the built HTML makes `csp.spec.ts` fail (2 tests, exit 1) — proves it's not a vacuous green
- ✅ `pnpm typecheck`
- ✅ `eslint apps/desktop/test/e2e/csp.spec.ts` clean; workflow YAML parses

## Follow-up (not in this PR — needs dashboard access)

The Automation trigger is a one-time setup at [cursor.com/automations](https://cursor.com/automations) (can't be committed to the repo); exact settings + prompt are in `docs/testing/automation-setup.md`. If PR CI should gate the agent, add a `CI completed` trigger.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5a895e13-ee40-489f-87a4-10a12973bd9d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5a895e13-ee40-489f-87a4-10a12973bd9d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

