### PR TITLE
chore(agents): scaffold Matt Pocock engineering-skills configuration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,3 +82,17 @@ pnpm lint        # eslint over the workspace; your changed files must be clean
 - Auth: Logto OIDC + PKCE in the system browser (ADR 0002), inert until configured.
 - Git: branch off `main`; commit/push only when asked; PRs get a smoke-test note for worker changes.
 - Decisions of record: `docs/adr/0001` (sync/processing), `0002` (auth), `0003` (all-TS on-device pipeline), `0004` (AI drafting model), `0005` (image/audio extraction), `0006` (monorepo structure).
+
+## Agent skills
+
+### Issue tracker
+
+Issues live in **Linear** (via the `productivity:linear` MCP); external PRs are **not** a triage surface. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Canonical vocabulary — `needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`. See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Single-context: `CONTEXT.md` (not yet created) + `docs/adr/` at the repo root. See `docs/agents/domain.md`.

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,51 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the
+codebase. This repo is **single-context**.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root (the domain glossary / ubiquitous language).
+- **`docs/adr/`** — read the ADRs that touch the area you're about to work in. The current set
+  covers sync/processing (0001), auth (0002), the all-TS on-device pipeline (0003), AI drafting
+  (0004), image/audio extraction (0005), monorepo structure (0006), connectors ingest (0007),
+  and the sync auth-token broker (0008).
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence or suggest
+creating them upfront. (`CONTEXT.md` does not exist yet — the `/domain-modeling` skill, reached
+via `/grill-with-docs` and `/improve-codebase-architecture`, creates it lazily when terms
+actually get resolved.) Note that the monorepo's narrower guides — root `CLAUDE.md`,
+`apps/desktop/CLAUDE.md`, `docs/INTEGRATION.md`, `docs/SECURITY.md` — already carry a lot of the
+shared vocabulary in the meantime.
+
+## File structure
+
+Single-context repo:
+
+```
+/
+├── CONTEXT.md          ← (not created yet)
+├── docs/adr/
+│   ├── 0001-sync-and-processing-architecture.md
+│   ├── 0002-authentication.md
+│   └── … through 0008-sync-auth-token-broker.md
+├── apps/desktop/
+└── packages/contract/
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a
+test name), use the term as defined in `CONTEXT.md` (and the existing CLAUDE.md guides). Don't
+drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing
+language the project doesn't use (reconsider) or there's a real gap (note it for
+`/domain-modeling`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently
+overriding:
+
+> _Contradicts ADR-0003 (all-TypeScript on-device pipeline) — but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,44 @@
+# Issue tracker: Linear
+
+Issues and PRDs for this repo live in **Linear**, not in GitHub Issues. Skills that
+create, read, or move work items (`to-issues`, `triage`, `to-prd`, `qa`) operate against
+Linear.
+
+## How to operate Linear
+
+Use the **Linear MCP** (the `productivity:linear` integration). Its tools are namespaced
+`mcp__...__*` and are loaded on demand via `ToolSearch` (query `linear`). The first call in
+a session may require an interactive auth/`authenticate` step — if a tool returns an auth
+error, surface it and ask the user to authorize rather than silently retrying. In a
+headless/cron run where interactive auth isn't possible, report that Linear is unreachable
+instead of falling back to another tracker.
+
+Typical operations (use the MCP tool whose schema matches; don't guess channel names):
+
+- **Create an issue**: create a Linear issue with a title and a markdown description. Set
+  the team/project if the skill knows it; otherwise let it default and note which team you used.
+- **Read an issue**: fetch the issue by its identifier (e.g. `NIM-123`) including comments,
+  labels, and current workflow state.
+- **List / search issues**: list open issues filtered by label or workflow state.
+- **Comment**: add a comment to the issue.
+- **Apply / remove labels**: edit the issue's labels (see `triage-labels.md` for the
+  canonical role → Linear label mapping).
+- **Move state / close**: move the issue through its workflow state; "close" means moving it
+  to a Done/Canceled state, not deleting it.
+
+Identifiers are Linear keys like `NIM-123`, not bare integers — when a skill references a
+ticket number, resolve it as a Linear identifier.
+
+## Pull requests as a triage surface
+
+**PRs as a request surface: no.** External GitHub PRs are not pulled into the Linear triage
+queue. `/triage` operates only on Linear issues. (Code review of PRs is a separate workflow —
+this flag is only about whether PRs are treated as incoming *requests*.)
+
+## When a skill says "publish to the issue tracker"
+
+Create a Linear issue (see above).
+
+## When a skill says "fetch the relevant ticket"
+
+Fetch the Linear issue by its identifier, including comments.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,21 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the
+actual label strings used in this repo's tracker (Linear — see `issue-tracker.md`).
+
+We use the canonical names verbatim. Create these as **labels** in Linear (or map them onto
+existing workflow states if you prefer state-based triage — edit the right-hand column if so).
+
+| Canonical role    | Label in our tracker | Meaning                                  |
+| ----------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`    | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`      | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent` | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human` | `ready-for-human`    | Requires human implementation            |
+| `wontfix`         | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), apply the
+corresponding label string from this table to the Linear issue.
+
+Edit the right-hand column to match whatever vocabulary you actually use (e.g. point
+`ready-for-agent` at a Linear label like `agent-ready`, or at a workflow state).


### PR DESCRIPTION
## Summary

- Adds `## Agent skills` section to `CLAUDE.md` pointing skills at the new docs
- Creates `docs/agents/issue-tracker.md` — Linear via the `productivity:linear` MCP as the issue tracker; external PRs are not a triage surface
- Creates `docs/agents/triage-labels.md` — canonical five-role label vocabulary (`needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`)
- Creates `docs/agents/domain.md` — single-context layout; root `CONTEXT.md` (not yet created) + `docs/adr/` as the domain docs source

## Why

Sets up the per-repo configuration that Matt Pocock's engineering skills (`triage`, `to-issues`, `to-prd`, `qa`, `diagnosing-bugs`, `tdd`, `improve-codebase-architecture`) read at runtime. Without these files the skills fall back to guessing conventions; with them they operate on the repo's actual tracker, label vocabulary, and domain doc layout.

## Reviewer notes

- No runtime behavior changes — these are agent-read docs only.
- `CONTEXT.md` does not exist yet; `domain.md` deliberately notes this and points to `/domain-modeling` to create it lazily.
- The Linear doc assumes the `productivity:linear` MCP integration. If the team drives Linear a different way, edit `docs/agents/issue-tracker.md` — the rest is unaffected.
- The five triage labels (`needs-triage` etc.) need to be created in Linear before `/triage` runs, or it will try to apply labels that don't exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)