### PR TITLE
fix(release): make release-please auto-tag by skipping the Merge plugin

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -41,9 +41,16 @@ Because release-please is dispatch-only, cutting a release is a **two-phase** fl
 5. **Phase 2 — ship.** Dispatch **"Release Please"** again. release-please now sees the
    merged release commit, tags `v<version>`, creates the GitHub Release, and the
    `publish-mikan` job builds + publishes the Mikan macOS app.
-6. **Watch the build** (`mcp__github__actions_list` / `actions_get` for that run's
-   `publish-mikan` job) and report the result. On failure, diagnose from job logs and
-   fix forward.
+6. **Confirm the tag was actually cut, then watch the build.** The `publish-mikan` job
+   is gated on `release_created == 'true'` — a green Release Please run that *skipped*
+   `publish-mikan` means **no release was cut**. Verify: (a) `mcp__github__get_release_by_tag`
+   for `v<version>` returns a release; (b) `publish-mikan` ran (not skipped); (c)
+   `.release-please-manifest.json` on `main` now reads `<version>`. If instead the logs
+   show `⚠ PR component: undefined does not match configured component: nimi` /
+   `Expected 1 releases, only found 0`, the config regressed — `separate-pull-requests`
+   must be `true` and `include-component-in-tag` must be `false` (see `docs/RELEASING.md`,
+   "Why `separate-pull-requests: true`"). Then watch the `publish-mikan` build and report
+   the result; on failure, diagnose from job logs and fix forward.
 
 ## To build/publish Momo (opt-in)
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -22,7 +22,7 @@ only through the `/release` skill (which dispatches the release workflow).
 
 | File                                   | Role                                                                                                                                              |
 | -------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `release-please-config.json`           | release-please manifest config: single root release, `extra-files` bump every workspace `package.json`, clean `v<version>` tags.                  |
+| `release-please-config.json`           | release-please manifest config: single root release, `extra-files` bump every workspace `package.json`, clean `v<version>` tags. **`separate-pull-requests: true` is load-bearing — see "Why `separate-pull-requests: true`" below.** |
 | `.release-please-manifest.json`        | The current released version (source of truth release-please reads/writes).                                                                       |
 | `.github/workflows/release-please.yml` | **Dispatch-only.** Maintains the Release PR; on a dispatch after that PR merges, tags + creates the Release and triggers the Mikan build.         |
 | `.github/workflows/release.yml`        | Reusable build/publish job (`workflow_call` + `workflow_dispatch`), parameterized by `BRAND`. Signs + notarizes + publishes via electron-builder. |
@@ -52,6 +52,53 @@ manual equivalent:
 > Why two dispatches instead of "merge = ship"? We deliberately keep `main`
 > automation-free: a normal merge/rebase never triggers a release. Shipping is
 > always an explicit action.
+
+### Confirming Phase 2 actually tagged (don't trust "the PR merged")
+
+Phase 2 only ships if release-please **creates the tag + GitHub Release** — that's
+the gate (`publish-mikan` runs only when `release_created == 'true'`). After the
+second dispatch, confirm all three landed before walking away:
+
+1. **Tag exists:** `gh release view v<version>` (or `git ls-remote --tags origin`)
+   shows the new `v<version>`.
+2. **`publish-mikan` ran** (not skipped) in the Release Please run — `gh run view`.
+3. **The manifest advanced:** release-please's github-release step writes the new
+   version back to `.release-please-manifest.json` on `main`. If that file is still
+   at the *previous* version after a "successful" Phase 2, the release step silently
+   matched **zero** releases — see below.
+
+If you see this in the Release Please logs, Phase 2 found the merged PR but threw it
+away, so no tag was cut and `publish-mikan` was skipped:
+
+```
+⚠ PR component: undefined does not match configured component: nimi
+⚠ Expected 1 releases, only found 0
+```
+
+### Why `separate-pull-requests: true`
+
+This is the fix for exactly that failure (v1.3.0, 2026-06). It is **not** about
+having more than one PR — there's a single root package, so there is only ever one
+release PR either way. It controls whether release-please runs its internal **Merge
+plugin**:
+
+- With `separate-pull-requests: false`, the Merge plugin rewrites the release PR onto
+  the **component-less** branch `release-please--branches--main`. At Phase 2,
+  `buildRelease` takes the "standalone PR" path and compares the branch's component
+  (`undefined`) against the strategy's configured component. For `release-type: node`
+  that component is derived from the root `package.json` `name` (**`nimi`**) — so
+  `'' !== 'nimi'`, the release is discarded, and no tag is cut. Editing the PR title
+  or `pull-request-title-pattern` does **not** help: the discard happens on the
+  component check, before the title matters.
+- With `separate-pull-requests: true`, the Merge plugin is skipped, so the single PR
+  keeps its **component-ful** branch `release-please--branches--main--components--nimi`.
+  Now the branch component (`nimi`) matches the configured component, the release is
+  built, and `include-component-in-tag: false` still yields a clean `v<version>` tag.
+
+So: keep `separate-pull-requests: true` **and** `include-component-in-tag: false`
+together. Flipping either one back reintroduces the broken combination. Unified
+versioning is unaffected — the `extra-files` fan-out is the root package's job and has
+nothing to do with the Merge plugin.
 
 ## Releasing Momo
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "node",
   "include-component-in-tag": false,
-  "separate-pull-requests": false,
+  "separate-pull-requests": true,
   "pull-request-title-pattern": "chore: release v${version}",
   "packages": {
     ".": {


### PR DESCRIPTION
## Problem

Cutting a release stops half-way: the version-bump Release PR merges to `main`, but release-please's **Phase 2** (`createReleases`) never creates the `v<version>` tag / GitHub Release. Because `publish-mikan` is gated on `release_created == 'true'`, the build is skipped and a human has to tag + dispatch by hand. Phase 2 logs:

```
Found pull request #79: 'chore: release ...'
⚠ PR component: undefined does not match configured component: nimi
⚠ Expected 1 releases, only found 0
⚠ Missing 1 paths: .
```

## Root cause (it's not the PR title)

With `separate-pull-requests: false`, release-please **always** runs its internal **Merge plugin** — even though we have a single root package — and the Merge plugin forces the release PR onto the **component-less** branch `release-please--branches--main` (`BranchName.ofTargetBranch`).

At github-release time, `buildRelease` (strategies/base.ts) takes the "standalone PR" path and compares the merged PR's branch component against the strategy's configured component:

- branch component, parsed from `release-please--branches--main` → **`undefined`**
- configured component, for `release-type: node`, falls through to `getDefaultPackageName()` → the root `package.json` `name` → **`nimi`** (node.ts reads `pkg.name`; this is why simply dropping `package-name` from the config does **not** help)

`'' !== 'nimi'` → the release is discarded → no tag → `publish-mikan` skipped. The discard happens on the component check, *before* the title is used for anything but version extraction — which is why editing the PR title / `pull-request-title-pattern` across earlier attempts couldn't have fixed it.

## Fix

```diff
-  "separate-pull-requests": false,
+  "separate-pull-requests": true,
```

For a single root package this changes **nothing** about how many PRs are opened (always one) — it only **skips the Merge plugin**. The single PR then keeps its **component-ful** branch `release-please--branches--main--components--nimi`, whose component (`nimi`) matches the configured component, so the release is built. Tags stay clean `v<version>` because `include-component-in-tag: false` is unchanged. Unified versioning is untouched — the `extra-files` fan-out across `apps/desktop`, `apps/mobile`, `packages/contract`, `packages/brand`, `services/token-broker` is the root package's job and is independent of the Merge plugin.

Rejected alternatives:
- **Drop `package-name`** — insufficient; `release-type: node` reads the name from `package.json` regardless.
- **`include-component-in-tag: true`** — would auto-tag, but as `nimi-v1.3.0`, breaking the required clean `v<version>` tags.

## Verification

Driven against `release-please@17.10.0` (the action's `@v4` line) by calling `buildRelease()` directly with this repo's config and a realistic merged-PR body:

| Branch shape | Produced when | `buildRelease` result |
|---|---|---|
| `release-please--branches--main` | `separate-pull-requests: false` (Merge plugin) | **no release** — emits the exact `⚠ PR component: undefined does not match configured component: nimi` |
| `…--components--nimi` | `separate-pull-requests: true` (no Merge) | **release created, tag `v1.3.0`** |

Holds under **both** the default and the current custom `pull-request-title-pattern`, confirming the title was never the failure. A Phase-1 `release-pr --dry-run` against the live repo confirms version detection is unaffected (`component:` empty → clean tag).

> Full end-to-end (a real tag) can only be observed on the next real Phase-2 dispatch, since the fix changes how *future* release PRs are branched. `docs/RELEASING.md` now documents exactly what to confirm.

## Note: stale manifest (separate, pre-existing)

`.release-please-manifest.json` is still `1.2.0` while `v1.3.0` shipped (manually). This is a *symptom* of the same bug — the github-release step, which writes the manifest back, never ran. release-please's dry-run recovers the real latest (`v1.3.0`) from tags via backfill, so the next cycle computes correctly; I left the version files untouched to keep this PR to the one-line behavioral fix. The next successful Phase 2 will reconcile the manifest automatically (and `RELEASING.md` now tells you to check it).

## Docs
- `docs/RELEASING.md`: "Why `separate-pull-requests: true`" + a Phase-2 "confirm the tag was actually cut" checklist (tag exists / `publish-mikan` ran / manifest advanced).
- `.claude/skills/release/SKILL.md`: Phase-2 step now confirms the tag + manifest instead of trusting a green run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)