### PR TITLE
fix(sync): auto-recover when enabling sync on an existing sync-off DB (#10)

### DIFF
--- a/apps/desktop/src/main/db/index.ts
+++ b/apps/desktop/src/main/db/index.ts
@@ -81,6 +81,7 @@ function buildClient(): Client {
     makeReplica: buildReplicaClient,
     dbExists: () => existsSync(dbPath),
     backupAside: (backup) => moveDbAside(dbPath, backup),
+    restoreBackup: (backup) => moveDbAside(backup, dbPath),
     dbPath
   })
   if (backupPath) {

--- a/apps/desktop/src/main/db/index.ts
+++ b/apps/desktop/src/main/db/index.ts
@@ -1,9 +1,11 @@
+import { existsSync, readdirSync, renameSync, rmSync } from 'node:fs'
 import { join } from 'path'
-import { createClient } from '@libsql/client'
+import { createClient, type Client } from '@libsql/client'
 import { drizzle } from 'drizzle-orm/libsql'
 import * as schema from './schema'
 import { userDataDir } from '../runtime/paths'
 import { getSyncConfig } from './sync-config'
+import { buildReplicaWithRecovery, migrateUserData } from './migrate'
 
 /**
  * Local-first data layer on libSQL (a SQLite fork). For now this is a plain
@@ -25,18 +27,85 @@ const dbPath = join(userDataDir(), 'neeme.db')
 
 const syncConfig = getSyncConfig()
 
+/** libSQL writes these sidecars next to the db file; move/remove them together. */
+const DB_SIDECARS = ['', '-wal', '-shm', '-journal', '-info', '-client_wal_index'] as const
+
+/** Path of a pre-sync (plain) DB moved aside so the replica could bootstrap; its
+ *  rows are migrated in after the first successful sync. null when no migration. */
+let preSyncBackupPath: string | null = null
+
+function buildReplicaClient(): Client {
+  return createClient({
+    url: `file:${dbPath}`,
+    syncUrl: syncConfig.syncUrl,
+    authToken: syncConfig.authToken,
+    // Periodic background pull in addition to the worker's explicit syncNow() calls.
+    syncInterval: syncConfig.syncIntervalMs / 1000
+  })
+}
+
+function moveDbAside(from: string, to: string): void {
+  for (const ext of DB_SIDECARS) {
+    if (existsSync(`${from}${ext}`)) renameSync(`${from}${ext}`, `${to}${ext}`)
+  }
+}
+
+/**
+ * Find a pre-sync backup left by a prior boot whose migration didn't finish
+ * (e.g. the network dropped mid-migration). Lets a later boot retry instead of
+ * orphaning the offline data. The Date.now() suffix sorts chronologically.
+ */
+function findOrphanedPreSyncBackup(): string | null {
+  let names: string[]
+  try {
+    names = readdirSync(userDataDir())
+  } catch {
+    return null
+  }
+  const backups = names.filter((n) => /^neeme\.db\.pre-sync-\d+$/.test(n)).sort()
+  const latest = backups[backups.length - 1]
+  return latest ? join(userDataDir(), latest) : null
+}
+
+/**
+ * Build the libSQL client. Sync off → a bare file: client (unchanged — used by
+ * every test). Sync on → an embedded replica. If a plain (sync-off) DB already
+ * exists at the path, libSQL refuses to open it as a replica ("invalid local
+ * state: db file exists but metadata file does not"); we back it up, bootstrap a
+ * fresh replica from the primary, and remember the backup so the worker can
+ * migrate its rows in after the first sync (reimportPreSyncBackup).
+ */
+function buildClient(): Client {
+  if (!syncConfig.enabled) return createClient({ url: `file:${dbPath}` })
+  const { client: replica, backupPath } = buildReplicaWithRecovery({
+    makeReplica: buildReplicaClient,
+    dbExists: () => existsSync(dbPath),
+    backupAside: (backup) => moveDbAside(dbPath, backup),
+    dbPath
+  })
+  if (backupPath) {
+    preSyncBackupPath = backupPath
+    console.warn(
+      `[sync] existing local DB is not an embedded replica — backed it up to ${backupPath} and ` +
+        'bootstrapped a fresh replica from the primary; its data migrates in after first sync'
+    )
+  } else {
+    // No fresh backup this boot, but a prior boot may have backed one up and
+    // failed to migrate it — adopt it so the worker retries after first sync.
+    preSyncBackupPath = findOrphanedPreSyncBackup()
+    if (preSyncBackupPath) {
+      console.warn(
+        `[sync] found pending pre-sync backup ${preSyncBackupPath} — will retry migration`
+      )
+    }
+  }
+  return replica
+}
+
 // Exported so the pipeline can use libSQL's native vector functions
 // (vector32 / vector_distance_cos / libsql_vector_idx) via raw SQL — Drizzle's
 // query builder doesn't model the F32_BLOB type.
-export const client = syncConfig.enabled
-  ? createClient({
-      url: `file:${dbPath}`,
-      syncUrl: syncConfig.syncUrl,
-      authToken: syncConfig.authToken,
-      // Periodic background pull in addition to the worker's explicit syncNow() calls.
-      syncInterval: syncConfig.syncIntervalMs / 1000
-    })
-  : createClient({ url: `file:${dbPath}` })
+export const client = buildClient()
 
 export const db = drizzle(client, { schema })
 
@@ -53,6 +122,30 @@ export const EMBED_DIM = 384
 export async function syncNow(): Promise<void> {
   if (!syncConfig.enabled) return
   await client.sync()
+}
+
+/**
+ * Migrate rows from a pre-sync backup DB (see buildClient) into the live replica,
+ * re-encrypting content under the active key so the cloud primary holds ciphertext.
+ * Call AFTER the first successful sync. No-op when there is no backup. The backup
+ * is deleted only on success and kept on failure, so offline data is never lost.
+ */
+export async function reimportPreSyncBackup(): Promise<number> {
+  if (!preSyncBackupPath) return 0
+  const backup = preSyncBackupPath
+  const src = createClient({ url: `file:${backup}` })
+  try {
+    const n = await migrateUserData(src, client)
+    src.close()
+    for (const ext of DB_SIDECARS) {
+      if (existsSync(`${backup}${ext}`)) rmSync(`${backup}${ext}`)
+    }
+    preSyncBackupPath = null
+    return n
+  } catch (err) {
+    src.close()
+    throw err // keep preSyncBackupPath + backup files so a later boot can retry
+  }
 }
 
 /**

--- a/apps/desktop/src/main/db/migrate.ts
+++ b/apps/desktop/src/main/db/migrate.ts
@@ -1,0 +1,110 @@
+/**
+ * One-time migration of a pre-sync (plain, sync-off) database into a freshly
+ * bootstrapped embedded replica.
+ *
+ * Why this exists: when sync is first enabled on a device that already has a
+ * plain local DB, libSQL cannot open that file as a replica ("invalid local
+ * state: db file exists but metadata file does not"). db/index.ts buildClient()
+ * recovers by moving the plain DB aside and bootstrapping a fresh replica from
+ * the primary; these helpers then copy the user's rows from the backup into the
+ * replica, re-encrypting content under the active key so the cloud primary only
+ * ever receives ciphertext.
+ */
+import type { Client, InValue, Row } from '@libsql/client'
+import { encrypt } from './crypto'
+
+/**
+ * User-data tables worth migrating. `chunks` is intentionally omitted — it's a
+ * rebuildable vector index that reindexAll() regenerates from items.text after
+ * migration. `meta`/`connector_state` are omitted too: they hold the embedder
+ * identity + sync cursors, and carrying stale values across would suppress the
+ * post-migration reindex / confuse connector resync.
+ */
+export const MIGRATABLE_TABLES = ['items', 'memories', 'todos', 'todo_context', 'todo_ai'] as const
+
+/** Per-table content columns that must be encrypted at rest before syncing. */
+const ENCRYPTED_COLUMNS: Record<string, readonly string[]> = {
+  items: ['text'],
+  todos: ['title', 'notes']
+}
+
+/** libSQL rejects opening a plain DB as a replica with this class of message. */
+export function isReplicaStateMismatch(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : String(err)
+  return /invalid local state|metadata file/i.test(msg)
+}
+
+export interface ReplicaRecoveryOps {
+  /** Construct the embedded-replica client (may throw on a state mismatch). */
+  makeReplica: () => Client
+  /** Does a (plain) DB already exist at the target path? */
+  dbExists: () => boolean
+  /** Move the existing plain DB (+ sidecars) aside to `backupPath`. */
+  backupAside: (backupPath: string) => void
+  /** Target DB path, used to derive the backup path. */
+  dbPath: string
+  /** Injectable clock for deterministic backup names in tests. */
+  now?: () => number
+}
+
+/**
+ * Build the embedded replica, recovering from the one expected, recoverable
+ * failure: a plain (sync-off) DB already exists and libSQL refuses to open it as
+ * a replica. In that case we move the plain DB aside and bootstrap a fresh
+ * replica, returning the backup path so its rows can be migrated in after the
+ * first sync. Any other construction error (e.g. a network failure) is re-thrown
+ * unchanged — the caller decides how to handle it.
+ */
+export function buildReplicaWithRecovery(ops: ReplicaRecoveryOps): {
+  client: Client
+  backupPath: string | null
+} {
+  try {
+    return { client: ops.makeReplica(), backupPath: null }
+  } catch (err) {
+    if (!isReplicaStateMismatch(err) || !ops.dbExists()) throw err
+    const backupPath = `${ops.dbPath}.pre-sync-${(ops.now ?? Date.now)()}`
+    ops.backupAside(backupPath)
+    return { client: ops.makeReplica(), backupPath }
+  }
+}
+
+/**
+ * Plaintext → ciphertext under the active key; already-encrypted values pass
+ * through unchanged (same key assumed). encrypt() is a no-op without a key, but
+ * migration only runs with sync on, where a valid key is required.
+ */
+function toStoredContent(value: InValue, encryptCol: boolean): InValue {
+  if (!encryptCol || typeof value !== 'string') return value
+  return value.startsWith('enc:') ? value : encrypt(value)
+}
+
+async function copyTable(src: Client, dest: Client, table: string): Promise<number> {
+  const res = await src.execute(`SELECT * FROM ${table}`)
+  if (res.rows.length === 0) return 0
+  const encCols = ENCRYPTED_COLUMNS[table] ?? []
+  let n = 0
+  for (const row of res.rows as Row[]) {
+    const cols = Object.keys(row)
+    const args = cols.map((c) => toStoredContent(row[c] as InValue, encCols.includes(c)))
+    await dest.execute({
+      sql: `INSERT OR IGNORE INTO ${table} (${cols.join(', ')}) VALUES (${cols.map(() => '?').join(', ')})`,
+      args
+    })
+    n++
+  }
+  return n
+}
+
+/**
+ * Copy user rows src → dest (INSERT OR IGNORE, so rows already pulled from the
+ * primary are not duplicated). Tables missing from src are skipped. Returns the
+ * number of rows processed.
+ */
+export async function migrateUserData(src: Client, dest: Client): Promise<number> {
+  let total = 0
+  for (const table of MIGRATABLE_TABLES) {
+    total += await copyTable(src, dest, table).catch(() => 0)
+  }
+  return total
+}

--- a/apps/desktop/src/main/db/migrate.ts
+++ b/apps/desktop/src/main/db/migrate.ts
@@ -95,6 +95,11 @@ function toStoredContent(value: InValue, encryptCol: boolean): InValue {
   return value.startsWith('enc:') ? value : encrypt(value)
 }
 
+function isMissingTableError(err: unknown, table: string): boolean {
+  const msg = err instanceof Error ? err.message : String(err)
+  return new RegExp(`no such table:\\s*(?:main\\.)?${table}\\b`, 'i').test(msg)
+}
+
 /**
  * Copy all rows from `table` in `src` into `dest` within a single transaction
  * (atomic per-table, idempotent via INSERT OR IGNORE). Column names are
@@ -102,7 +107,13 @@ function toStoredContent(value: InValue, encryptCol: boolean): InValue {
  * rows actually inserted (rowsAffected, not the total selected).
  */
 async function copyTable(src: Client, dest: Client, table: string): Promise<number> {
-  const res = await src.execute(`SELECT * FROM "${table}"`)
+  let res: Awaited<ReturnType<Client['execute']>>
+  try {
+    res = await src.execute(`SELECT * FROM "${table}"`)
+  } catch (err) {
+    if (isMissingTableError(err, table)) return 0
+    throw err
+  }
   if (res.rows.length === 0) return 0
   const encCols = ENCRYPTED_COLUMNS[table] ?? []
   let inserted = 0
@@ -134,7 +145,7 @@ async function copyTable(src: Client, dest: Client, table: string): Promise<numb
 export async function migrateUserData(src: Client, dest: Client): Promise<number> {
   let total = 0
   for (const table of MIGRATABLE_TABLES) {
-    total += await copyTable(src, dest, table).catch(() => 0)
+    total += await copyTable(src, dest, table)
   }
   return total
 }

--- a/apps/desktop/src/main/db/migrate.ts
+++ b/apps/desktop/src/main/db/migrate.ts
@@ -41,6 +41,8 @@ export interface ReplicaRecoveryOps {
   dbExists: () => boolean
   /** Move the existing plain DB (+ sidecars) aside to `backupPath`. */
   backupAside: (backupPath: string) => void
+  /** Restore a backup moved aside by backupAside (called when second makeReplica fails). */
+  restoreBackup: (backupPath: string) => void
   /** Target DB path, used to derive the backup path. */
   dbPath: string
   /** Injectable clock for deterministic backup names in tests. */
@@ -51,9 +53,15 @@ export interface ReplicaRecoveryOps {
  * Build the embedded replica, recovering from the one expected, recoverable
  * failure: a plain (sync-off) DB already exists and libSQL refuses to open it as
  * a replica. In that case we move the plain DB aside and bootstrap a fresh
- * replica, returning the backup path so its rows can be migrated in after the
- * first sync. Any other construction error (e.g. a network failure) is re-thrown
- * unchanged — the caller decides how to handle it.
+ * replica from the primary, returning the backup path so its rows can be migrated
+ * after the first sync.
+ *
+ * If the second makeReplica() call also fails (e.g. a transient network error
+ * after the plain DB was already moved aside), we restore the backup so the user
+ * is left in a valid local-first state instead of a broken one, then re-throw.
+ *
+ * Any other first-call construction error (e.g. a network failure when no DB
+ * exists yet) is re-thrown unchanged — the caller decides how to handle it.
  */
 export function buildReplicaWithRecovery(ops: ReplicaRecoveryOps): {
   client: Client
@@ -65,7 +73,15 @@ export function buildReplicaWithRecovery(ops: ReplicaRecoveryOps): {
     if (!isReplicaStateMismatch(err) || !ops.dbExists()) throw err
     const backupPath = `${ops.dbPath}.pre-sync-${(ops.now ?? Date.now)()}`
     ops.backupAside(backupPath)
-    return { client: ops.makeReplica(), backupPath }
+    try {
+      return { client: ops.makeReplica(), backupPath }
+    } catch (err2) {
+      // The plain DB was moved aside but the replica still can't be built
+      // (e.g. network is down). Restore the backup so the user isn't left
+      // with neither a working local DB nor a replica.
+      ops.restoreBackup(backupPath)
+      throw err2
+    }
   }
 }
 
@@ -79,27 +95,41 @@ function toStoredContent(value: InValue, encryptCol: boolean): InValue {
   return value.startsWith('enc:') ? value : encrypt(value)
 }
 
+/**
+ * Copy all rows from `table` in `src` into `dest` within a single transaction
+ * (atomic per-table, idempotent via INSERT OR IGNORE). Column names are
+ * double-quoted to handle any reserved-word collisions. Returns the number of
+ * rows actually inserted (rowsAffected, not the total selected).
+ */
 async function copyTable(src: Client, dest: Client, table: string): Promise<number> {
-  const res = await src.execute(`SELECT * FROM ${table}`)
+  const res = await src.execute(`SELECT * FROM "${table}"`)
   if (res.rows.length === 0) return 0
   const encCols = ENCRYPTED_COLUMNS[table] ?? []
-  let n = 0
-  for (const row of res.rows as Row[]) {
-    const cols = Object.keys(row)
-    const args = cols.map((c) => toStoredContent(row[c] as InValue, encCols.includes(c)))
-    await dest.execute({
-      sql: `INSERT OR IGNORE INTO ${table} (${cols.join(', ')}) VALUES (${cols.map(() => '?').join(', ')})`,
-      args
-    })
-    n++
+  let inserted = 0
+  await dest.execute('BEGIN')
+  try {
+    for (const row of res.rows as Row[]) {
+      const cols = Object.keys(row)
+      const quotedCols = cols.map((c) => `"${c}"`).join(', ')
+      const args = cols.map((c) => toStoredContent(row[c] as InValue, encCols.includes(c)))
+      const r = await dest.execute({
+        sql: `INSERT OR IGNORE INTO "${table}" (${quotedCols}) VALUES (${cols.map(() => '?').join(', ')})`,
+        args
+      })
+      inserted += r.rowsAffected
+    }
+    await dest.execute('COMMIT')
+  } catch (err) {
+    await dest.execute('ROLLBACK').catch(() => {})
+    throw err
   }
-  return n
+  return inserted
 }
 
 /**
  * Copy user rows src → dest (INSERT OR IGNORE, so rows already pulled from the
  * primary are not duplicated). Tables missing from src are skipped. Returns the
- * number of rows processed.
+ * number of rows actually inserted.
  */
 export async function migrateUserData(src: Client, dest: Client): Promise<number> {
   let total = 0

--- a/apps/desktop/src/main/worker/index.ts
+++ b/apps/desktop/src/main/worker/index.ts
@@ -11,7 +11,7 @@
  */
 import { IPC } from '@nimi/contract/ipc'
 import type { ConnectorId, SyncStatus } from '@nimi/contract/ipc'
-import { initDb, syncNow } from '../db'
+import { initDb, syncNow, reimportPreSyncBackup } from '../db'
 import { getSyncConfig } from '../db/sync-config'
 import { pipelineService } from '../services/pipeline-service'
 import { todoService } from '../services/todo-service'
@@ -117,6 +117,22 @@ async function start(): Promise<void> {
   // ── Boot-time sync (before reindex so the first index sees pulled items) ──
   if (initialSyncConfig.enabled) {
     await runSyncNow()
+
+    // If this device had a pre-sync (sync-off) DB, its rows were backed up while
+    // bootstrapping the replica (db/index.ts buildClient). Migrate them in now —
+    // after the first successful sync so we don't fight the initial pull. Best-effort:
+    // the backup is kept on failure, and reindex below rebuilds the vector index.
+    if (syncState.error === null) {
+      try {
+        const migrated = await reimportPreSyncBackup()
+        if (migrated > 0) {
+          console.log(`[worker] migrated ${migrated} pre-sync row(s) into the replica`)
+          await runSyncNow() // push the migrated rows up to the primary
+        }
+      } catch (err) {
+        console.error('[worker] pre-sync data migration failed (backup kept for retry):', err)
+      }
+    }
 
     // Periodic sync — in addition to the libSQL syncInterval background pull,
     // an explicit loop lets us update syncState and log status.

--- a/apps/desktop/test/services/sync-migrate.test.ts
+++ b/apps/desktop/test/services/sync-migrate.test.ts
@@ -72,6 +72,7 @@ describe('buildReplicaWithRecovery', () => {
       backupAside: () => {
         backedUp = true
       },
+      restoreBackup: () => {},
       dbPath: '/data/neeme.db'
     })
     expect(res.backupPath).toBeNull()
@@ -237,5 +238,15 @@ describe('migrateUserData', () => {
       .rows[0]!
     expect(String(row.text)).toBe(ct)
     expect(decrypt(String(row.text))).toBe('already secret')
+  })
+
+  it('re-throws copy failures so the pre-sync backup is kept for retry', async () => {
+    await src.execute({
+      sql: 'INSERT INTO items (id, source_name, text, status) VALUES (?, ?, ?, ?)',
+      args: ['i3', 'n', 'kept on failure', 'captured']
+    })
+    await dest.execute('DROP TABLE items')
+
+    await expect(migrateUserData(src, dest)).rejects.toThrow(/no such table/i)
   })
 })

--- a/apps/desktop/test/services/sync-migrate.test.ts
+++ b/apps/desktop/test/services/sync-migrate.test.ts
@@ -92,10 +92,11 @@ describe('buildReplicaWithRecovery', () => {
       backupAside: (p) => {
         backupArg = p
       },
+      restoreBackup: () => {},
       dbPath: '/data/neeme.db',
       now: () => 123
     })
-    expect(calls).toBe(2) // failed once, then rebuilt
+    expect(calls).toBe(2)
     expect(res.backupPath).toBe('/data/neeme.db.pre-sync-123')
     expect(backupArg).toBe('/data/neeme.db.pre-sync-123')
   })
@@ -108,12 +109,13 @@ describe('buildReplicaWithRecovery', () => {
         },
         dbExists: () => false,
         backupAside: () => {},
+        restoreBackup: () => {},
         dbPath: '/data/neeme.db'
       })
     ).toThrow(/invalid local state/)
   })
 
-  it('re-throws non-recoverable (e.g. network) construction errors', () => {
+  it('re-throws non-recoverable first-call errors without touching the backup', () => {
     let backedUp = false
     expect(() =>
       buildReplicaWithRecovery({
@@ -124,10 +126,34 @@ describe('buildReplicaWithRecovery', () => {
         backupAside: () => {
           backedUp = true
         },
+        restoreBackup: () => {},
         dbPath: '/data/neeme.db'
       })
     ).toThrow(/tls handshake/)
     expect(backedUp).toBe(false)
+  })
+
+  it('restores the backup when the second makeReplica fails (e.g. transient network error)', () => {
+    let calls = 0
+    let restored: string | undefined
+    expect(() =>
+      buildReplicaWithRecovery({
+        makeReplica: () => {
+          calls++
+          if (calls === 1) throw STATE_MISMATCH
+          throw new Error('error trying to connect: tls handshake eof') // second call fails
+        },
+        dbExists: () => true,
+        backupAside: () => {},
+        restoreBackup: (p) => {
+          restored = p
+        },
+        dbPath: '/data/neeme.db',
+        now: () => 456
+      })
+    ).toThrow(/tls handshake/)
+    expect(calls).toBe(2)
+    expect(restored).toBe('/data/neeme.db.pre-sync-456') // backup restored, user not left broken
   })
 })
 
@@ -188,7 +214,8 @@ describe('migrateUserData', () => {
       args: ['i1', 'n', 'enc:primary-wins', 'captured']
     })
 
-    await migrateUserData(src, dest)
+    const inserted = await migrateUserData(src, dest)
+    expect(inserted).toBe(0) // all rows ignored (already present from primary pull)
 
     const row = (await dest.execute({ sql: 'SELECT text FROM items WHERE id = ?', args: ['i1'] }))
       .rows[0]!

--- a/apps/desktop/test/services/sync-migrate.test.ts
+++ b/apps/desktop/test/services/sync-migrate.test.ts
@@ -1,0 +1,214 @@
+/**
+ * Unit tests for the pre-sync → replica migration (db/migrate.ts).
+ *
+ * Pure logic against two local libSQL files (no replica, no network): proves that
+ * enabling sync on a device with offline data copies that data into the new
+ * replica, encrypting content at rest, without duplicating rows already pulled
+ * from the primary.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { createClient, type Client } from '@libsql/client'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  migrateUserData,
+  isReplicaStateMismatch,
+  buildReplicaWithRecovery
+} from '../../src/main/db/migrate'
+import { encrypt, decrypt } from '../../src/main/db/crypto'
+
+const STATE_MISMATCH = new Error(
+  'sync error: invalid local state: db file exists but metadata file does not'
+)
+const FAKE_CLIENT = {} as unknown as Client
+
+const KEY_ENV = 'NEEME_SYNC_ENCRYPTION_KEY'
+const VALID_KEY = 'a'.repeat(64)
+
+async function makeDb(path: string): Promise<Client> {
+  const c = createClient({ url: `file:${path}` })
+  await c.executeMultiple(`
+    CREATE TABLE items (
+      id TEXT PRIMARY KEY, source_name TEXT NOT NULL, content_type TEXT NOT NULL DEFAULT 'text',
+      size_bytes INTEGER NOT NULL DEFAULT 0, text TEXT NOT NULL DEFAULT '',
+      status TEXT NOT NULL DEFAULT 'captured', created_at INTEGER NOT NULL DEFAULT 0
+    );
+    CREATE TABLE todos (
+      id TEXT PRIMARY KEY, title TEXT NOT NULL, notes TEXT, status TEXT NOT NULL DEFAULT 'open',
+      day TEXT, position INTEGER NOT NULL DEFAULT 0, created_at INTEGER NOT NULL DEFAULT 0,
+      completed_at INTEGER
+    );
+  `)
+  return c
+}
+
+describe('isReplicaStateMismatch', () => {
+  it('matches libSQL invalid-local-state / metadata errors', () => {
+    expect(
+      isReplicaStateMismatch(
+        new Error('sync error: invalid local state: db file exists but metadata file does not')
+      )
+    ).toBe(true)
+    expect(isReplicaStateMismatch(new Error('replica metadata file missing'))).toBe(true)
+  })
+
+  it('rejects unrelated errors', () => {
+    expect(isReplicaStateMismatch(new Error('Replication(PrimaryHandshakeTimeout)'))).toBe(false)
+    expect(isReplicaStateMismatch(new Error('network unreachable'))).toBe(false)
+  })
+})
+
+describe('buildReplicaWithRecovery', () => {
+  it('returns the replica with no backup when construction succeeds', () => {
+    let calls = 0
+    let backedUp = false
+    const res = buildReplicaWithRecovery({
+      makeReplica: () => {
+        calls++
+        return FAKE_CLIENT
+      },
+      dbExists: () => true,
+      backupAside: () => {
+        backedUp = true
+      },
+      dbPath: '/data/neeme.db'
+    })
+    expect(res.backupPath).toBeNull()
+    expect(calls).toBe(1)
+    expect(backedUp).toBe(false)
+  })
+
+  it('on a state mismatch with an existing DB, backs it up and rebuilds', () => {
+    let calls = 0
+    let backupArg: string | undefined
+    const res = buildReplicaWithRecovery({
+      makeReplica: () => {
+        calls++
+        if (calls === 1) throw STATE_MISMATCH
+        return FAKE_CLIENT
+      },
+      dbExists: () => true,
+      backupAside: (p) => {
+        backupArg = p
+      },
+      dbPath: '/data/neeme.db',
+      now: () => 123
+    })
+    expect(calls).toBe(2) // failed once, then rebuilt
+    expect(res.backupPath).toBe('/data/neeme.db.pre-sync-123')
+    expect(backupArg).toBe('/data/neeme.db.pre-sync-123')
+  })
+
+  it('re-throws a state mismatch when no DB exists to back up', () => {
+    expect(() =>
+      buildReplicaWithRecovery({
+        makeReplica: () => {
+          throw STATE_MISMATCH
+        },
+        dbExists: () => false,
+        backupAside: () => {},
+        dbPath: '/data/neeme.db'
+      })
+    ).toThrow(/invalid local state/)
+  })
+
+  it('re-throws non-recoverable (e.g. network) construction errors', () => {
+    let backedUp = false
+    expect(() =>
+      buildReplicaWithRecovery({
+        makeReplica: () => {
+          throw new Error('error trying to connect: tls handshake eof')
+        },
+        dbExists: () => true,
+        backupAside: () => {
+          backedUp = true
+        },
+        dbPath: '/data/neeme.db'
+      })
+    ).toThrow(/tls handshake/)
+    expect(backedUp).toBe(false)
+  })
+})
+
+describe('migrateUserData', () => {
+  let dir: string
+  let src: Client
+  let dest: Client
+  let savedKey: string | undefined
+
+  beforeEach(async () => {
+    savedKey = process.env[KEY_ENV]
+    process.env[KEY_ENV] = VALID_KEY // migration only runs with sync on (key required)
+    dir = mkdtempSync(join(tmpdir(), 'nimi-migrate-'))
+    src = await makeDb(join(dir, 'src.db'))
+    dest = await makeDb(join(dir, 'dest.db'))
+  })
+
+  afterEach(() => {
+    src.close()
+    dest.close()
+    rmSync(dir, { recursive: true, force: true })
+    if (savedKey === undefined) delete process.env[KEY_ENV]
+    else process.env[KEY_ENV] = savedKey
+  })
+
+  it('copies items + todos and encrypts content at rest', async () => {
+    await src.execute({
+      sql: 'INSERT INTO items (id, source_name, text, status) VALUES (?, ?, ?, ?)',
+      args: ['i1', 'note.txt', 'buy oat milk', 'captured']
+    })
+    await src.execute({
+      sql: 'INSERT INTO todos (id, title, notes) VALUES (?, ?, ?)',
+      args: ['t1', 'renew passport', 'gate code 4821']
+    })
+
+    expect(await migrateUserData(src, dest)).toBe(2)
+
+    const item = (await dest.execute({ sql: 'SELECT text FROM items WHERE id = ?', args: ['i1'] }))
+      .rows[0]!
+    const todo = (
+      await dest.execute({ sql: 'SELECT title, notes FROM todos WHERE id = ?', args: ['t1'] })
+    ).rows[0]!
+    expect(String(item.text)).toMatch(/^enc:/)
+    expect(decrypt(String(item.text))).toBe('buy oat milk')
+    expect(String(todo.title)).toMatch(/^enc:/)
+    expect(decrypt(String(todo.title))).toBe('renew passport')
+    expect(decrypt(String(todo.notes))).toBe('gate code 4821')
+  })
+
+  it('is idempotent — INSERT OR IGNORE keeps rows already pulled from the primary', async () => {
+    await src.execute({
+      sql: 'INSERT INTO items (id, source_name, text, status) VALUES (?, ?, ?, ?)',
+      args: ['i1', 'n', 'hello', 'captured']
+    })
+    // dest already has this id (as if pulled from the primary during first sync)
+    await dest.execute({
+      sql: 'INSERT INTO items (id, source_name, text, status) VALUES (?, ?, ?, ?)',
+      args: ['i1', 'n', 'enc:primary-wins', 'captured']
+    })
+
+    await migrateUserData(src, dest)
+
+    const row = (await dest.execute({ sql: 'SELECT text FROM items WHERE id = ?', args: ['i1'] }))
+      .rows[0]!
+    expect(String(row.text)).toBe('enc:primary-wins')
+    expect(Number((await dest.execute('SELECT count(*) c FROM items')).rows[0]!.c)).toBe(1)
+  })
+
+  it('passes already-encrypted values through unchanged (no double-encrypt)', async () => {
+    const ct = encrypt('already secret')
+    expect(ct).toMatch(/^enc:/)
+    await src.execute({
+      sql: 'INSERT INTO items (id, source_name, text, status) VALUES (?, ?, ?, ?)',
+      args: ['i2', 'n', ct, 'captured']
+    })
+
+    await migrateUserData(src, dest)
+
+    const row = (await dest.execute({ sql: 'SELECT text FROM items WHERE id = ?', args: ['i2'] }))
+      .rows[0]!
+    expect(String(row.text)).toBe(ct)
+    expect(decrypt(String(row.text))).toBe('already secret')
+  })
+})

--- a/docs/testing/sync-encryption-runbook.md
+++ b/docs/testing/sync-encryption-runbook.md
@@ -106,6 +106,7 @@ appears in the other's archive (see `docs/setup/turso-credentials.md` §"Smoke t
 | `Replication(PrimaryHandshakeTimeout)` / `replicator sync error` | bad/expired token, wrong URL, or no network | rotate the token (`turso db tokens create`), recheck `NEEME_SYNC_URL` |
 | `[crypto] decrypt failed (wrong key or corrupt data)` warnings | rows on the primary were encrypted with a **different** key | use the same key across devices; warnings are non-fatal (raw value returned) |
 | `[primary] ciphertext: false` | sync ran without a key (older build) or key was unset on Device A | ensure the key is set before capturing; wipe + retry |
+| `invalid local state: db file exists but metadata file does not` | enabling sync on a DB first created sync-off | auto-recovered: the plain DB is backed up, a fresh replica bootstraps, and its rows migrate in after first sync (`db/migrate.ts`) — no manual step needed |
 
 > The "wrong key" warning is by design: `decrypt()` never throws on bad data — it returns
 > the raw value and logs, so a key mismatch degrades gracefully instead of crashing.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## The bug

Enabling sync on a device that already has a plain (sync-off) `neeme.db` crashed the worker at boot. libSQL refuses to open a plain file as an embedded replica:

```
sync error: invalid local state: db file exists but metadata file does not
```

So a user who used the app offline and *then* turned on sync would hit a crash (and previously needed to manually delete their local DB — losing offline captures).

> Stacked on `cursor/enforce-sync-encryption-3cd9` (PR #46). Base moves to `main` once #46 merges.

## The fix

`db/index.ts` `buildClient()` now recovers from that specific, recoverable case:
1. Try to build the embedded replica.
2. If it throws a state mismatch **and** a local DB exists → move the plain DB (+ sidecars) aside to a `neeme.db.pre-sync-<ts>` backup and bootstrap a **fresh replica** from the primary.
3. After the first successful sync, the worker migrates the backup's rows into the replica via `migrateUserData()` — **re-encrypting content under the active key** so the primary only ever holds ciphertext — then deletes the backup.
4. **Durable:** an interrupted migration leaves the backup in place; a later boot adopts the orphaned backup and retries. Data is never deleted before a successful migration.
5. Any **non-recoverable** construction error (e.g. a network/TLS failure) is re-thrown unchanged.

`chunks` (the vector index) is intentionally not migrated — `reindexAll()` rebuilds it from `items.text` after migration.

### Files
- `db/migrate.ts` (new): `isReplicaStateMismatch`, `buildReplicaWithRecovery` (injectable, pure control flow), `migrateUserData`.
- `db/index.ts`: resilient `buildClient`, `reimportPreSyncBackup`, orphan-backup adoption. Sync-off path is byte-for-byte unchanged.
- `worker/index.ts`: migrate pre-sync rows after first successful sync, then push + reindex.
- `docs/testing/sync-encryption-runbook.md`: troubleshooting note.

No contract change. Entirely back-lane (`apps/desktop/src/main/**`).

## Testing

- ✅ `pnpm --filter @nimi/desktop test` — **249/249** (9 new): recovery control flow (success / state-mismatch→backup+rebuild / no-DB re-throw / network re-throw) + data migration (encrypt-at-rest / idempotent INSERT OR IGNORE / no double-encrypt) + mismatch detection.
- ✅ `pnpm typecheck`
- ✅ `eslint` changed files — clean

**Scope of automated coverage:** the recovery control flow and the row-migration logic are unit-tested offline against local libSQL files. The full live `construct → state-mismatch → recover → migrate → push` path requires a reachable Turso primary (the `invalid local state` error only surfaces *after* a successful TLS handshake, so it can't be reproduced with a fake/bogus primary). That exact error was observed earlier against the real primary, and `isReplicaStateMismatch` matches it; the end-to-end is best confirmed via `docs/testing/sync-encryption-runbook.md` with a live DB.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-81f3fad4-0487-4010-82c9-fe629f003cd9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-81f3fad4-0487-4010-82c9-fe629f003cd9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

