### PR TITLE
fix(token-broker): update lockfile after removing @nimi/contract dep

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -156,9 +156,6 @@ importers:
       '@hono/node-server':
         specifier: ^1.14.4
         version: 1.19.14(hono@4.12.23)
-      '@nimi/contract':
-        specifier: workspace:*
-        version: link:../../packages/contract
       hono:
         specifier: ^4.7.11
         version: 4.12.23


### PR DESCRIPTION
Lockfile was outdated after the workspace dependency removal in the previous fix.