### PR TITLE
feat(theme): default accent to matcha (green)

### DIFF
--- a/apps/desktop/src/renderer/src/nimi/NimiApp.tsx
+++ b/apps/desktop/src/renderer/src/nimi/NimiApp.tsx
@@ -7,7 +7,7 @@
 //      frameless-window + tray integration is a later main-process step). The app
 //      is a single centred column on the matcha wallpaper, "the same size as mobile".
 //   2. The design-time TweaksPanel (a variation explorer) is dropped. Its chosen
-//      defaults — dark / rose / stack / cozy / ambient-on — are applied to <html>.
+//      defaults — dark / matcha / stack / cozy / ambient-on — are applied to <html>.
 //      Accent (primary color) is now user-configurable in Settings (nimi/theme.ts);
 //      the header's "Plan tomorrow" button still triggers the new-day ritual.
 //   3. The prototype's menu-bar/tray search + badge live on the header here: the

--- a/apps/desktop/src/renderer/src/nimi/theme.ts
+++ b/apps/desktop/src/renderer/src/nimi/theme.ts
@@ -22,8 +22,15 @@ export interface AccentPalette {
   deep: string
 }
 
-// Ordered for the picker. Rose (red) is the product default.
+// Ordered for the picker (default first). Matcha (green) is the product default.
 export const ACCENTS: Record<AccentId, AccentPalette> = {
+  matcha: {
+    id: 'matcha',
+    label: 'Matcha',
+    solid: 'oklch(0.80 0.13 142)',
+    ink: 'oklch(0.90 0.09 142)',
+    deep: 'oklch(0.62 0.13 142)'
+  },
   rose: {
     id: 'rose',
     label: 'Rose',
@@ -38,13 +45,6 @@ export const ACCENTS: Record<AccentId, AccentPalette> = {
     ink: 'oklch(0.90 0.09 64)',
     deep: 'oklch(0.64 0.12 64)'
   },
-  matcha: {
-    id: 'matcha',
-    label: 'Matcha',
-    solid: 'oklch(0.80 0.13 142)',
-    ink: 'oklch(0.90 0.09 142)',
-    deep: 'oklch(0.62 0.13 142)'
-  },
   iris: {
     id: 'iris',
     label: 'Iris',
@@ -56,7 +56,7 @@ export const ACCENTS: Record<AccentId, AccentPalette> = {
 
 export const ACCENT_LIST: AccentPalette[] = Object.values(ACCENTS)
 
-export const DEFAULT_ACCENT: AccentId = 'rose'
+export const DEFAULT_ACCENT: AccentId = 'matcha'
 
 const STORAGE_KEY = 'nimi.accent'
 


### PR DESCRIPTION
## Summary
- Sets the default primary color to **matcha (green)** (`DEFAULT_ACCENT = 'matcha'`) and lists it first in the Settings color picker.
- Builds on the accent system landed on `main` (the `Appearance` picker + `nimi/theme.ts`): users can still switch to Rose / Apricot / Iris, and the choice persists per device via `localStorage`.

## Changes
- `nimi/theme.ts`: matcha moved to the top of the palette map (picker order = default first); `DEFAULT_ACCENT` flipped from `rose` to `matcha`.
- `NimiApp.tsx`: doc comment updated to reflect the matcha default.

## Test plan
- [ ] `pnpm --filter @nimi/desktop typecheck` passes (verified `typecheck:web` locally).
- [ ] `pnpm lint` clean for changed files (verified locally).
- [ ] Launch the app: header mark + accent surfaces render green on first run (no stored preference).
- [ ] Settings → Appearance: Matcha shows as selected by default; switching to Rose/Apricot/Iris applies instantly and survives a reload.