### PR TITLE
fix(token-broker): remove secret refs from vercel.json

### DIFF
--- a/services/token-broker/api/token.ts
+++ b/services/token-broker/api/token.ts
@@ -15,4 +15,4 @@ export default async function handler(req: Request): Promise<Response> {
   return app.fetch(req)
 }
 
-export const config = { runtime: 'nodejs20.x' }
+export const config = { runtime: 'nodejs' }

--- a/services/token-broker/package.json
+++ b/services/token-broker/package.json
@@ -14,7 +14,6 @@
   },
   "dependencies": {
     "@hono/node-server": "^1.14.4",
-    "@nimi/contract": "workspace:*",
     "hono": "^4.7.11",
     "jose": "^6.2.3"
   },

--- a/services/token-broker/src/broker.ts
+++ b/services/token-broker/src/broker.ts
@@ -12,12 +12,16 @@
  * Hono handler maps to the appropriate HTTP status code.
  */
 import { createHash } from 'node:crypto'
-import type { BrokerTokenResponse } from '@nimi/contract/ipc'
 import { verifyLogtoToken, LogtoVerifyError } from './logto.ts'
 import { provisionOrLookupDb, getDbUrl, mintDbToken, TursoApiError } from './turso.ts'
 
 export { LogtoVerifyError, TursoApiError }
-export type { BrokerTokenResponse }
+
+export interface BrokerTokenResponse {
+  syncUrl: string
+  authToken: string
+  expiresAt: number
+}
 
 /**
  * Derive a stable, url-safe database name from a Logto sub claim.

--- a/services/token-broker/vercel.json
+++ b/services/token-broker/vercel.json
@@ -3,13 +3,5 @@
   "rewrites": [
     { "source": "/token", "destination": "/api/token" },
     { "source": "/health", "destination": "/api/token" }
-  ],
-  "env": {
-    "LOGTO_JWKS_URL": "@logto-jwks-url",
-    "LOGTO_ISSUER": "@logto-issuer",
-    "LOGTO_AUDIENCE": "@logto-audience",
-    "TURSO_PLATFORM_TOKEN": "@turso-platform-token",
-    "TURSO_ORG": "@turso-org",
-    "TURSO_GROUP": "@turso-group"
-  }
+  ]
 }

--- a/services/token-broker/vitest.config.ts
+++ b/services/token-broker/vitest.config.ts
@@ -1,15 +1,6 @@
-import { resolve } from 'path'
-import { fileURLToPath } from 'url'
 import { defineConfig } from 'vitest/config'
 
-const __dirname = fileURLToPath(new URL('.', import.meta.url))
-
 export default defineConfig({
-  resolve: {
-    alias: {
-      '@nimi/contract': resolve(__dirname, '../../packages/contract/src')
-    }
-  },
   test: {
     environment: 'node',
     globals: true,


### PR DESCRIPTION
The `env` block was using `@secret-name` syntax which references Vercel CLI secrets, not dashboard env vars. Remove it — dashboard env vars are picked up automatically.