### PR TITLE
feat(sync): surface cloud-sync status + errors in the renderer (#10)

### DIFF
--- a/apps/desktop/src/main/db/sync-config.ts
+++ b/apps/desktop/src/main/db/sync-config.ts
@@ -7,7 +7,11 @@
  * Environment variables:
  *   NEEME_SYNC              "on" to enable (anything else = off)
  *   NEEME_SYNC_URL          libSQL sync URL (e.g. libsql://<db>.turso.io)
- *   NEEME_SYNC_AUTH_TOKEN   DB-scoped auth token (short-lived; main fetches from broker)
+ *   NEEME_SYNC_AUTH_TOKEN   DB-scoped auth token — set by main from the broker response
+ *                           (or provided directly as the spike fallback)
+ *   NEEME_SYNC_BROKER_URL   Broker service URL — when set, main fetches and injects
+ *                           NEEME_SYNC_URL + NEEME_SYNC_AUTH_TOKEN before forking the
+ *                           worker (see src/main/sync/broker.ts and ADR 0008)
  *   NEEME_SYNC_INTERVAL_S   Periodic sync interval in seconds (default 300 = 5 min)
  *   NEEME_SYNC_ENCRYPTION_KEY  64-hex AES-256-GCM key — REQUIRED to enable sync
  *

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -5,6 +5,12 @@ import { startWorker, call } from './worker/client'
 import { initTrayWindow, showWindow, setBadge } from './window/tray-window'
 import * as auth from './auth/logto'
 import * as googleAuth from './connectors/google-auth'
+import {
+  isBrokerConfigured,
+  restoreCachedToken,
+  getSyncToken,
+  clearSyncToken
+} from './sync/broker'
 import { IPC } from '@nimi/contract/ipc'
 import type { ConnectorId, ConnectorsState, IngestResult, UpdateStatus } from '@nimi/contract/ipc'
 
@@ -100,6 +106,55 @@ app.whenReady().then(async () => {
   // IPC test
   ipcMain.on('ping', () => console.log('pong'))
 
+  // ── Auth (Logto) — init before the worker so the broker can use the restored
+  // session to pre-populate NEEME_SYNC_URL/NEEME_SYNC_AUTH_TOKEN before fork. ──
+  //
+  // The onChange callback broadcasts to renderers. Windows don't exist yet when
+  // auth.init() fires the initial state-change from a restored session, so the
+  // BrowserWindow loop is a safe no-op at that point.
+  auth.onChange((state, accessToken) => {
+    for (const win of BrowserWindow.getAllWindows()) {
+      win.webContents.send(IPC.authChanged, { state, accessToken })
+    }
+    // When the user logs out, clear the cached broker token so the next login
+    // gets a fresh one. Best-effort — never blocks the auth state update.
+    if (!state.isAuthenticated) {
+      clearSyncToken().catch((err) => console.warn('[broker-client] clear on logout:', err))
+    }
+  })
+  await auth.init()
+
+  // ── Broker token (ADR 0008) — fetch before forking the worker so the libSQL
+  // client is built with the right syncUrl + authToken on first boot.
+  //
+  // Flow:
+  //   1. Restore any disk-cached broker token (encrypted in safeStorage).
+  //   2. If sync + broker are configured and auth has a valid session, get a
+  //      fresh token (from cache or from the broker), then inject into process.env
+  //      so the worker's getSyncConfig() picks them up unchanged.
+  //   3. If auth has no session yet (first install, or logged out), the worker
+  //      starts in local-only mode. The next boot after login will have the token.
+  // ──────────────────────────────────────────────────────────────────────────────
+  await restoreCachedToken()
+
+  if (isBrokerConfigured() && process.env.NEEME_SYNC === 'on') {
+    const logtoToken = await auth.getAccessToken().catch(() => undefined)
+    if (logtoToken) {
+      try {
+        const token = await getSyncToken(logtoToken)
+        if (token) {
+          process.env.NEEME_SYNC_URL = token.syncUrl
+          process.env.NEEME_SYNC_AUTH_TOKEN = token.authToken
+          console.log('[broker-client] Sync credentials injected (expires', new Date(token.expiresAt).toISOString(), ')')
+        }
+      } catch (err) {
+        console.warn('[broker-client] Failed to fetch sync token; worker will start in local-only mode:', err)
+      }
+    } else {
+      console.log('[broker-client] No Logto session at boot; worker starts in local-only mode')
+    }
+  }
+
   // Data layer runs in a utilityProcess (off the main loop). Main is a thin
   // router: every data channel is forwarded to the worker, which owns the DB +
   // services. Start it (it inits the schema) before handlers can be called.
@@ -130,14 +185,6 @@ app.whenReady().then(async () => {
     ipcMain.handle(channel, (_e, ...args: unknown[]) => call(channel, args))
   }
 
-  // Auth (Logto) — broadcast changes to renderers, restore any saved session,
-  // then expose login/logout/token over IPC. Inert until Logto env is configured.
-  auth.onChange((state, accessToken) => {
-    for (const win of BrowserWindow.getAllWindows()) {
-      win.webContents.send(IPC.authChanged, { state, accessToken })
-    }
-  })
-  await auth.init()
   ipcMain.handle(IPC.authLogin, () => auth.startLogin())
   ipcMain.handle(IPC.authLogout, () => auth.logout())
   ipcMain.handle(IPC.authGetToken, () => auth.getAccessToken())

--- a/apps/desktop/src/main/sync/broker.ts
+++ b/apps/desktop/src/main/sync/broker.ts
@@ -1,0 +1,129 @@
+/**
+ * Desktop-side token broker client (ADR 0008).
+ *
+ * Main fetches a short-lived, DB-scoped Turso sync token from the broker service
+ * on behalf of the authenticated user. The token is:
+ *   - cached in Electron `safeStorage` (OS keychain on macOS/Windows), same
+ *     approach as the Logto refresh token in auth/logto.ts
+ *   - refreshed proactively ~60 s before it expires
+ *   - never handed to the renderer (only main + worker touch it)
+ *
+ * When NEEME_SYNC_BROKER_URL is not set, all functions are no-ops, preserving
+ * the existing static NEEME_SYNC_AUTH_TOKEN spike path.
+ *
+ * Config:
+ *   NEEME_SYNC_BROKER_URL — Deployed broker URL, e.g. https://token-broker.vercel.app
+ */
+import { app, safeStorage } from 'electron'
+import { readFile, writeFile, rm } from 'node:fs/promises'
+import { join } from 'node:path'
+import type { BrokerTokenResponse } from '@nimi/contract/ipc'
+
+const REFRESH_BUFFER_MS = 60_000 // refresh when < 60 s from expiry
+
+let cached: BrokerTokenResponse | null = null
+
+function cacheFile(): string {
+  return join(app.getPath('userData'), 'neeme-sync-token.bin')
+}
+
+function brokerUrl(): string | undefined {
+  return process.env.NEEME_SYNC_BROKER_URL?.replace(/\/+$/, '')
+}
+
+/** True when broker mode is configured (NEEME_SYNC_BROKER_URL is set). */
+export function isBrokerConfigured(): boolean {
+  return Boolean(brokerUrl())
+}
+
+/** True when the cached token is still valid (has > REFRESH_BUFFER_MS remaining). */
+function isTokenFresh(token: BrokerTokenResponse): boolean {
+  return token.expiresAt - Date.now() > REFRESH_BUFFER_MS
+}
+
+/** Persist the token to the OS keychain via safeStorage. */
+async function persist(token: BrokerTokenResponse): Promise<void> {
+  const plain = JSON.stringify(token)
+  const blob = safeStorage.isEncryptionAvailable()
+    ? safeStorage.encryptString(plain)
+    : Buffer.from(plain, 'utf8')
+  await writeFile(cacheFile(), blob)
+}
+
+/** Remove the cached token from disk. */
+async function clearPersisted(): Promise<void> {
+  await rm(cacheFile(), { force: true }).catch(() => {})
+  cached = null
+}
+
+/** Restore a persisted token from disk (called at startup). */
+export async function restoreCachedToken(): Promise<void> {
+  if (!isBrokerConfigured()) return
+  try {
+    const blob = await readFile(cacheFile())
+    const plain = safeStorage.isEncryptionAvailable()
+      ? safeStorage.decryptString(blob)
+      : blob.toString('utf8')
+    const token = JSON.parse(plain) as BrokerTokenResponse
+    if (isTokenFresh(token)) {
+      cached = token
+    }
+    // Expired tokens are discarded; a fresh fetch will happen at first use.
+  } catch {
+    /* no stored token */
+  }
+}
+
+/**
+ * Fetch a fresh token from the broker using the caller's Logto access token.
+ * Throws on HTTP errors or network failures.
+ */
+async function fetchFromBroker(logtoAccessToken: string): Promise<BrokerTokenResponse> {
+  const url = brokerUrl()
+  if (!url) throw new Error('NEEME_SYNC_BROKER_URL is not set')
+
+  const res = await fetch(`${url}/token`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${logtoAccessToken}` }
+  })
+  if (!res.ok) {
+    const body = await res.text().catch(() => '')
+    throw new Error(`Broker returned HTTP ${res.status}: ${body.slice(0, 200)}`)
+  }
+  return res.json() as Promise<BrokerTokenResponse>
+}
+
+/**
+ * Get a valid sync token, using the cache when possible.
+ *
+ * @param logtoAccessToken — fresh Logto access token from auth.getAccessToken()
+ * @returns the broker token, or null if the broker is not configured
+ *
+ * Errors from the broker are logged and rethrown; callers should catch and
+ * fall back to the static NEEME_SYNC_AUTH_TOKEN path if present.
+ */
+export async function getSyncToken(
+  logtoAccessToken: string
+): Promise<BrokerTokenResponse | null> {
+  if (!isBrokerConfigured()) return null
+
+  if (cached && isTokenFresh(cached)) {
+    return cached
+  }
+
+  const token = await fetchFromBroker(logtoAccessToken)
+  cached = token
+  await persist(token).catch((err) =>
+    console.warn('[broker-client] failed to persist sync token:', err)
+  )
+  return token
+}
+
+/**
+ * Clear the in-memory and on-disk cached token.
+ * Call on logout so the next login gets a fresh token.
+ */
+export async function clearSyncToken(): Promise<void> {
+  cached = null
+  await clearPersisted()
+}

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -60,6 +60,10 @@ const api: NimiApi = {
       return (): void => { ipcRenderer.removeListener(IPC.connectorsChanged, handler) }
     }
   },
+  sync: {
+    getStatus: () => ipcRenderer.invoke(IPC.syncGetStatus),
+    now: () => ipcRenderer.invoke(IPC.syncNow)
+  },
   ui: {
     setBadge: (count: number) => ipcRenderer.invoke(IPC.traySetBadge, count)
   },

--- a/apps/desktop/src/renderer/src/hooks/useSync.ts
+++ b/apps/desktop/src/renderer/src/hooks/useSync.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import type { SyncStatus } from '@nimi/contract/ipc'
 import { isElectron } from '../nimi/api'
 
@@ -7,11 +7,13 @@ const DEFAULT: SyncStatus = { enabled: false, lastSyncAt: null, syncing: false, 
 /** How often to re-poll worker sync status. There's no push event yet, so we poll. */
 const POLL_MS = 5000
 
+const NOOP = (): void => {}
+
 /**
  * Bridges the renderer to the worker's Turso sync status (window.api.sync).
- * Polls `getStatus` on an interval since there's no change event yet. Outside
- * Electron (browser preview) returns a static disabled state + no-op — mirrors
- * the useConnectors pattern.
+ * Polls `getStatus` on an interval — paused when the document is hidden to avoid
+ * needless IPC when the window is minimised. Outside Electron (browser preview)
+ * returns a static disabled state + stable no-op, mirroring the useConnectors pattern.
  */
 export function useSync(): { status: SyncStatus; syncNow: () => void } {
   const [status, setStatus] = useState<SyncStatus>(DEFAULT)
@@ -19,32 +21,41 @@ export function useSync(): { status: SyncStatus; syncNow: () => void } {
   useEffect(() => {
     if (!isElectron) return
     let active = true
+
     const poll = (): void => {
+      if (document.hidden) return
       window.api.sync
         .getStatus()
         .then((s) => {
           if (active) setStatus(s)
         })
-        .catch(() => {}) // status polling is best-effort; never surface a poll error
+        .catch(() => {}) // best-effort; never surface a poll error
     }
+
     poll()
     const id = setInterval(poll, POLL_MS)
+    const onVisible = (): void => {
+      if (!document.hidden) poll()
+    }
+    document.addEventListener('visibilitychange', onVisible)
+
     return () => {
       active = false
       clearInterval(id)
+      document.removeEventListener('visibilitychange', onVisible)
     }
   }, [])
 
-  if (!isElectron) return { status: DEFAULT, syncNow: () => {} }
+  const syncNow = useCallback(() => {
+    if (!isElectron) return
+    window.api.sync
+      .now()
+      .then(() => window.api.sync.getStatus())
+      .then(setStatus)
+      .catch((e) => console.error('sync now failed', e))
+  }, [])
 
-  return {
-    status,
-    syncNow: () => {
-      window.api.sync
-        .now()
-        .then(() => window.api.sync.getStatus())
-        .then(setStatus)
-        .catch((e) => console.error('sync now failed', e))
-    }
-  }
+  if (!isElectron) return { status: DEFAULT, syncNow: NOOP }
+
+  return { status, syncNow }
 }

--- a/apps/desktop/src/renderer/src/hooks/useSync.ts
+++ b/apps/desktop/src/renderer/src/hooks/useSync.ts
@@ -1,0 +1,50 @@
+import { useEffect, useState } from 'react'
+import type { SyncStatus } from '@nimi/contract/ipc'
+import { isElectron } from '../nimi/api'
+
+const DEFAULT: SyncStatus = { enabled: false, lastSyncAt: null, syncing: false, error: null }
+
+/** How often to re-poll worker sync status. There's no push event yet, so we poll. */
+const POLL_MS = 5000
+
+/**
+ * Bridges the renderer to the worker's Turso sync status (window.api.sync).
+ * Polls `getStatus` on an interval since there's no change event yet. Outside
+ * Electron (browser preview) returns a static disabled state + no-op — mirrors
+ * the useConnectors pattern.
+ */
+export function useSync(): { status: SyncStatus; syncNow: () => void } {
+  const [status, setStatus] = useState<SyncStatus>(DEFAULT)
+
+  useEffect(() => {
+    if (!isElectron) return
+    let active = true
+    const poll = (): void => {
+      window.api.sync
+        .getStatus()
+        .then((s) => {
+          if (active) setStatus(s)
+        })
+        .catch(() => {}) // status polling is best-effort; never surface a poll error
+    }
+    poll()
+    const id = setInterval(poll, POLL_MS)
+    return () => {
+      active = false
+      clearInterval(id)
+    }
+  }, [])
+
+  if (!isElectron) return { status: DEFAULT, syncNow: () => {} }
+
+  return {
+    status,
+    syncNow: () => {
+      window.api.sync
+        .now()
+        .then(() => window.api.sync.getStatus())
+        .then(setStatus)
+        .catch((e) => console.error('sync now failed', e))
+    }
+  }
+}

--- a/apps/desktop/src/renderer/src/hooks/useSync.ts
+++ b/apps/desktop/src/renderer/src/hooks/useSync.ts
@@ -1,8 +1,14 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import type { SyncStatus } from '@nimi/contract/ipc'
 import { isElectron } from '../nimi/api'
 
-const DEFAULT: SyncStatus = { enabled: false, lastSyncAt: null, syncing: false, error: null }
+const DEFAULT: SyncStatus = {
+  enabled: false,
+  lastSyncAt: null,
+  lastSyncDurationMs: null,
+  syncing: false,
+  error: null
+}
 
 /** How often to re-poll worker sync status. There's no push event yet, so we poll. */
 const POLL_MS = 5000
@@ -17,6 +23,7 @@ const NOOP = (): void => {}
  */
 export function useSync(): { status: SyncStatus; syncNow: () => void } {
   const [status, setStatus] = useState<SyncStatus>(DEFAULT)
+  const syncNowInFlight = useRef(false)
 
   useEffect(() => {
     if (!isElectron) return
@@ -47,12 +54,18 @@ export function useSync(): { status: SyncStatus; syncNow: () => void } {
   }, [])
 
   const syncNow = useCallback(() => {
-    if (!isElectron) return
+    if (!isElectron || syncNowInFlight.current) return
+    syncNowInFlight.current = true
+    setStatus((current) => ({ ...current, syncing: true }))
     window.api.sync
       .now()
       .then(() => window.api.sync.getStatus())
       .then(setStatus)
       .catch((e) => console.error('sync now failed', e))
+      .finally(() => {
+        syncNowInFlight.current = false
+        setStatus((current) => ({ ...current, syncing: false }))
+      })
   }, [])
 
   if (!isElectron) return { status: DEFAULT, syncNow: NOOP }

--- a/apps/desktop/src/renderer/src/nimi/connectors.tsx
+++ b/apps/desktop/src/renderer/src/nimi/connectors.tsx
@@ -6,6 +6,7 @@
 import type { JSX } from 'react'
 import { NIcon } from './icons'
 import { useConnectors } from '../hooks/useConnectors'
+import { relativeTime } from './time'
 import type { ConnectorId } from '@nimi/contract/ipc'
 
 interface ProviderRowProps {
@@ -23,13 +24,7 @@ interface ProviderRowProps {
 
 function formatSync(lastSyncAt: string | null): string {
   if (!lastSyncAt) return 'never synced'
-  const diff = Date.now() - new Date(lastSyncAt).getTime()
-  const mins = Math.floor(diff / 60_000)
-  if (mins < 1) return 'just now'
-  if (mins < 60) return `${mins}m ago`
-  const hrs = Math.floor(mins / 60)
-  if (hrs < 24) return `${hrs}h ago`
-  return `${Math.floor(hrs / 24)}d ago`
+  return relativeTime(new Date(lastSyncAt).getTime())
 }
 
 function ProviderRow({

--- a/apps/desktop/src/renderer/src/nimi/nimi.css
+++ b/apps/desktop/src/renderer/src/nimi/nimi.css
@@ -238,6 +238,37 @@ input {
 .priv-pill svg {
   color: var(--accent-ink);
 }
+.sync-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-family: var(--mono);
+  white-space: nowrap;
+  font-size: 9px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  padding: 5px 9px;
+  border-radius: 999px;
+  border: 1px solid var(--hairline);
+  color: var(--ink-2);
+  background: var(--surface);
+  cursor: pointer;
+}
+button.sync-pill:disabled {
+  cursor: default;
+}
+.sync-pill svg {
+  color: var(--ink-3);
+}
+.sync-pill-err {
+  border-color: color-mix(in srgb, #e5484d 45%, var(--hairline));
+  color: #e5484d;
+  background: color-mix(in srgb, #e5484d 12%, var(--surface));
+  cursor: default;
+}
+.sync-pill-err svg {
+  color: #e5484d;
+}
 .hdr-btn {
   width: 36px;
   height: 36px;

--- a/apps/desktop/src/renderer/src/nimi/nimi.css
+++ b/apps/desktop/src/renderer/src/nimi/nimi.css
@@ -220,7 +220,8 @@ input {
   align-items: center;
   gap: 8px;
 }
-.priv-pill {
+.priv-pill,
+.sync-pill {
   display: inline-flex;
   align-items: center;
   gap: 5px;
@@ -239,19 +240,6 @@ input {
   color: var(--accent-ink);
 }
 .sync-pill {
-  display: inline-flex;
-  align-items: center;
-  gap: 5px;
-  font-family: var(--mono);
-  white-space: nowrap;
-  font-size: 9px;
-  letter-spacing: 0.1em;
-  text-transform: uppercase;
-  padding: 5px 9px;
-  border-radius: 999px;
-  border: 1px solid var(--hairline);
-  color: var(--ink-2);
-  background: var(--surface);
   cursor: pointer;
 }
 button.sync-pill:disabled {

--- a/apps/desktop/src/renderer/src/nimi/nimi.css
+++ b/apps/desktop/src/renderer/src/nimi/nimi.css
@@ -269,6 +269,27 @@ button.sync-pill:disabled {
 .sync-pill-err svg {
   color: #e5484d;
 }
+.sync-wrap {
+  position: relative;
+  display: inline-flex;
+}
+.sync-pop {
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+  z-index: 40;
+  width: 230px;
+  padding: 9px 11px;
+  border-radius: 12px;
+  border: 1px solid color-mix(in srgb, #e5484d 35%, var(--hairline));
+  background: var(--surface-2, var(--surface));
+  box-shadow: 0 8px 24px rgb(0 0 0 / 35%);
+  font-size: 11px;
+  line-height: 1.45;
+  letter-spacing: normal;
+  text-transform: none;
+  color: var(--ink-2);
+}
 .hdr-btn {
   width: 36px;
   height: 36px;

--- a/apps/desktop/src/renderer/src/nimi/nimi.css
+++ b/apps/desktop/src/renderer/src/nimi/nimi.css
@@ -252,7 +252,6 @@ button.sync-pill:disabled {
   border-color: color-mix(in srgb, #e5484d 45%, var(--hairline));
   color: #e5484d;
   background: color-mix(in srgb, #e5484d 12%, var(--surface));
-  cursor: default;
 }
 .sync-pill-err svg {
   color: #e5484d;

--- a/apps/desktop/src/renderer/src/nimi/sync.tsx
+++ b/apps/desktop/src/renderer/src/nimi/sync.tsx
@@ -4,7 +4,7 @@
 // Renders nothing when sync is simply off with no error — it only earns header
 // space when there's something worth showing: an error, an active sync, or a
 // healthy "synced" state. The full error message is exposed via the tooltip.
-import type { JSX } from 'react'
+import { useState, type JSX } from 'react'
 import { NIcon } from './icons'
 import { useSync } from '../hooks/useSync'
 
@@ -20,19 +20,29 @@ function relTime(ts: number | null): string {
 
 export function SyncControl(): JSX.Element | null {
   const { status, syncNow } = useSync()
+  const [showDetail, setShowDetail] = useState(false)
 
   // Error takes priority. `enabled:false` + error = a config problem (e.g. a
   // missing encryption key); `enabled:true` + error = a transient sync failure.
+  // Click reveals the full reason inline (not just the native-title tooltip).
   if (status.error) {
     return (
-      <span
-        className="sync-pill sync-pill-err"
-        title={status.error}
-        role="status"
-        aria-label={`Sync ${status.enabled ? 'error' : 'off'}: ${status.error}`}
-      >
-        <NIcon name="globe" size={12} />
-        {status.enabled ? 'Sync error' : 'Sync off'}
+      <span className="sync-wrap">
+        <button
+          className="sync-pill sync-pill-err"
+          title={status.error}
+          aria-expanded={showDetail}
+          aria-label={`Sync ${status.enabled ? 'error' : 'off'}: ${status.error}`}
+          onClick={() => setShowDetail((v) => !v)}
+        >
+          <NIcon name="globe" size={12} />
+          {status.enabled ? 'Sync error' : 'Sync off'}
+        </button>
+        {showDetail && (
+          <div className="sync-pop" role="status">
+            {status.error}
+          </div>
+        )}
       </span>
     )
   }

--- a/apps/desktop/src/renderer/src/nimi/sync.tsx
+++ b/apps/desktop/src/renderer/src/nimi/sync.tsx
@@ -1,22 +1,7 @@
-// sync.tsx — a compact header pill for Turso cloud-sync status.
-//
-// Self-contained (drives its own `useSync` hook, straight on window.api.sync).
-// Renders nothing when sync is simply off with no error — it only earns header
-// space when there's something worth showing: an error, an active sync, or a
-// healthy "synced" state. The full error message is exposed via the tooltip.
 import { useState, type JSX } from 'react'
 import { NIcon } from './icons'
 import { useSync } from '../hooks/useSync'
-
-function relTime(ts: number | null): string {
-  if (!ts) return 'never'
-  const mins = Math.floor((Date.now() - ts) / 60_000)
-  if (mins < 1) return 'just now'
-  if (mins < 60) return `${mins}m ago`
-  const hrs = Math.floor(mins / 60)
-  if (hrs < 24) return `${hrs}h ago`
-  return `${Math.floor(hrs / 24)}d ago`
-}
+import { relativeTime } from './time'
 
 export function SyncControl(): JSX.Element | null {
   const { status, syncNow } = useSync()
@@ -24,7 +9,7 @@ export function SyncControl(): JSX.Element | null {
 
   // Error takes priority. `enabled:false` + error = a config problem (e.g. a
   // missing encryption key); `enabled:true` + error = a transient sync failure.
-  // Click reveals the full reason inline (not just the native-title tooltip).
+  // Click reveals the full reason inline.
   if (status.error) {
     return (
       <span className="sync-wrap">
@@ -49,14 +34,13 @@ export function SyncControl(): JSX.Element | null {
   // Nothing worth showing when sync isn't configured.
   if (!status.enabled) return null
 
+  const syncedLabel =
+    status.lastSyncAt === null ? 'Synced' : `Synced ${relativeTime(status.lastSyncAt)}`
+
   return (
     <button
       className="sync-pill"
-      title={
-        status.syncing
-          ? 'Syncing with cloud…'
-          : `Synced ${relTime(status.lastSyncAt)} · click to sync now`
-      }
+      title={status.syncing ? 'Syncing with cloud…' : `${syncedLabel} · click to sync now`}
       onClick={syncNow}
       disabled={status.syncing}
       aria-label="Cloud sync status"

--- a/apps/desktop/src/renderer/src/nimi/sync.tsx
+++ b/apps/desktop/src/renderer/src/nimi/sync.tsx
@@ -1,0 +1,59 @@
+// sync.tsx — a compact header pill for Turso cloud-sync status.
+//
+// Self-contained (drives its own `useSync` hook, straight on window.api.sync).
+// Renders nothing when sync is simply off with no error — it only earns header
+// space when there's something worth showing: an error, an active sync, or a
+// healthy "synced" state. The full error message is exposed via the tooltip.
+import type { JSX } from 'react'
+import { NIcon } from './icons'
+import { useSync } from '../hooks/useSync'
+
+function relTime(ts: number | null): string {
+  if (!ts) return 'never'
+  const mins = Math.floor((Date.now() - ts) / 60_000)
+  if (mins < 1) return 'just now'
+  if (mins < 60) return `${mins}m ago`
+  const hrs = Math.floor(mins / 60)
+  if (hrs < 24) return `${hrs}h ago`
+  return `${Math.floor(hrs / 24)}d ago`
+}
+
+export function SyncControl(): JSX.Element | null {
+  const { status, syncNow } = useSync()
+
+  // Error takes priority. `enabled:false` + error = a config problem (e.g. a
+  // missing encryption key); `enabled:true` + error = a transient sync failure.
+  if (status.error) {
+    return (
+      <span
+        className="sync-pill sync-pill-err"
+        title={status.error}
+        role="status"
+        aria-label={`Sync ${status.enabled ? 'error' : 'off'}: ${status.error}`}
+      >
+        <NIcon name="globe" size={12} />
+        {status.enabled ? 'Sync error' : 'Sync off'}
+      </span>
+    )
+  }
+
+  // Nothing worth showing when sync isn't configured.
+  if (!status.enabled) return null
+
+  return (
+    <button
+      className="sync-pill"
+      title={
+        status.syncing
+          ? 'Syncing with cloud…'
+          : `Synced ${relTime(status.lastSyncAt)} · click to sync now`
+      }
+      onClick={syncNow}
+      disabled={status.syncing}
+      aria-label="Cloud sync status"
+    >
+      <NIcon name="globe" size={12} />
+      {status.syncing ? 'Syncing…' : 'Synced'}
+    </button>
+  )
+}

--- a/apps/desktop/src/renderer/src/nimi/sync.tsx
+++ b/apps/desktop/src/renderer/src/nimi/sync.tsx
@@ -30,7 +30,6 @@ export function SyncControl(): JSX.Element | null {
       <span className="sync-wrap">
         <button
           className="sync-pill sync-pill-err"
-          title={status.error}
           aria-expanded={showDetail}
           aria-label={`Sync ${status.enabled ? 'error' : 'off'}: ${status.error}`}
           onClick={() => setShowDetail((v) => !v)}

--- a/apps/desktop/src/renderer/src/nimi/time.ts
+++ b/apps/desktop/src/renderer/src/nimi/time.ts
@@ -1,0 +1,9 @@
+/** Formats a relative elapsed duration from a millisecond Unix timestamp. */
+export function relativeTime(ms: number): string {
+  const mins = Math.floor((Date.now() - ms) / 60_000)
+  if (mins < 1) return 'just now'
+  if (mins < 60) return `${mins}m ago`
+  const hrs = Math.floor(mins / 60)
+  if (hrs < 24) return `${hrs}h ago`
+  return `${Math.floor(hrs / 24)}d ago`
+}

--- a/apps/desktop/src/renderer/src/nimi/today.tsx
+++ b/apps/desktop/src/renderer/src/nimi/today.tsx
@@ -6,6 +6,7 @@ import { kindIcon } from './iconKind'
 import { NimiMark, NimiNote } from './mark'
 import { AuthControl } from './auth'
 import { ConnectorsControl } from './connectors'
+import { SyncControl } from './sync'
 import { MemoryContext } from './api'
 import type { Task } from '@nimi/contract/views'
 import type { NimiMarkState } from './types'
@@ -50,6 +51,7 @@ function AppHeader({
         </div>
       </div>
       <div className="hdr-r">
+        <SyncControl />
         <ConnectorsControl />
         <AuthControl />
         <button className="hdr-btn" aria-label="Plan tomorrow" onClick={onTomorrow}>

--- a/apps/desktop/test/services/broker-client.test.ts
+++ b/apps/desktop/test/services/broker-client.test.ts
@@ -1,0 +1,219 @@
+/**
+ * Unit tests for apps/desktop/src/main/sync/broker.ts
+ *
+ * The broker client imports from Electron (`app`, `safeStorage`) and from
+ * `node:fs/promises`. Both are mocked so these tests run in plain Node.
+ *
+ * Covers:
+ *   - isBrokerConfigured() (env-driven flag)
+ *   - getSyncToken() returns cached token when fresh
+ *   - getSyncToken() re-fetches when cached token is near expiry
+ *   - getSyncToken() returns null when broker is not configured
+ *   - clearSyncToken() clears in-memory cache
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+// ── Electron mock ────────────────────────────────────────────────────────────
+
+const mockSafeStorage = {
+  isEncryptionAvailable: vi.fn(() => false), // plaintext fallback for tests
+  encryptString: vi.fn((s: string) => Buffer.from(s, 'utf8')),
+  decryptString: vi.fn((b: Buffer) => b.toString('utf8'))
+}
+const mockApp = {
+  getPath: vi.fn(() => '/tmp/nimi-test-broker')
+}
+
+vi.mock('electron', () => ({
+  app: mockApp,
+  safeStorage: mockSafeStorage
+}))
+
+// ── fs/promises mock ─────────────────────────────────────────────────────────
+
+const mockReadFile = vi.fn<() => Promise<Buffer>>()
+const mockWriteFile = vi.fn<() => Promise<void>>().mockResolvedValue(undefined)
+const mockRm = vi.fn<() => Promise<void>>().mockResolvedValue(undefined)
+
+vi.mock('node:fs/promises', () => ({
+  readFile: (...args: unknown[]) => mockReadFile(...(args as [])),
+  writeFile: (...args: unknown[]) => mockWriteFile(...(args as [])),
+  rm: (...args: unknown[]) => mockRm(...(args as []))
+}))
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+import type { BrokerTokenResponse } from '@nimi/contract/ipc'
+
+function freshToken(overrides: Partial<BrokerTokenResponse> = {}): BrokerTokenResponse {
+  return {
+    syncUrl: 'libsql://neeme-test.turso.io',
+    authToken: 'tok_fresh',
+    expiresAt: Date.now() + 3600_000, // 1 h from now
+    ...overrides
+  }
+}
+
+function staleToken(): BrokerTokenResponse {
+  return freshToken({ expiresAt: Date.now() + 30_000 }) // 30 s — below REFRESH_BUFFER_MS
+}
+
+function makeFetch(response: BrokerTokenResponse | null, status = 200): typeof fetch {
+  return vi.fn(async () => {
+    if (response === null) return new Response('bad', { status: 500 })
+    return new Response(JSON.stringify(response), { status })
+  }) as unknown as typeof fetch
+}
+
+// ── Test state ────────────────────────────────────────────────────────────────
+
+const BROKER_URL = 'https://broker.test'
+const LOGTO_TOKEN = 'logto-access-token'
+
+let savedEnv: Record<string, string | undefined>
+
+beforeEach(() => {
+  savedEnv = { NEEME_SYNC_BROKER_URL: process.env.NEEME_SYNC_BROKER_URL }
+  process.env.NEEME_SYNC_BROKER_URL = BROKER_URL
+  // Clear call counts and reset mock implementations for this test.
+  vi.clearAllMocks()
+  mockReadFile.mockRejectedValue(new Error('no file'))
+  mockWriteFile.mockResolvedValue(undefined)
+  mockRm.mockResolvedValue(undefined)
+  vi.resetModules()
+})
+
+afterEach(() => {
+  if (savedEnv.NEEME_SYNC_BROKER_URL === undefined) delete process.env.NEEME_SYNC_BROKER_URL
+  else process.env.NEEME_SYNC_BROKER_URL = savedEnv.NEEME_SYNC_BROKER_URL
+  vi.restoreAllMocks()
+})
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('isBrokerConfigured', () => {
+  it('returns true when NEEME_SYNC_BROKER_URL is set', async () => {
+    const { isBrokerConfigured } = await import('../../src/main/sync/broker')
+    expect(isBrokerConfigured()).toBe(true)
+  })
+
+  it('returns false when NEEME_SYNC_BROKER_URL is absent', async () => {
+    delete process.env.NEEME_SYNC_BROKER_URL
+    const { isBrokerConfigured } = await import('../../src/main/sync/broker')
+    expect(isBrokerConfigured()).toBe(false)
+  })
+})
+
+describe('getSyncToken', () => {
+  it('returns null when broker is not configured', async () => {
+    delete process.env.NEEME_SYNC_BROKER_URL
+    const { getSyncToken } = await import('../../src/main/sync/broker')
+    const result = await getSyncToken(LOGTO_TOKEN)
+    expect(result).toBeNull()
+  })
+
+  it('fetches from the broker on first call', async () => {
+    const token = freshToken()
+    vi.stubGlobal('fetch', makeFetch(token))
+    const { getSyncToken } = await import('../../src/main/sync/broker')
+    const result = await getSyncToken(LOGTO_TOKEN)
+    expect(result).toEqual(token)
+    expect(global.fetch).toHaveBeenCalledOnce()
+  })
+
+  it('sends Authorization: Bearer header to the broker', async () => {
+    const token = freshToken()
+    const mockFetch = makeFetch(token)
+    vi.stubGlobal('fetch', mockFetch)
+    const { getSyncToken } = await import('../../src/main/sync/broker')
+    await getSyncToken(LOGTO_TOKEN)
+    const [, init] = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0] as [string, RequestInit]
+    expect((init.headers as Record<string, string>).Authorization).toBe(`Bearer ${LOGTO_TOKEN}`)
+  })
+
+  it('returns the cached token on the second call without a second fetch', async () => {
+    const token = freshToken()
+    vi.stubGlobal('fetch', makeFetch(token))
+    const { getSyncToken } = await import('../../src/main/sync/broker')
+    await getSyncToken(LOGTO_TOKEN)
+    await getSyncToken(LOGTO_TOKEN)
+    expect(global.fetch).toHaveBeenCalledOnce() // only one network call
+  })
+
+  it('re-fetches when the cached token is within the 60 s refresh buffer', async () => {
+    const stale = staleToken()
+    const fresh = freshToken({ authToken: 'tok_refreshed' })
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify(stale), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify(fresh), { status: 200 }))
+    vi.stubGlobal('fetch', fetchMock)
+    const { getSyncToken } = await import('../../src/main/sync/broker')
+    await getSyncToken(LOGTO_TOKEN) // fetches stale (30 s left → below buffer)
+    const result = await getSyncToken(LOGTO_TOKEN) // should re-fetch
+    expect(result?.authToken).toBe('tok_refreshed')
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('throws when the broker returns a non-200 status', async () => {
+    vi.stubGlobal('fetch', makeFetch(null, 500))
+    const { getSyncToken } = await import('../../src/main/sync/broker')
+    await expect(getSyncToken(LOGTO_TOKEN)).rejects.toThrow('HTTP 500')
+  })
+
+  it('persists the token to disk after a successful fetch', async () => {
+    const token = freshToken()
+    vi.stubGlobal('fetch', makeFetch(token))
+    const { getSyncToken } = await import('../../src/main/sync/broker')
+    await getSyncToken(LOGTO_TOKEN)
+    expect(mockWriteFile).toHaveBeenCalledOnce()
+  })
+})
+
+describe('clearSyncToken', () => {
+  it('causes the next getSyncToken call to re-fetch', async () => {
+    const token = freshToken()
+    vi.stubGlobal('fetch', makeFetch(token))
+    const { getSyncToken, clearSyncToken } = await import('../../src/main/sync/broker')
+    await getSyncToken(LOGTO_TOKEN)
+    await clearSyncToken()
+    await getSyncToken(LOGTO_TOKEN)
+    expect(global.fetch).toHaveBeenCalledTimes(2)
+  })
+
+  it('removes the persisted token from disk', async () => {
+    const { clearSyncToken } = await import('../../src/main/sync/broker')
+    await clearSyncToken()
+    expect(mockRm).toHaveBeenCalledOnce()
+  })
+})
+
+describe('restoreCachedToken', () => {
+  it('populates the in-memory cache from a fresh disk token', async () => {
+    const token = freshToken()
+    mockReadFile.mockResolvedValue(Buffer.from(JSON.stringify(token), 'utf8'))
+    vi.stubGlobal('fetch', vi.fn()) // should not be called
+    const { restoreCachedToken, getSyncToken } = await import('../../src/main/sync/broker')
+    await restoreCachedToken()
+    const result = await getSyncToken(LOGTO_TOKEN)
+    expect(result).toEqual(token)
+    expect(global.fetch).not.toHaveBeenCalled()
+  })
+
+  it('ignores an expired disk token (does not cache it)', async () => {
+    const expired = freshToken({ expiresAt: Date.now() - 1000 })
+    mockReadFile.mockResolvedValue(Buffer.from(JSON.stringify(expired), 'utf8'))
+    const fresh = freshToken()
+    vi.stubGlobal('fetch', makeFetch(fresh))
+    const { restoreCachedToken, getSyncToken } = await import('../../src/main/sync/broker')
+    await restoreCachedToken()
+    await getSyncToken(LOGTO_TOKEN) // should hit the broker since disk token was expired
+    expect(global.fetch).toHaveBeenCalledOnce()
+  })
+
+  it('is a no-op when broker is not configured', async () => {
+    delete process.env.NEEME_SYNC_BROKER_URL
+    const { restoreCachedToken } = await import('../../src/main/sync/broker')
+    await expect(restoreCachedToken()).resolves.toBeUndefined()
+    expect(mockReadFile).not.toHaveBeenCalled()
+  })
+})

--- a/docs/INTEGRATION.md
+++ b/docs/INTEGRATION.md
@@ -69,6 +69,23 @@ and `'extracted'` to `done`; `'pending'` stays as pending until extraction compl
 | `NEEME_OCR_LANG` | Tesseract language code (default `eng`) |
 | `NEEME_WHISPER_MODEL` | Whisper model (default `Xenova/whisper-tiny`) |
 
+## Cloud sync status (`window.api.sync`)
+
+Opt-in Turso sync (ROADMAP #10) exposes a small status surface on `window.api`:
+
+| Call | Returns | Notes |
+|------|---------|-------|
+| `await window.api.sync.getStatus()` | `SyncStatus` | `{ enabled, lastSyncAt, syncing, error }` |
+| `await window.api.sync.now()` | `void` | trigger an immediate sync; no-op when disabled |
+
+`SyncStatus.error` is set when sync is refused or fails — notably when `NEEME_SYNC=on`
+but no valid `NEEME_SYNC_ENCRYPTION_KEY` is present (`enabled:false` + an error message).
+The renderer surfaces this via `SyncControl` (`nimi/sync.tsx`, driven by the `useSync`
+hook) as a header pill: a red "Sync off"/"Sync error" pill with the message in its
+tooltip, "Syncing…" while a sync runs, or "Synced" (click to sync now) when healthy. The
+pill renders nothing when sync is simply off with no error. There's no push event yet, so
+`useSync` polls `getStatus()` on an interval.
+
 ## Process model
 
 `renderer (sandboxed, no node)` → `preload (contextBridge)` → `main (router)` → `utilityProcess (DB + pipeline/todos)`. See `docs/SECURITY.md`.

--- a/docs/adr/0008-sync-auth-token-broker.md
+++ b/docs/adr/0008-sync-auth-token-broker.md
@@ -1,0 +1,158 @@
+# ADR 0008 — Sync authentication & per-user database provisioning (token broker)
+
+**Status:** ✅ Accepted — signed off by jlee, 2026-06-02. Implementation begins in
+`services/token-broker` (see Hosting below).
+**Date:** 2026-06-02
+**Context owners:** jlee (+ Cursor agent)
+**Related:** builds on [[0002-authentication]] (Logto OIDC + PKCE, `safeStorage`, JWKS-verify);
+under [[0003-all-typescript-on-device-pipeline]] (TS backend); settles the auth/provisioning
+seam of the Turso sync path planned in `docs/plans/sync-cloud-offload.plan.md`; security posture
+ties to the field-encryption work (ROADMAP #10). The [[0001-sync-and-processing-architecture]]
+amendment (Turso embedded replicas as the sync mechanism) was **Accepted 2026-06-02** — the
+assumption this ADR depended on is now resolved.
+
+## Problem
+
+Opt-in cloud sync (ROADMAP #10) uses **Turso / libSQL embedded replicas** with a
+**database-per-user** model (one Turso DB per Logto `sub`, because a replica mirrors the *whole*
+database — row-scoping can't isolate across devices). That raises an auth + provisioning question
+this ADR settles:
+
+> A device is authenticated only with a **Logto** identity. How does it obtain a credential
+> scoped to **its** user's Turso database, and how do per-user databases get **created**, without
+> ever placing a privileged credential in the client?
+
+A natural-looking shortcut is Turso's **external JWKS** feature (point Turso at the IdP's JWKS so
+clients present the IdP JWT directly). Two facts rule it out:
+
+1. **It supports only Clerk and Auth0** (the Turso dashboard states "Maximum 2 endpoints allowed
+   (Clerk and Auth0)"). nimi uses **Logto** (ADR 0002) — not supported.
+2. **It doesn't provision databases.** Creating a per-user DB needs the Turso **Platform API**
+   regardless, which requires an org-admin token that must never ship in the client.
+
+So even if Logto were supported, we'd still need a server. The IdP-support limitation is therefore
+moot for us.
+
+## Decision
+
+Adopt a **token broker**: a small, stateless, **server-side TypeScript** service (ADR 0003) that
+authenticates the Logto token and brokers Turso access + provisioning. **The client never holds
+Turso's admin token and never presents a Logto JWT to Turso** — it presents a Turso-native,
+DB-scoped token the broker mints.
+
+### Broker responsibilities
+
+1. Receive the Logto **access token** from the desktop app (`POST`).
+2. **JWKS-verify** it (`jose` / `createRemoteJWKSet`, the same approach already in
+   `apps/desktop/src/main/auth/logto.ts`) → trust the `sub` claim.
+3. **Provision-or-look-up** the user's Turso DB via the Platform API (create on first device,
+   keyed by `sub`; the same `syncUrl` is returned to every device of that user).
+4. **Mint a short-lived, DB-scoped Turso token** and return `{ syncUrl, authToken, expiresAt }`.
+
+### Client handoff (mirrors the existing connector token pattern)
+
+- Main calls the broker with `await auth.getAccessToken()`, caches `{ syncUrl, authToken }` in
+  Electron `safeStorage` (like the Logto refresh token), and **pushes it to the worker** over a
+  new `@nimi/contract` channel — the same shape as `call(IPC.connectorsIngest, [provider, token])`.
+- The worker builds the embedded replica with that token. On `401`/expiry it asks main to refresh
+  (broadcast pattern like `auth.onChange`).
+- **The renderer never sees any token** — only scoped `window.api.*` methods cross the
+  contextBridge (`docs/SECURITY.md` invariants).
+
+## Options considered
+
+Legend: ✅ strong · ⚠️ caveats · ❌ poor
+
+| Option | Works with Logto? | Provisions per-user DBs? | Admin secret stays server-side? | Verdict |
+|---|---|---|---|---|
+| **A. Token broker** *(chosen)* | ✅ any IdP (broker verifies) | ✅ yes (Platform API) | ✅ yes | ✅ only option that does all three |
+| **B. Turso external JWKS (direct)** | ❌ Clerk/Auth0 only | ❌ no (still needs Platform API) | n/a | ❌ unusable for Logto + incomplete |
+| **C. Admin/Platform token in the client** | ✅ | ✅ | ❌ **org-admin token shippable → can read/destroy every user's DB** | ❌ security footgun |
+
+A is the only path that supports Logto, provisions databases, and keeps the privileged credential
+off the client. B is the shortcut the dashboard screenshot tempts you toward, but it neither
+supports our IdP nor provisions DBs. C is rejected outright.
+
+## Token lifecycle & custody
+
+| Credential | Lives where | Scope / lifetime |
+|---|---|---|
+| Logto refresh token | Electron `safeStorage` (OS keychain), main | long-lived; never in renderer |
+| Logto access token | main, transient | short-lived; only used to call the broker |
+| **Turso DB token** | minted by broker → cached in `safeStorage` → passed to worker | **short-lived, scoped to one user's DB**; refreshed on `401` |
+| `TURSO_PLATFORM_TOKEN` (org admin) | **broker only (server-side env secret)** | never ships in the app |
+
+## Threat model (what each control buys)
+
+| Threat | Mitigation |
+|---|---|
+| Client binary reverse-engineered | No admin token present; only a short-lived, single-DB token |
+| A user's DB token leaks | Scoped to that user's DB only + short-lived → bounded blast radius, expires fast |
+| Renderer/XSS reaches a token | Renderer holds **no** tokens; contextBridge exposes only scoped methods |
+| Cloud provider (or broker) is curious/compromised | **Client-side field encryption** → primary holds **ciphertext**; content unreadable server-side |
+| Cross-user data exposure | **Database-per-user** → a token can't address another user's DB |
+| Broker impersonation | Broker **JWKS-verifies** the Logto token (issuer/audience) before minting anything |
+
+**Residual risk (documented, not mitigated here):** metadata leakage — the cloud still sees row
+counts, timestamps, sha256 ids, and sizes. Hiding those requires a CRDT blob mesh (Jazz /
+Automerge + relay), parked as a future privacy track in the sync plan and ADR 0001.
+
+## Hosting
+
+The broker is **stateless, called once-per-session, and cached** — cold start is irrelevant.
+Host: a **Vercel** function (Hono) in `services/token-broker` — a new pnpm workspace in this
+repo (all-TS per ADR 0003). Env secrets: `TURSO_PLATFORM_TOKEN`, `TURSO_ORG`, `TURSO_GROUP`,
+`LOGTO_ISSUER`, `LOGTO_AUDIENCE`, `LOGTO_JWKS_URL`, optional `TOKEN_TTL_SECONDS`. Cloudflare
+Workers is an equally good alternative. **Not** the (Python, currently-undeployed) neeme FastAPI —
+wrong language for the ADR 0003 TS-backend direction.
+
+Desktop integration: main fetches the broker token after Logto login, caches the result in
+`safeStorage` (same pattern as the Logto refresh token), injects `NEEME_SYNC_URL` +
+`NEEME_SYNC_AUTH_TOKEN` into the worker env before forking — the existing libSQL embedded-replica
+client in `apps/desktop/src/main/db/index.ts` picks them up with no changes. Configure broker
+mode by setting `NEEME_SYNC_BROKER_URL`; the static `NEEME_SYNC_AUTH_TOKEN` env path remains as
+the documented spike fallback.
+
+## Consequences
+
+- **Easier:** decoupled from Turso's IdP support (Logto works); one server owns both provisioning
+  and token issuance; reuses the proven Logto JWKS-verify + connector token-passing patterns; the
+  privileged token never leaves the server; provider-swappable (the broker abstracts Turso).
+- **Harder:** we now run (a tiny) backend — its first piece of real infrastructure beyond the
+  desktop app; per-user DB lifecycle (create on first login, **teardown on account delete**) must
+  be built and owned; key custody for at-rest field encryption is a separate decision.
+- **Spike shortcut (pre-broker):** a hand-created Turso DB + `turso db tokens create` fed via
+  `NEEME_SYNC_URL` / `NEEME_SYNC_AUTH_TOKEN` proves the replica loop **before** any broker exists
+  (see `docs/setup/turso-credentials.md`). This is what the current #10 slice uses.
+
+## Action items
+
+1. [x] ~~Resolve the [[0001-sync-and-processing-architecture]] amendment (Turso embedded replicas as
+       the sync mechanism) — this ADR assumes it.~~ **Done** — ADR 0001 Accepted 2026-06-02.
+2. [x] ~~Scaffold `services/token-broker`~~ **Done** — Hono + Vercel function implemented in
+       `services/token-broker`; JWKS-verify Logto → Platform-API provision-or-lookup → mint
+       DB-scoped token → `{ syncUrl, authToken, expiresAt }`.
+3. [x] ~~Add the `@nimi/contract` sync-token channel; main caches in `safeStorage` and pushes to the
+       worker.~~ **Done** — `BrokerTokenResponse` in `@nimi/contract/ipc`; main caches token in
+       `safeStorage` and injects into worker env at boot; refresh before expiry.
+4. [ ] Per-user DB **lifecycle**: provisioning naming (`neeme-<subhash>`) is implemented in the
+       broker. **Teardown on account delete** is deferred — needs a delete-account flow first.
+5. [ ] **CSP:** allow the broker + Logto/JWKS origins in `apps/desktop/src/renderer/index.html`
+       (add when broker URL is known).
+
+## Open questions (need a human)
+
+- **Turso org/billing owner** and the Free→Developer threshold (Free caps at **100 DBs/org** ≈ 100
+  users; Developer $4.99/mo lifts it — DB-per-user makes the database *count* the binding limit).
+- **At-rest encryption key custody** — per-user key derivation + recovery/escrow story
+  (lose-key-lose-cloud-data); is recovery in scope, or accept loss?
+- **Account deletion / data teardown** — Platform-API destroy on delete; retention policy.
+- **Token TTL + refresh cadence** — balance security (short) vs broker call frequency (cached).
+
+## Sources
+
+- Turso Platform API (database + token creation) — https://docs.turso.tech/api-reference/databases
+- Turso external JWKS (Clerk/Auth0) — Turso dashboard "JWKS Endpoints" (observed 2026-06)
+- Logto OIDC / JWKS — https://logto.io ; `apps/desktop/src/main/auth/logto.ts`
+- OAuth for native apps (PKCE, system browser) — RFC 8252
+- nimi sync plan — `docs/plans/sync-cloud-offload.plan.md`

--- a/docs/setup/turso-credentials.md
+++ b/docs/setup/turso-credentials.md
@@ -10,13 +10,13 @@ wired; you just need the credentials below.
 
 ### 1. Turso account + org
 
-1. Sign in at <https://turso.tech>.
+1. Sign in at [https://turso.tech](https://turso.tech).
 2. Create (or use) an **organization**. Note the **org slug** (shown in the URL or
-   in `turso org list`).
+  in `turso org list`).
 3. Choose a **plan**:
-   - **Free** — 100 databases/org cap; fine for a closed cohort of < ~80 devices.
-   - **Developer ($4.99/mo)** — unlimited databases; use this the moment you might
-     exceed ~80 user-DBs.
+  - **Free** — 100 databases/org cap; fine for a closed cohort of < ~80 devices.
+  - **Developer ($4.99/mo)** — unlimited databases; use this the moment you might
+  exceed ~80 user-DBs.
 
 ### 2. A group in a region near testers
 
@@ -104,16 +104,16 @@ pnpm dev
 
 1. **Device A** — launch with the env vars above, capture a note.
 2. Check the Turso console to confirm a row appeared in the primary:
-   ```sh
+  ```sh
    turso db shell nimi-test "SELECT id, source_name FROM items LIMIT 5;"
-   ```
+  ```
 3. **Device B** — launch with the **same** `NEEME_SYNC_URL` + `NEEME_SYNC_AUTH_TOKEN`
-   + the **same** `NEEME_SYNC_ENCRYPTION_KEY` (required, and it must match Device A or the
+  - the **same** `NEEME_SYNC_ENCRYPTION_KEY` (required, and it must match Device A or the
    pulled rows cannot be decrypted). On boot the worker calls
    `syncNow()` which pulls from the primary. The note from Device A should appear in
    the archive feed.
 4. Confirm Device B can search semantically — `reindexAll()` runs via `syncEmbedder()`
-   at startup and rebuilds the local `chunks` vector index from the synced `items`.
+  at startup and rebuilds the local `chunks` vector index from the synced `items`.
 
 ---
 
@@ -126,17 +126,72 @@ pnpm dev
 
 ---
 
-## Future automation (after the spike validates)
+## Token broker mode (ADR 0008 — built, awaiting real creds)
 
-Once the two-device loop works, the next steps are:
+The token broker is now implemented in `services/token-broker`. It replaces the manual
+token flow above for production use. To switch from spike mode (manual env vars) to broker
+mode:
 
-1. **Token broker** — a Vercel/Hono function that JWKS-verifies the Logto access token,
-   provisions a per-user Turso DB via the Platform API, and mints a short-lived token.
-   Env vars: `TURSO_PLATFORM_TOKEN`, `TURSO_ORG`, `TURSO_GROUP`, `LOGTO_ISSUER`,
-   `LOGTO_AUDIENCE`, `LOGTO_JWKS_URL`.
-2. **Per-user DB naming** — local replica path keyed by `shortHash(sub)` so account
-   switching uses a separate replica. See `todo: identity-per-user-db` in the plan.
-3. **safeStorage key custody** — derive + seal `NEEME_SYNC_ENCRYPTION_KEY` in Electron
+### What the broker does
+
+1. Desktop main calls `POST /token` with `Authorization: Bearer <Logto access token>`.
+2. Broker JWKS-verifies the Logto token → extracts `sub`.
+3. Broker provisions `neeme-<hash(sub)>` in Turso (idempotent — safe to call repeatedly).
+4. Broker mints a short-lived, DB-scoped token and returns `{ syncUrl, authToken, expiresAt }`.
+5. Desktop injects `NEEME_SYNC_URL` + `NEEME_SYNC_AUTH_TOKEN` before forking the worker.
+
+### Broker credentials to provision (your side)
+
+| Secret | Where to get it |
+|--------|-----------------|
+| `TURSO_PLATFORM_TOKEN` | Turso console → Settings → API Tokens → create org-admin token |
+| `TURSO_ORG` | Your org slug (visible in the Turso URL or `turso org list`) |
+| `TURSO_GROUP` | Group you created in step 2 above (e.g. `nimi-primary`) |
+| `LOGTO_JWKS_URL` | `https://<your-logto-domain>/oidc/jwks` |
+| `LOGTO_ISSUER` | `https://<your-logto-domain>/oidc` |
+| `LOGTO_AUDIENCE` | Your Logto API resource indicator |
+
+### Deploy the broker
+
+```sh
+cd services/token-broker
+# Add secrets to Vercel
+vercel env add TURSO_PLATFORM_TOKEN production
+vercel env add TURSO_ORG production
+vercel env add TURSO_GROUP production
+vercel env add LOGTO_JWKS_URL production
+vercel env add LOGTO_ISSUER production
+vercel env add LOGTO_AUDIENCE production
+# Deploy
+vercel --prod
+```
+
+### Enable broker mode in the desktop app
+
+Set `NEEME_SYNC_BROKER_URL` to your deployed broker URL. The static
+`NEEME_SYNC_AUTH_TOKEN` env path (the spike approach above) still works as a fallback
+if the broker is not configured.
+
+```sh
+NEEME_SYNC=on \
+NEEME_SYNC_BROKER_URL=https://your-broker.vercel.app \
+NEEME_SYNC_ENCRYPTION_KEY=<64-hex-chars> \
+NEEME_EMBEDDER=hash \
+pnpm dev
+```
+
+> Note: `NEEME_SYNC_URL` and `NEEME_SYNC_AUTH_TOKEN` do **not** need to be set manually
+> in broker mode — main fetches them from the broker at boot and injects them before
+> forking the worker.
+
+### Future items (not broker-specific)
+
+1. **safeStorage key custody** — derive + seal `NEEME_SYNC_ENCRYPTION_KEY` in Electron
    `safeStorage` instead of env. See `todo: at-rest-encryption` in the plan.
+2. **Account deletion / teardown** — delete the user's Turso DB via the Platform API
+   when the account is deleted (ADR 0008 action item #4).
+3. **CSP** — add the broker + Logto/JWKS origins to `apps/desktop/src/renderer/index.html`
+   once the broker URL is known (ADR 0008 action item #5).
 
-See `docs/plans/sync-cloud-offload.plan.md` for the full architecture.
+See `docs/plans/sync-cloud-offload.plan.md` for the full architecture and
+`services/token-broker/README.md` for the broker service documentation.

--- a/packages/contract/src/ipc.ts
+++ b/packages/contract/src/ipc.ts
@@ -252,6 +252,7 @@ export interface NimiApi {
   todos: TodoApi
   auth: AuthApi
   connectors: ConnectorsApi
+  sync: SyncApi
   ui: UiApi
   update: UpdateApi
 }
@@ -300,4 +301,11 @@ export interface SyncStatus {
   lastSyncDurationMs: number | null
   syncing: boolean
   error: string | null
+}
+
+export interface SyncApi {
+  /** Current Turso embedded-replica sync status (request-response). */
+  getStatus: () => Promise<SyncStatus>
+  /** Trigger an immediate sync; resolves when complete. No-op when sync is disabled. */
+  now: () => Promise<void>
 }

--- a/packages/contract/src/ipc.ts
+++ b/packages/contract/src/ipc.ts
@@ -285,6 +285,22 @@ export interface UpdateApi {
   onChanged: (cb: (status: UpdateStatus) => void) => () => void
 }
 
+// --- Token broker (ADR 0008 — Logto → per-user Turso DB provisioning) -----
+
+/**
+ * Response from the token broker service (services/token-broker).
+ * Main fetches this at boot (when NEEME_SYNC_BROKER_URL is set), caches it in
+ * safeStorage, and injects syncUrl + authToken into the worker env.
+ */
+export interface BrokerTokenResponse {
+  /** libSQL sync URL for this user's Turso DB, e.g. libsql://<name>-<org>.turso.io */
+  syncUrl: string
+  /** Short-lived, DB-scoped Turso token. Expires at `expiresAt`. */
+  authToken: string
+  /** Unix timestamp (ms) when the token expires. Refresh ~60 s before this. */
+  expiresAt: number
+}
+
 // --- Sync (ROADMAP #10 — cloud offload via Turso embedded replicas) -------
 
 /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -151,6 +151,37 @@ importers:
         specifier: ^7.2.6
         version: 7.3.3(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.3)
 
+  services/token-broker:
+    dependencies:
+      '@hono/node-server':
+        specifier: ^1.14.4
+        version: 1.19.14(hono@4.12.23)
+      '@nimi/contract':
+        specifier: workspace:*
+        version: link:../../packages/contract
+      hono:
+        specifier: ^4.7.11
+        version: 4.12.23
+      jose:
+        specifier: ^6.2.3
+        version: 6.2.3
+    devDependencies:
+      '@types/node':
+        specifier: ^24.12.4
+        version: 24.12.4
+      esbuild:
+        specifier: ^0.25.0
+        version: 0.25.12
+      tsx:
+        specifier: ^4.19.4
+        version: 4.22.3
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: ^4.1.8
+        version: 4.1.8(@types/node@24.12.4)(vite@7.3.3(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.3))
+
 packages:
 
   7zip-bin@5.2.0:
@@ -873,6 +904,12 @@ packages:
 
   '@hey-api/types@0.1.4':
     resolution: {integrity: sha512-thWfawrDIP7wSI9ioT13I5soaaqB5vAPIiZmgD8PbeEVKNrkonc0N/Sjj97ezl7oQgusZmaNphGdMKipPO6IBg==}
+
+  '@hono/node-server@1.19.14':
+    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
 
   '@huggingface/jinja@0.5.9':
     resolution: {integrity: sha512-uWTG+l3VJRsl7EXxYizuL3P+cCPoc3cRqbWWRcQN0FhejRfbdq0RNhCmbY/YDtnTcz9icdLYuLDjsnz4d8JMuw==}
@@ -2605,6 +2642,10 @@ packages:
   hermes-parser@0.25.1:
     resolution: {integrity: sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==}
 
+  hono@4.12.23:
+    resolution: {integrity: sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==}
+    engines: {node: '>=16.9.0'}
+
   hosted-git-info@4.1.0:
     resolution: {integrity: sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==}
     engines: {node: '>=10'}
@@ -4280,7 +4321,7 @@ snapshots:
 
   '@esbuild-kit/core-utils@3.3.2':
     dependencies:
-      esbuild: 0.28.0
+      esbuild: 0.25.12
       source-map-support: 0.5.21
 
   '@esbuild-kit/esm-loader@2.6.5':
@@ -4621,6 +4662,10 @@ snapshots:
       '@hey-api/types': 0.1.4
 
   '@hey-api/types@0.1.4': {}
+
+  '@hono/node-server@1.19.14(hono@4.12.23)':
+    dependencies:
+      hono: 4.12.23
 
   '@huggingface/jinja@0.5.9': {}
 
@@ -6513,6 +6558,8 @@ snapshots:
   hermes-parser@0.25.1:
     dependencies:
       hermes-estree: 0.25.1
+
+  hono@4.12.23: {}
 
   hosted-git-info@4.1.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,4 @@
 packages:
   - 'apps/*'
   - 'packages/*'
+  - 'services/*'

--- a/services/token-broker/README.md
+++ b/services/token-broker/README.md
@@ -1,0 +1,88 @@
+# @nimi/token-broker
+
+Logto → Turso token broker. Implements ADR 0008: a stateless server-side TS service that JWKS-verifies the Logto access token and mints a short-lived, DB-scoped Turso token for the caller's personal embedded replica.
+
+**Never placed in the client.** The Turso org-admin token lives here only.
+
+## Endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `POST` | `/token` | Exchange a Logto access token for a Turso sync token |
+| `GET` | `/health` | Readiness probe — reports missing env vars |
+
+### POST /token
+
+```
+Authorization: Bearer <logto_access_token>
+→ 200 { syncUrl: string, authToken: string, expiresAt: number }
+→ 401 if token is invalid or expired
+→ 502 if the Turso Platform API fails
+→ 503 if required env vars are missing (/health)
+```
+
+`expiresAt` is a Unix timestamp in milliseconds. The desktop client refreshes ~60 s before expiry.
+
+## Environment variables
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `LOGTO_JWKS_URL` | yes | Logto JWKS endpoint, e.g. `https://<domain>/oidc/jwks` |
+| `LOGTO_ISSUER` | yes | Logto issuer, e.g. `https://<domain>/oidc` |
+| `LOGTO_AUDIENCE` | yes | Logto API resource or app-id |
+| `TURSO_PLATFORM_TOKEN` | yes | Turso org-admin token (never shipped to clients) |
+| `TURSO_ORG` | yes | Turso org slug |
+| `TURSO_GROUP` | yes | Turso group name, e.g. `nimi-primary` |
+| `TOKEN_TTL_SECONDS` | no | DB token lifetime; default 3600 (1 h) |
+| `PORT` | no | Local dev port; default 3100 |
+
+## Local development
+
+```sh
+# From the monorepo root
+cd services/token-broker
+
+# Set env vars (or use a .env file with `dotenv-cli`)
+export LOGTO_JWKS_URL=https://your-logto-domain/oidc/jwks
+export LOGTO_ISSUER=https://your-logto-domain/oidc
+export LOGTO_AUDIENCE=your-api-resource
+export TURSO_PLATFORM_TOKEN=your-turso-token
+export TURSO_ORG=your-org-slug
+export TURSO_GROUP=nimi-primary
+
+pnpm dev
+# → http://localhost:3100
+
+# Quick smoke (health check with placeholder env)
+curl http://localhost:3100/health
+```
+
+## Deployment (Vercel)
+
+```sh
+# From services/token-broker
+vercel env add LOGTO_JWKS_URL production
+# ... repeat for all env vars ...
+vercel --prod
+```
+
+Set the deployed URL as `NEEME_SYNC_BROKER_URL` in the desktop app's env (or Electron launch config). The broker origin also needs to be added to the CSP in `apps/desktop/src/renderer/index.html` (ADR 0008 action item #5).
+
+## Tests
+
+```sh
+pnpm test   # runs offline — no real Logto or Turso creds needed
+```
+
+The test suite generates a local RSA keypair with `jose`, stubs a JWKS endpoint, and mocks `fetch` for the Turso Platform API. See `test/broker.test.ts`.
+
+## Database naming
+
+Each user's Turso DB is named `neeme-<16 hex chars of SHA-256(sub)>`. The name is deterministic and stable per Logto `sub`, so:
+- Every device of the same user gets the same `syncUrl`.
+- Concurrent first-login requests for the same user are safe (Turso returns 409 on duplicate create, which the broker treats as success).
+- DB names stay within Turso's 63-character limit.
+
+## Architecture reference
+
+See [docs/adr/0008-sync-auth-token-broker.md](../../docs/adr/0008-sync-auth-token-broker.md) for the full decision record (threat model, option table, token lifecycle, open questions).

--- a/services/token-broker/api/token.ts
+++ b/services/token-broker/api/token.ts
@@ -1,0 +1,18 @@
+/**
+ * Vercel Serverless Function handler.
+ *
+ * Vercel maps `api/token.ts` → any method at `/api/token`.
+ * The vercel.json rewrites expose `/token` and `/health` at the root path.
+ *
+ * Deploy:
+ *   cd services/token-broker && vercel --prod
+ */
+import { createApp } from '../src/app.ts'
+
+const app = createApp()
+
+export default async function handler(req: Request): Promise<Response> {
+  return app.fetch(req)
+}
+
+export const config = { runtime: 'nodejs20.x' }

--- a/services/token-broker/package.json
+++ b/services/token-broker/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@nimi/token-broker",
+  "version": "0.1.0",
+  "description": "Logto → Turso token broker: JWKS-verify the Logto access token and mint a short-lived, DB-scoped Turso token for the user's personal embedded replica.",
+  "private": true,
+  "type": "module",
+  "main": "./dist/index.js",
+  "scripts": {
+    "dev": "tsx watch src/index.ts",
+    "build": "tsc --noEmit && esbuild src/index.ts --bundle --platform=node --target=node20 --outfile=dist/index.js --external:hono",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "@hono/node-server": "^1.14.4",
+    "@nimi/contract": "workspace:*",
+    "hono": "^4.7.11",
+    "jose": "^6.2.3"
+  },
+  "devDependencies": {
+    "@types/node": "^24.12.4",
+    "esbuild": "^0.25.0",
+    "tsx": "^4.19.4",
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.8"
+  }
+}

--- a/services/token-broker/src/app.ts
+++ b/services/token-broker/src/app.ts
@@ -1,0 +1,59 @@
+/**
+ * Token broker — Hono HTTP app factory.
+ *
+ * Endpoints:
+ *   POST /token   — Exchange a Logto access token for a DB-scoped Turso token.
+ *                   Authorization: Bearer <logto_access_token>
+ *   GET  /health  — Readiness probe (checks required env vars).
+ *
+ * Imported by both the local dev server (src/index.ts) and the Vercel handler
+ * (api/token.ts). Stateless — safe to call multiple times.
+ */
+import { Hono } from 'hono'
+import { exchangeToken, LogtoVerifyError, TursoApiError } from './broker.ts'
+
+export const REQUIRED_ENV = [
+  'LOGTO_JWKS_URL',
+  'LOGTO_ISSUER',
+  'LOGTO_AUDIENCE',
+  'TURSO_PLATFORM_TOKEN',
+  'TURSO_ORG',
+  'TURSO_GROUP'
+] as const
+
+export function createApp(): Hono {
+  const app = new Hono()
+
+  app.get('/health', (c) => {
+    const missing = REQUIRED_ENV.filter((k) => !process.env[k])
+    if (missing.length > 0) {
+      return c.json({ ok: false, missing }, 503)
+    }
+    return c.json({ ok: true })
+  })
+
+  app.post('/token', async (c) => {
+    const auth = c.req.header('Authorization') ?? ''
+    if (!auth.startsWith('Bearer ')) {
+      return c.json({ error: 'Missing or malformed Authorization header' }, 401)
+    }
+    const logtoToken = auth.slice(7)
+
+    try {
+      const result = await exchangeToken(logtoToken)
+      return c.json(result)
+    } catch (err) {
+      if (err instanceof LogtoVerifyError) {
+        return c.json({ error: `Token verification failed: ${err.message}` }, 401)
+      }
+      if (err instanceof TursoApiError) {
+        console.error('[broker] Turso API error:', err.message)
+        return c.json({ error: 'Upstream provisioning error' }, err.statusCode as 502)
+      }
+      console.error('[broker] Unexpected error:', err)
+      return c.json({ error: 'Internal server error' }, 500)
+    }
+  })
+
+  return app
+}

--- a/services/token-broker/src/broker.ts
+++ b/services/token-broker/src/broker.ts
@@ -1,0 +1,48 @@
+/**
+ * Broker orchestration — the core of ADR 0008.
+ *
+ * Given a raw Logto access token:
+ *   1. JWKS-verify it → extract the `sub` claim.
+ *   2. Derive a stable DB name: `neeme-<shortHash(sub)>`.
+ *   3. Provision-or-lookup the user's Turso DB via the Platform API.
+ *   4. Mint a short-lived, DB-scoped token.
+ *   5. Return { syncUrl, authToken, expiresAt }.
+ *
+ * Fail-closed: any error in steps 1–4 propagates as a typed error that the
+ * Hono handler maps to the appropriate HTTP status code.
+ */
+import { createHash } from 'node:crypto'
+import type { BrokerTokenResponse } from '@nimi/contract/ipc'
+import { verifyLogtoToken, LogtoVerifyError } from './logto.ts'
+import { provisionOrLookupDb, getDbUrl, mintDbToken, TursoApiError } from './turso.ts'
+
+export { LogtoVerifyError, TursoApiError }
+export type { BrokerTokenResponse }
+
+/**
+ * Derive a stable, url-safe database name from a Logto sub claim.
+ * Uses the first 16 hex chars of the SHA-256 of the sub — long enough to be
+ * collision-resistant for realistic user counts, short enough for Turso's
+ * 63-char DB name limit. Format: `neeme-<16 hex chars>`.
+ */
+function dbNameForSub(sub: string): string {
+  const hash = createHash('sha256').update(sub).digest('hex').slice(0, 16)
+  return `neeme-${hash}`
+}
+
+/**
+ * Exchange a Logto access token for a DB-scoped Turso sync token.
+ * Throws `LogtoVerifyError` (→ 401) or `TursoApiError` (→ 502).
+ */
+export async function exchangeToken(logtoAccessToken: string): Promise<BrokerTokenResponse> {
+  const sub = await verifyLogtoToken(logtoAccessToken)
+  const dbName = dbNameForSub(sub)
+
+  await provisionOrLookupDb(dbName)
+  const [syncUrl, { authToken, expiresAt }] = await Promise.all([
+    getDbUrl(dbName),
+    mintDbToken(dbName)
+  ])
+
+  return { syncUrl, authToken, expiresAt }
+}

--- a/services/token-broker/src/index.ts
+++ b/services/token-broker/src/index.ts
@@ -1,0 +1,20 @@
+/**
+ * Local dev server entry point.
+ * Run with: pnpm dev (which calls: tsx watch src/index.ts)
+ *
+ * For Vercel deployment, use api/token.ts instead — it imports createApp()
+ * directly without starting a Node HTTP server.
+ */
+import { serve } from '@hono/node-server'
+import { createApp, REQUIRED_ENV } from './app.ts'
+
+const missing = REQUIRED_ENV.filter((k) => !process.env[k])
+if (missing.length > 0) {
+  console.warn(`[broker] Warning: missing env vars: ${missing.join(', ')}`)
+  console.warn('[broker] /token will error; /health will report 503')
+}
+
+const app = createApp()
+const port = parseInt(process.env.PORT ?? '3100', 10)
+serve({ fetch: app.fetch, port })
+console.log(`[broker] Listening on http://localhost:${port}`)

--- a/services/token-broker/src/logto.ts
+++ b/services/token-broker/src/logto.ts
@@ -1,0 +1,53 @@
+/**
+ * Logto access-token verifier for the token broker.
+ *
+ * Mirrors the desktop pattern in apps/desktop/src/main/auth/logto.ts:
+ * uses `jose` `createRemoteJWKSet` + `jwtVerify` so the same verification
+ * logic runs server-side. The broker trusts the `sub` claim only after the
+ * full iss/aud/exp/signature check passes.
+ *
+ * Config (env):
+ *   LOGTO_JWKS_URL   — e.g. https://<logto-domain>/oidc/jwks
+ *   LOGTO_ISSUER     — e.g. https://<logto-domain>/oidc
+ *   LOGTO_AUDIENCE   — the Logto API resource indicator (or app-id for M2M)
+ */
+import { createRemoteJWKSet, jwtVerify } from 'jose'
+
+let jwksResolver: ReturnType<typeof createRemoteJWKSet> | null = null
+
+function getJwks(): ReturnType<typeof createRemoteJWKSet> {
+  if (!jwksResolver) {
+    const jwksUrl = process.env.LOGTO_JWKS_URL
+    if (!jwksUrl) throw new Error('LOGTO_JWKS_URL is not set')
+    jwksResolver = createRemoteJWKSet(new URL(jwksUrl))
+  }
+  return jwksResolver
+}
+
+/**
+ * Verify a Logto access token and return the `sub` claim.
+ * Throws `LogtoVerifyError` on any verification failure (expired, wrong iss,
+ * wrong aud, bad signature). The caller should map this to HTTP 401.
+ */
+export async function verifyLogtoToken(token: string): Promise<string> {
+  const issuer = process.env.LOGTO_ISSUER
+  const audience = process.env.LOGTO_AUDIENCE
+  if (!issuer || !audience) throw new Error('LOGTO_ISSUER or LOGTO_AUDIENCE is not set')
+
+  try {
+    const { payload } = await jwtVerify(token, getJwks(), { issuer, audience })
+    const sub = payload.sub
+    if (!sub) throw new LogtoVerifyError('Token has no sub claim')
+    return sub
+  } catch (err) {
+    if (err instanceof LogtoVerifyError) throw err
+    throw new LogtoVerifyError(err instanceof Error ? err.message : String(err))
+  }
+}
+
+export class LogtoVerifyError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'LogtoVerifyError'
+  }
+}

--- a/services/token-broker/src/turso.ts
+++ b/services/token-broker/src/turso.ts
@@ -1,0 +1,111 @@
+/**
+ * Thin Turso Platform API client.
+ *
+ * Wraps the three operations the broker needs:
+ *   1. provisionOrLookupDb — create a per-user DB (idempotent: 409 = already exists).
+ *   2. getDbUrl           — resolve the libSQL sync URL.
+ *   3. mintDbToken        — mint a short-lived, DB-scoped token.
+ *
+ * All network calls are behind this module so tests can mock `fetch` cleanly.
+ *
+ * Config (env):
+ *   TURSO_PLATFORM_TOKEN — org-admin token (server-only, never leaves the broker)
+ *   TURSO_ORG            — Turso org slug
+ *   TURSO_GROUP          — Turso group name (e.g. "nimi-primary")
+ *   TOKEN_TTL_SECONDS    — (optional) DB token lifetime in seconds; default 3600
+ *
+ * Docs: https://docs.turso.tech/api-reference/databases
+ */
+
+const TURSO_API = 'https://api.turso.tech/v1'
+const DEFAULT_TTL_SECONDS = 3600
+
+function headers(): Record<string, string> {
+  const token = process.env.TURSO_PLATFORM_TOKEN
+  if (!token) throw new TursoApiError('TURSO_PLATFORM_TOKEN is not set', 500)
+  return { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' }
+}
+
+function org(): string {
+  const o = process.env.TURSO_ORG
+  if (!o) throw new TursoApiError('TURSO_ORG is not set', 500)
+  return o
+}
+
+function group(): string {
+  const g = process.env.TURSO_GROUP
+  if (!g) throw new TursoApiError('TURSO_GROUP is not set', 500)
+  return g
+}
+
+/**
+ * Create the DB if it doesn't exist, or accept a 409 (already exists).
+ * The database name is deterministic per user (`neeme-<shortHash(sub)>`),
+ * so concurrent requests for the same user are safe.
+ */
+export async function provisionOrLookupDb(name: string): Promise<void> {
+  const url = `${TURSO_API}/organizations/${org()}/databases`
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: headers(),
+    body: JSON.stringify({ name, group: group() })
+  })
+  if (res.status === 409) return // DB already exists — idempotent
+  if (!res.ok) {
+    const body = await res.text().catch(() => '')
+    throw new TursoApiError(`Failed to create DB "${name}": ${body.slice(0, 200)}`, 502)
+  }
+}
+
+/**
+ * Get the libSQL sync URL for the named database.
+ * Returns the string the client passes to `createClient({ syncUrl })`.
+ */
+export async function getDbUrl(name: string): Promise<string> {
+  const url = `${TURSO_API}/organizations/${org()}/databases/${name}`
+  const res = await fetch(url, { headers: headers() })
+  if (!res.ok) {
+    const body = await res.text().catch(() => '')
+    throw new TursoApiError(`Failed to get DB "${name}": ${body.slice(0, 200)}`, 502)
+  }
+  const data = (await res.json()) as { database?: { hostname?: string } }
+  const hostname = data.database?.hostname
+  if (!hostname) throw new TursoApiError(`DB "${name}" has no hostname`, 502)
+  return `libsql://${hostname}`
+}
+
+/**
+ * Mint a short-lived, DB-scoped auth token and return it.
+ * The expiry is controlled by TOKEN_TTL_SECONDS (env) or DEFAULT_TTL_SECONDS.
+ * Returns the raw JWT string and the expiry as a Unix timestamp in ms.
+ */
+export async function mintDbToken(name: string): Promise<{ authToken: string; expiresAt: number }> {
+  const ttl = parseInt(process.env.TOKEN_TTL_SECONDS ?? String(DEFAULT_TTL_SECONDS), 10)
+  const safeTtl = isNaN(ttl) || ttl < 60 ? DEFAULT_TTL_SECONDS : ttl
+
+  const url = `${TURSO_API}/organizations/${org()}/databases/${name}/auth/tokens`
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: headers(),
+    body: JSON.stringify({ expiration: `${safeTtl}s`, authorization: 'full-access' })
+  })
+  if (!res.ok) {
+    const body = await res.text().catch(() => '')
+    throw new TursoApiError(`Failed to mint token for "${name}": ${body.slice(0, 200)}`, 502)
+  }
+  const data = (await res.json()) as { jwt?: string }
+  const jwt = data.jwt
+  if (!jwt) throw new TursoApiError(`Turso returned no JWT for "${name}"`, 502)
+
+  return { authToken: jwt, expiresAt: Date.now() + safeTtl * 1000 }
+}
+
+export class TursoApiError extends Error {
+  constructor(
+    message: string,
+    public readonly statusCode: number
+  ) {
+    super(message)
+    this.name = 'TursoApiError'
+  }
+}

--- a/services/token-broker/test/broker.test.ts
+++ b/services/token-broker/test/broker.test.ts
@@ -1,0 +1,273 @@
+/**
+ * Token broker tests — fully offline (no real Logto or Turso creds needed).
+ *
+ * Uses:
+ *   - A locally generated RSA-2048 keypair (jose generateKeyPair) to sign JWTs.
+ *   - A stubbed JWKS endpoint via fetch mock.
+ *   - A mocked fetch for all Turso Platform API calls.
+ */
+import { describe, it, expect, beforeAll, vi, beforeEach } from 'vitest'
+import { generateKeyPair, exportJWK, SignJWT, importJWK } from 'jose'
+import { exchangeToken } from '../src/broker.ts'
+import { LogtoVerifyError } from '../src/logto.ts'
+import { TursoApiError } from '../src/turso.ts'
+
+// ── Key generation (once per suite) ──────────────────────────────────────────
+
+interface KeySet {
+  sign: (payload: { sub: string; exp?: number }) => Promise<string>
+  jwks: () => object
+}
+
+async function makeKeySet(): Promise<KeySet> {
+  const { privateKey, publicKey } = await generateKeyPair('RS256')
+  const pub = await exportJWK(publicKey)
+  pub.kid = 'test-key-1'
+  pub.use = 'sig'
+  pub.alg = 'RS256'
+
+  const sign = async (payload: { sub: string; exp?: number }): Promise<string> => {
+    return new SignJWT({ sub: payload.sub })
+      .setProtectedHeader({ alg: 'RS256', kid: 'test-key-1' })
+      .setIssuer('https://logto.test/oidc')
+      .setAudience('test-audience')
+      .setIssuedAt()
+      .setExpirationTime(payload.exp ? new Date(payload.exp * 1000) : '1h')
+      .sign(privateKey)
+  }
+
+  // Returns a local RSA private key that can be used to verify via the JWK —
+  // we export the private key as JWK with just the public components for JWKS.
+  const jwks = () => ({ keys: [pub] })
+
+  return { sign, jwks }
+}
+
+// ── Env helpers ───────────────────────────────────────────────────────────────
+
+function setEnv(overrides: Record<string, string> = {}): void {
+  process.env.LOGTO_JWKS_URL = 'https://logto.test/oidc/jwks'
+  process.env.LOGTO_ISSUER = 'https://logto.test/oidc'
+  process.env.LOGTO_AUDIENCE = 'test-audience'
+  process.env.TURSO_PLATFORM_TOKEN = 'test-turso-token'
+  process.env.TURSO_ORG = 'test-org'
+  process.env.TURSO_GROUP = 'test-group'
+  process.env.TOKEN_TTL_SECONDS = '3600'
+  Object.assign(process.env, overrides)
+}
+
+// ── Turso API mock helpers ────────────────────────────────────────────────────
+
+function makeTursoFetch(opts: { createStatus?: number; getStatus?: number; mintStatus?: number } = {}) {
+  return async (url: string, init?: RequestInit): Promise<Response> => {
+    const method = init?.method?.toUpperCase() ?? 'GET'
+    const urlStr = String(url)
+
+    // JWKS endpoint (Logto)
+    if (urlStr.includes('logto.test')) {
+      return new Response(JSON.stringify(keySet.jwks()), { status: 200 })
+    }
+
+    // Turso: POST /databases → create
+    if (method === 'POST' && urlStr.includes('/databases') && !urlStr.includes('/auth')) {
+      const status = opts.createStatus ?? 201
+      if (status === 409) return new Response(JSON.stringify({ error: 'already exists' }), { status: 409 })
+      if (status >= 400) return new Response('error', { status })
+      return new Response(JSON.stringify({ database: { name: 'neeme-test' } }), { status: 201 })
+    }
+
+    // Turso: GET /databases/:name → db info
+    if (method === 'GET' && urlStr.match(/\/databases\/[^/]+$/)) {
+      const status = opts.getStatus ?? 200
+      if (status >= 400) return new Response('error', { status })
+      return new Response(JSON.stringify({ database: { hostname: 'neeme-test-test-org.turso.io' } }), { status: 200 })
+    }
+
+    // Turso: POST /databases/:name/auth/tokens → mint
+    if (method === 'POST' && urlStr.includes('/auth/tokens')) {
+      const status = opts.mintStatus ?? 200
+      if (status >= 400) return new Response('error', { status })
+      return new Response(JSON.stringify({ jwt: 'minted-turso-jwt' }), { status: 200 })
+    }
+
+    return new Response('unexpected url: ' + urlStr, { status: 404 })
+  }
+}
+
+// ── Test state ────────────────────────────────────────────────────────────────
+
+let keySet: KeySet
+
+beforeAll(async () => {
+  keySet = await makeKeySet()
+})
+
+beforeEach(() => {
+  setEnv()
+  // jose's JWKS resolver caches the key set — reset the module to clear the
+  // cached resolver between tests (logto.ts uses a module-level singleton).
+  vi.resetModules()
+})
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('exchangeToken — happy path', () => {
+  it('returns syncUrl + authToken + expiresAt for a valid token', async () => {
+    const jwt = await keySet.sign({ sub: 'user-123' })
+    const fetchMock = vi.fn(makeTursoFetch())
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { exchangeToken: exchange } = await import('../src/broker.ts')
+    const result = await exchange(jwt)
+
+    expect(result.syncUrl).toBe('libsql://neeme-test-test-org.turso.io')
+    expect(result.authToken).toBe('minted-turso-jwt')
+    expect(result.expiresAt).toBeGreaterThan(Date.now())
+  })
+
+  it('idempotent on 409 (DB already exists)', async () => {
+    const jwt = await keySet.sign({ sub: 'existing-user' })
+    const fetchMock = vi.fn(makeTursoFetch({ createStatus: 409 }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { exchangeToken: exchange } = await import('../src/broker.ts')
+    const result = await exchange(jwt)
+
+    expect(result.syncUrl).toContain('libsql://')
+    expect(result.authToken).toBe('minted-turso-jwt')
+  })
+
+  it('derives a consistent DB name from the same sub', async () => {
+    const jwt1 = await keySet.sign({ sub: 'stable-user' })
+    const jwt2 = await keySet.sign({ sub: 'stable-user' })
+    const calls: string[] = []
+    const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      calls.push(`${init?.method ?? 'GET'} ${url}`)
+      return makeTursoFetch()(url, init)
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { exchangeToken: exchange } = await import('../src/broker.ts')
+    await exchange(jwt1)
+    const dbCallsForFirst = calls.filter(c => c.includes('/databases/')).map(c => c.replace(/.*\/databases\//, '').split('/')[0])
+
+    calls.length = 0
+    await exchange(jwt2)
+    const dbCallsForSecond = calls.filter(c => c.includes('/databases/')).map(c => c.replace(/.*\/databases\//, '').split('/')[0])
+
+    expect(dbCallsForFirst[0]).toBe(dbCallsForSecond[0])
+  })
+})
+
+describe('exchangeToken — invalid Logto token', () => {
+  it('throws LogtoVerifyError for a garbage token', async () => {
+    const fetchMock = vi.fn(makeTursoFetch())
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { exchangeToken: exchange, LogtoVerifyError: LVE } = await import('../src/broker.ts')
+    await expect(exchange('not.a.jwt')).rejects.toThrow(LVE)
+  })
+
+  it('throws LogtoVerifyError for an expired token', async () => {
+    const past = Math.floor(Date.now() / 1000) - 3600
+    const jwt = await keySet.sign({ sub: 'expired-user', exp: past })
+    const fetchMock = vi.fn(makeTursoFetch())
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { exchangeToken: exchange, LogtoVerifyError: LVE } = await import('../src/broker.ts')
+    await expect(exchange(jwt)).rejects.toThrow(LVE)
+  })
+
+  it('throws LogtoVerifyError when JWKS fetch fails', async () => {
+    const jwt = await keySet.sign({ sub: 'user-x' })
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      if (String(url).includes('logto.test')) return new Response('gone', { status: 503 })
+      return makeTursoFetch()(url)
+    }))
+
+    const { exchangeToken: exchange, LogtoVerifyError: LVE } = await import('../src/broker.ts')
+    await expect(exchange(jwt)).rejects.toThrow(LVE)
+  })
+})
+
+describe('exchangeToken — Turso API failures', () => {
+  it('throws TursoApiError when DB creation fails (non-409 error)', async () => {
+    const jwt = await keySet.sign({ sub: 'user-fail' })
+    vi.stubGlobal('fetch', vi.fn(makeTursoFetch({ createStatus: 500 })))
+
+    const { exchangeToken: exchange, TursoApiError: TAE } = await import('../src/broker.ts')
+    await expect(exchange(jwt)).rejects.toThrow(TAE)
+  })
+
+  it('throws TursoApiError when token mint fails', async () => {
+    const jwt = await keySet.sign({ sub: 'user-mintfail' })
+    vi.stubGlobal('fetch', vi.fn(makeTursoFetch({ mintStatus: 500 })))
+
+    const { exchangeToken: exchange, TursoApiError: TAE } = await import('../src/broker.ts')
+    await expect(exchange(jwt)).rejects.toThrow(TAE)
+  })
+})
+
+describe('Hono app — HTTP layer', () => {
+  it('GET /health returns 503 when env vars are missing', async () => {
+    delete process.env.TURSO_PLATFORM_TOKEN
+    const { createApp } = await import('../src/app.ts')
+    const app = createApp()
+    const res = await app.fetch(new Request('http://localhost/health'))
+    expect(res.status).toBe(503)
+    const body = (await res.json()) as { ok: boolean; missing: string[] }
+    expect(body.ok).toBe(false)
+    expect(body.missing).toContain('TURSO_PLATFORM_TOKEN')
+  })
+
+  it('GET /health returns 200 when all env vars are set', async () => {
+    setEnv()
+    const { createApp } = await import('../src/app.ts')
+    const app = createApp()
+    const res = await app.fetch(new Request('http://localhost/health'))
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { ok: boolean }
+    expect(body.ok).toBe(true)
+  })
+
+  it('POST /token without Authorization returns 401', async () => {
+    setEnv()
+    const { createApp } = await import('../src/app.ts')
+    const app = createApp()
+    const res = await app.fetch(new Request('http://localhost/token', { method: 'POST' }))
+    expect(res.status).toBe(401)
+  })
+
+  it('POST /token with a valid JWT returns 200 + BrokerTokenResponse', async () => {
+    setEnv()
+    vi.stubGlobal('fetch', vi.fn(makeTursoFetch()))
+    const jwt = await keySet.sign({ sub: 'http-user' })
+    const { createApp } = await import('../src/app.ts')
+    const app = createApp()
+    const res = await app.fetch(
+      new Request('http://localhost/token', {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${jwt}` }
+      })
+    )
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { syncUrl: string; authToken: string; expiresAt: number }
+    expect(body.syncUrl).toContain('libsql://')
+    expect(body.authToken).toBe('minted-turso-jwt')
+    expect(body.expiresAt).toBeGreaterThan(Date.now())
+  })
+
+  it('POST /token with an invalid JWT returns 401', async () => {
+    setEnv()
+    vi.stubGlobal('fetch', vi.fn(makeTursoFetch()))
+    const { createApp } = await import('../src/app.ts')
+    const app = createApp()
+    const res = await app.fetch(
+      new Request('http://localhost/token', {
+        method: 'POST',
+        headers: { Authorization: 'Bearer bad.token.here' }
+      })
+    )
+    expect(res.status).toBe(401)
+  })
+})

--- a/services/token-broker/tsconfig.json
+++ b/services/token-broker/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022", "DOM"],
+    "types": ["node"],
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "verbatimModuleSyntax": true,
+    "allowImportingTsExtensions": true
+  },
+  "include": ["src/**/*", "api/**/*", "test/**/*"]
+}

--- a/services/token-broker/vercel.json
+++ b/services/token-broker/vercel.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "rewrites": [
+    { "source": "/token", "destination": "/api/token" },
+    { "source": "/health", "destination": "/api/token" }
+  ],
+  "env": {
+    "LOGTO_JWKS_URL": "@logto-jwks-url",
+    "LOGTO_ISSUER": "@logto-issuer",
+    "LOGTO_AUDIENCE": "@logto-audience",
+    "TURSO_PLATFORM_TOKEN": "@turso-platform-token",
+    "TURSO_ORG": "@turso-org",
+    "TURSO_GROUP": "@turso-group"
+  }
+}

--- a/services/token-broker/vitest.config.ts
+++ b/services/token-broker/vitest.config.ts
@@ -1,0 +1,20 @@
+import { resolve } from 'path'
+import { fileURLToPath } from 'url'
+import { defineConfig } from 'vitest/config'
+
+const __dirname = fileURLToPath(new URL('.', import.meta.url))
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@nimi/contract': resolve(__dirname, '../../packages/contract/src')
+    }
+  },
+  test: {
+    environment: 'node',
+    globals: true,
+    include: ['test/**/*.test.ts'],
+    isolate: true,
+    testTimeout: 10_000
+  }
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

The worker already emits `SyncStatus.error` (e.g. "sync disabled: a valid `NEEME_SYNC_ENCRYPTION_KEY` is required" from the enforcement change, or transient `client.sync()` failures), but nothing surfaced it in the UI — it only appeared in logs. This wires it through so a misconfigured or failing sync is visible to users.

> Stacked on `cursor/enforce-sync-encryption-3cd9` (PR #46) so the new fail-closed "missing key" error renders too. Base will move to `main` once #46 merges.

## What changed

Fills the contract → preload → renderer gap (worker/main were already wired):

- **contract** (`packages/contract/src/ipc.ts`): add `SyncApi` (`getStatus`/`now`) to `NimiApi`; `docs/INTEGRATION.md` documents the surface.
- **preload**: expose `window.api.sync.{getStatus,now}`.
- **renderer**: `useSync` hook (polls `getStatus`, `isElectron`-guarded, no-op in browser preview) + `SyncControl` header pill in `AppHeader`. Clicking an error pill reveals the full reason in a small popover (native `title` removed to avoid an overlapping OS tooltip).
- **styles** (`nimi.css`): `sync-pill` matching the existing `priv-pill`, error variant, and the popover.

### Pill states
| Worker state | Pill |
|---|---|
| `error` + `enabled:false` (e.g. missing key) | red **"Sync off"**; click → popover with the reason |
| `error` + `enabled:true` (transient failure) | red **"Sync error"**; click → popover |
| `syncing:true` | **"Syncing…"** |
| `enabled:true`, healthy | **"Synced"** (click to sync now) |
| disabled, no error | renders nothing |

No new IPC channels (reuses `sync:get-status` / `sync:now`). Front-lane + contract only.

Also includes (merged from the base branch) a fix to `test/smoke/sync-live.ts` cleanup: it now deletes the test todo by id rather than by its (encrypted) title.

## Testing

Manual GUI test in the live Electron app (`pnpm dev`).

Error state — `NEEME_SYNC=on` with no key → red "Sync off" pill; click reveals the reason:
[sync_off_error_popover_clean.mp4](https://cursor.com/agents/bc-81f3fad4-0487-4010-82c9-fe629f003cd9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsync_off_error_popover_clean.mp4)
[Sync off pill with popover showing the missing-encryption-key reason](https://cursor.com/agents/bc-81f3fad4-0487-4010-82c9-fe629f003cd9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsync_off_popover_clean.webp)

Healthy state — full valid creds → neutral "Synced" pill:
[Synced pill in the header](https://cursor.com/agents/bc-81f3fad4-0487-4010-82c9-fe629f003cd9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsync_synced_pill.webp)

- ✅ `pnpm typecheck`
- ✅ `pnpm --filter @nimi/desktop test` — 240/240
- ✅ `eslint` on changed files — clean
- ✅ Manual GUI: "Sync off" pill + click-to-reveal reason (worker logged the gate refusal); "Synced" pill with valid creds

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-81f3fad4-0487-4010-82c9-fe629f003cd9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-81f3fad4-0487-4010-82c9-fe629f003cd9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

