### PR TITLE
fix(token-broker): remove .ts extensions from imports (Vercel compile compat)

### DIFF
--- a/services/token-broker/api/token.ts
+++ b/services/token-broker/api/token.ts
@@ -7,7 +7,7 @@
  * Deploy:
  *   cd services/token-broker && vercel --prod
  */
-import { createApp } from '../src/app.ts'
+import { createApp } from '../src/app'
 
 const app = createApp()
 

--- a/services/token-broker/src/app.ts
+++ b/services/token-broker/src/app.ts
@@ -10,7 +10,7 @@
  * (api/token.ts). Stateless — safe to call multiple times.
  */
 import { Hono } from 'hono'
-import { exchangeToken, LogtoVerifyError, TursoApiError } from './broker.ts'
+import { exchangeToken, LogtoVerifyError, TursoApiError } from './broker'
 
 export const REQUIRED_ENV = [
   'LOGTO_JWKS_URL',

--- a/services/token-broker/src/broker.ts
+++ b/services/token-broker/src/broker.ts
@@ -12,8 +12,8 @@
  * Hono handler maps to the appropriate HTTP status code.
  */
 import { createHash } from 'node:crypto'
-import { verifyLogtoToken, LogtoVerifyError } from './logto.ts'
-import { provisionOrLookupDb, getDbUrl, mintDbToken, TursoApiError } from './turso.ts'
+import { LogtoVerifyError, verifyLogtoToken } from './logto'
+import { getDbUrl, mintDbToken, provisionOrLookupDb, TursoApiError } from './turso'
 
 export { LogtoVerifyError, TursoApiError }
 

--- a/services/token-broker/src/index.ts
+++ b/services/token-broker/src/index.ts
@@ -6,7 +6,7 @@
  * directly without starting a Node HTTP server.
  */
 import { serve } from '@hono/node-server'
-import { createApp, REQUIRED_ENV } from './app.ts'
+import { createApp, REQUIRED_ENV } from './app'
 
 const missing = REQUIRED_ENV.filter((k) => !process.env[k])
 if (missing.length > 0) {


### PR DESCRIPTION
Vercel compiles .ts → .js but preserves .ts import extensions in the output, so Node can't resolve them at runtime. Strip all internal .ts extensions — works fine with moduleResolution: Bundler.