### PR TITLE
feat(sync): transfer recovery key via QR (desktop render + mobile scan)

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -39,6 +39,7 @@
     "ffmpeg-static": "^5.3.0",
     "heic-convert": "^2.1.0",
     "jose": "^6.2.3",
+    "qrcode.react": "^4.2.0",
     "tesseract.js": "^7.0.0",
     "unpdf": "^1.6.2"
   },

--- a/apps/desktop/src/renderer/src/nimi/nimi.css
+++ b/apps/desktop/src/renderer/src/nimi/nimi.css
@@ -4696,6 +4696,26 @@ html[data-density='compact'] .mem {
   font-size: 11px;
   word-break: break-all;
 }
+.settings-key-qr {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  align-self: stretch;
+  padding: 14px;
+  border: 1px solid var(--hairline);
+  border-radius: 12px;
+  background: var(--surface-3);
+}
+.settings-key-qr svg {
+  /* QR modules read on any theme only against a solid light field. */
+  background: #fff;
+  padding: 10px;
+  border-radius: 8px;
+}
+.settings-key-qr .settings-key-s {
+  text-align: center;
+}
 .settings-input {
   width: 100%;
   padding: 9px 11px;

--- a/apps/desktop/src/renderer/src/nimi/settings.tsx
+++ b/apps/desktop/src/renderer/src/nimi/settings.tsx
@@ -9,6 +9,7 @@
 //   - Connections: the Gmail + Google Calendar connectors (self-contained).
 //   - Updates: current version + check / restart-to-update.
 import { useBrand } from '@nimi/brand/web'
+import { QRCodeSVG } from 'qrcode.react'
 import { useState, type JSX } from 'react'
 import { useAuth } from '../hooks/useAuth'
 import { useSync, useSyncSettings } from '../hooks/useSync'
@@ -49,6 +50,7 @@ function SyncSection(): JSX.Element {
   const { settings, busy, setEnabled, importKey, revealKey } = useSyncSettings()
 
   const [revealed, setRevealed] = useState<string | null>(null)
+  const [showQr, setShowQr] = useState(false)
   const [copied, setCopied] = useState(false)
   const [importOpen, setImportOpen] = useState(false)
   const [importVal, setImportVal] = useState('')
@@ -73,6 +75,7 @@ function SyncSection(): JSX.Element {
   const onReveal = async (): Promise<void> => {
     if (revealed) {
       setRevealed(null)
+      setShowQr(false)
       return
     }
     setRevealed(await revealKey())
@@ -137,13 +140,29 @@ function SyncSection(): JSX.Element {
             notes — keep it safe, and never share it.
           </div>
           {revealed ? (
-            <div className="settings-key-reveal">
-              <code className="settings-key-code">{revealed}</code>
-              <button className="settings-btn" onClick={() => void onCopy()}>
-                <NIcon name={copied ? 'check' : 'copy'} size={13} />
-                {copied ? 'Copied' : 'Copy'}
+            <>
+              <div className="settings-key-reveal">
+                <code className="settings-key-code">{revealed}</code>
+                <button className="settings-btn" onClick={() => void onCopy()}>
+                  <NIcon name={copied ? 'check' : 'copy'} size={13} />
+                  {copied ? 'Copied' : 'Copy'}
+                </button>
+              </div>
+              <button
+                className="settings-btn settings-btn-quiet"
+                onClick={() => setShowQr((v) => !v)}
+              >
+                {showQr ? 'Hide QR code' : 'Show QR code'}
               </button>
-            </div>
+              {showQr && (
+                <div className="settings-key-qr">
+                  <QRCodeSVG value={revealed} size={180} marginSize={2} />
+                  <div className="settings-key-s">
+                    On mobile, open Settings and scan this with “Scan QR from desktop”.
+                  </div>
+                </div>
+              )}
+            </>
           ) : null}
           <button className="settings-btn settings-btn-quiet" onClick={() => void onReveal()}>
             {revealed ? 'Hide recovery key' : 'Reveal recovery key'}

--- a/apps/mobile/CLAUDE.md
+++ b/apps/mobile/CLAUDE.md
@@ -78,6 +78,6 @@ in `app/_layout.tsx`. This is the t3-turbo app-layer config injection pattern.
 
 - Real Logto auth: `login.tsx` is a PKCE stub; needs `EXPO_PUBLIC_LOGTO_*` env + registered app
 - Background sync: no push / periodic pull; user must pull-to-refresh
-- At-rest encryption: broker doesn't return `encryptionKey` yet; `openDb` accepts it but won't receive it
+- At-rest encryption: broker doesn't return `encryptionKey` yet; `openDb` accepts it but won't receive it. The shared content key is moved from desktop manually — paste the 64-hex in Settings, or tap **Scan QR from desktop** (`expo-camera` `CameraView`) to scan the QR desktop renders under Settings → Cloud sync → Reveal recovery key. Both feed `setSyncKey`/`setCurrentKey`. `expo-camera` is a native module → needs a dev-client rebuild (`expo run:ios/android`), not Expo Go.
 - Schema drift guard: `src/db/schema.ts` is hand-maintained — see ADR 0009 for the plan to share it
 - Mastra/Inngest cloud pipeline: capture → `memory/ingest` event not fired yet from mobile

--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -17,7 +17,16 @@
       },
       "package": "cool.jlee.nimi"
     },
-    "plugins": ["expo-router", "expo-secure-store"],
+    "plugins": [
+      "expo-router",
+      "expo-secure-store",
+      [
+        "expo-camera",
+        {
+          "cameraPermission": "Nimi uses the camera to scan the sync recovery key QR shown on your desktop."
+        }
+      ]
+    ],
     "experiments": {
       "typedRoutes": true
     }

--- a/apps/mobile/app/(tabs)/settings.tsx
+++ b/apps/mobile/app/(tabs)/settings.tsx
@@ -10,11 +10,7 @@ import {
   ActivityIndicator,
   Modal
 } from 'react-native'
-import {
-  CameraView,
-  useCameraPermissions,
-  type BarcodeScanningResult
-} from 'expo-camera'
+import { CameraView, useCameraPermissions, type BarcodeScanningResult } from 'expo-camera'
 import { getSyncKey, setSyncKey, clearSyncKey } from '../../src/db/key-store'
 import { setCurrentKey } from '../../src/db/client'
 
@@ -122,11 +118,10 @@ export default function SettingsScreen(): ReactElement {
     <ScrollView style={styles.scroll} contentContainerStyle={styles.container}>
       <Text style={styles.heading}>Cloud sync key</Text>
       <Text style={styles.body}>
-        To sync securely across devices, both desktop and mobile must share the
-        same AES-256-GCM content encryption key. On desktop, open{' '}
-        <Text style={styles.mono}>Settings → Cloud sync → Reveal recovery key</Text>.
-        Scan the QR with the camera below, or paste the 64-character hex string
-        manually.
+        To sync securely across devices, both desktop and mobile must share the same AES-256-GCM
+        content encryption key. On desktop, open{' '}
+        <Text style={styles.mono}>Settings → Cloud sync → Reveal recovery key</Text>. Scan the QR
+        with the camera below, or paste the 64-character hex string manually.
       </Text>
 
       <View style={styles.statusRow}>
@@ -178,10 +173,11 @@ export default function SettingsScreen(): ReactElement {
         onPress={handleSave}
         disabled={!keyInput.trim() || loading}
       >
-        {loading
-          ? <ActivityIndicator color="#18181b" />
-          : <Text style={styles.buttonSecondaryText}>Save key</Text>
-        }
+        {loading ? (
+          <ActivityIndicator color="#18181b" />
+        ) : (
+          <Text style={styles.buttonSecondaryText}>Save key</Text>
+        )}
       </Pressable>
 
       {isKeySet && (
@@ -200,9 +196,7 @@ export default function SettingsScreen(): ReactElement {
           />
           <View style={styles.scannerOverlay} pointerEvents="box-none">
             <View style={styles.scannerFrame} />
-            <Text style={styles.scannerHint}>
-              Point the camera at the QR code on your desktop
-            </Text>
+            <Text style={styles.scannerHint}>Point the camera at the QR code on your desktop</Text>
             <Pressable style={styles.scannerCancel} onPress={() => setScanning(false)}>
               <Text style={styles.scannerCancelText}>Cancel</Text>
             </Pressable>

--- a/apps/mobile/app/(tabs)/settings.tsx
+++ b/apps/mobile/app/(tabs)/settings.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect, type ReactElement } from 'react'
+import { useState, useCallback, useEffect, useRef, type ReactElement } from 'react'
 import {
   View,
   Text,
@@ -7,8 +7,14 @@ import {
   StyleSheet,
   ScrollView,
   Alert,
-  ActivityIndicator
+  ActivityIndicator,
+  Modal
 } from 'react-native'
+import {
+  CameraView,
+  useCameraPermissions,
+  type BarcodeScanningResult
+} from 'expo-camera'
 import { getSyncKey, setSyncKey, clearSyncKey } from '../../src/db/key-store'
 import { setCurrentKey } from '../../src/db/client'
 
@@ -26,6 +32,11 @@ export default function SettingsScreen(): ReactElement {
   const [storedKey, setStoredKey] = useState<string | null>(null)
   const [loading, setLoading] = useState(false)
   const [refreshing, setRefreshing] = useState(true)
+  const [scanning, setScanning] = useState(false)
+  const [permission, requestPermission] = useCameraPermissions()
+  // CameraView fires onBarcodeScanned continuously; this latch makes the first
+  // valid frame win and ignores the rest until the scanner is reopened.
+  const scanHandled = useRef(false)
 
   const refresh = useCallback(async () => {
     setRefreshing(true)
@@ -39,9 +50,11 @@ export default function SettingsScreen(): ReactElement {
     void refresh()
   }, [refresh])
 
-  async function handleSave(): Promise<void> {
-    const trimmed = keyInput.trim()
-    if (!trimmed) return
+  // Persist + inject a key. Shared by the paste flow and the QR scanner.
+  // Returns true on success so the scanner can decide whether to close.
+  async function saveKey(value: string): Promise<boolean> {
+    const trimmed = value.trim()
+    if (!trimmed) return false
     setLoading(true)
     try {
       await setSyncKey(trimmed)
@@ -49,11 +62,39 @@ export default function SettingsScreen(): ReactElement {
       setKeyInput('')
       await refresh()
       Alert.alert('Saved', 'Recovery key saved. Captures will now be encrypted.')
+      return true
     } catch (e) {
       Alert.alert('Invalid key', e instanceof Error ? e.message : String(e))
+      return false
     } finally {
       setLoading(false)
     }
+  }
+
+  async function handleSave(): Promise<void> {
+    await saveKey(keyInput)
+  }
+
+  async function openScanner(): Promise<void> {
+    if (!permission?.granted) {
+      const res = await requestPermission()
+      if (!res.granted) {
+        Alert.alert(
+          'Camera access needed',
+          'Allow camera access to scan the recovery key QR from your desktop. You can still paste the key manually.'
+        )
+        return
+      }
+    }
+    scanHandled.current = false
+    setScanning(true)
+  }
+
+  function handleBarcode(result: BarcodeScanningResult): void {
+    if (scanHandled.current) return
+    scanHandled.current = true
+    setScanning(false)
+    void saveKey(result.data)
   }
 
   async function handleClear(): Promise<void> {
@@ -82,9 +123,10 @@ export default function SettingsScreen(): ReactElement {
       <Text style={styles.heading}>Cloud sync key</Text>
       <Text style={styles.body}>
         To sync securely across devices, both desktop and mobile must share the
-        same AES-256-GCM content encryption key. Reveal it on desktop via{' '}
-        <Text style={styles.mono}>Settings → Cloud sync → Show recovery key</Text>,
-        then paste the 64-character hex string below.
+        same AES-256-GCM content encryption key. On desktop, open{' '}
+        <Text style={styles.mono}>Settings → Cloud sync → Reveal recovery key</Text>.
+        Scan the QR with the camera below, or paste the 64-character hex string
+        manually.
       </Text>
 
       <View style={styles.statusRow}>
@@ -100,6 +142,20 @@ export default function SettingsScreen(): ReactElement {
         </Text>
       )}
 
+      <Pressable
+        style={[styles.button, loading && styles.buttonDisabled]}
+        onPress={openScanner}
+        disabled={loading}
+      >
+        <Text style={styles.buttonText}>Scan QR from desktop</Text>
+      </Pressable>
+
+      <View style={styles.dividerRow}>
+        <View style={styles.dividerLine} />
+        <Text style={styles.dividerText}>or paste manually</Text>
+        <View style={styles.dividerLine} />
+      </View>
+
       <Text style={styles.inputLabel}>Paste recovery key (64 hex chars)</Text>
       <TextInput
         style={styles.input}
@@ -114,13 +170,17 @@ export default function SettingsScreen(): ReactElement {
       />
 
       <Pressable
-        style={[styles.button, (!keyInput.trim() || loading) && styles.buttonDisabled]}
+        style={[
+          styles.button,
+          styles.buttonSecondary,
+          (!keyInput.trim() || loading) && styles.buttonDisabled
+        ]}
         onPress={handleSave}
         disabled={!keyInput.trim() || loading}
       >
         {loading
-          ? <ActivityIndicator color="#fff" />
-          : <Text style={styles.buttonText}>Save key</Text>
+          ? <ActivityIndicator color="#18181b" />
+          : <Text style={styles.buttonSecondaryText}>Save key</Text>
         }
       </Pressable>
 
@@ -129,6 +189,26 @@ export default function SettingsScreen(): ReactElement {
           <Text style={styles.clearButtonText}>Remove key</Text>
         </Pressable>
       )}
+
+      <Modal visible={scanning} animationType="slide" onRequestClose={() => setScanning(false)}>
+        <View style={styles.scannerRoot}>
+          <CameraView
+            style={StyleSheet.absoluteFill}
+            facing="back"
+            barcodeScannerSettings={{ barcodeTypes: ['qr'] }}
+            onBarcodeScanned={handleBarcode}
+          />
+          <View style={styles.scannerOverlay} pointerEvents="box-none">
+            <View style={styles.scannerFrame} />
+            <Text style={styles.scannerHint}>
+              Point the camera at the QR code on your desktop
+            </Text>
+            <Pressable style={styles.scannerCancel} onPress={() => setScanning(false)}>
+              <Text style={styles.scannerCancelText}>Cancel</Text>
+            </Pressable>
+          </View>
+        </View>
+      </Modal>
     </ScrollView>
   )
 }
@@ -174,6 +254,43 @@ const styles = StyleSheet.create({
   },
   buttonDisabled: { opacity: 0.4 },
   buttonText: { color: '#fff', fontSize: 16, fontWeight: '600' },
+  buttonSecondary: {
+    backgroundColor: '#fff',
+    borderWidth: 1,
+    borderColor: '#d1d5db'
+  },
+  buttonSecondaryText: { color: '#18181b', fontSize: 16, fontWeight: '600' },
+  dividerRow: { flexDirection: 'row', alignItems: 'center', gap: 10, marginVertical: 4 },
+  dividerLine: { flex: 1, height: 1, backgroundColor: '#e5e5e5' },
+  dividerText: { fontSize: 12, color: '#999' },
+  scannerRoot: { flex: 1, backgroundColor: '#000' },
+  scannerOverlay: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 24
+  },
+  scannerFrame: {
+    width: 240,
+    height: 240,
+    borderWidth: 3,
+    borderColor: '#fff',
+    borderRadius: 16,
+    backgroundColor: 'transparent'
+  },
+  scannerHint: {
+    color: '#fff',
+    fontSize: 15,
+    textAlign: 'center',
+    paddingHorizontal: 40
+  },
+  scannerCancel: {
+    paddingVertical: 12,
+    paddingHorizontal: 28,
+    borderRadius: 10,
+    backgroundColor: 'rgba(255,255,255,0.15)'
+  },
+  scannerCancelText: { color: '#fff', fontSize: 16, fontWeight: '600' },
   clearButton: {
     paddingVertical: 12,
     alignItems: 'center',

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -19,6 +19,7 @@
     "@tursodatabase/sync-react-native": "^0.6.1",
     "expo": "^56.0.12",
     "expo-auth-session": "^56.0.14",
+    "expo-camera": "~56.0.8",
     "expo-constants": "^56.0.18",
     "expo-crypto": "~56.0.4",
     "expo-dev-client": "^56.0.20",

--- a/docs/auth/auth-gate-and-sync.md
+++ b/docs/auth/auth-gate-and-sync.md
@@ -120,9 +120,12 @@ downgrading it.
   sealed in the OS keychain (`safeStorage`) at `neeme-sync-key.bin`
   (`sync-prefs.getOrCreateKey`).
 - **Reveal recovery key** (Settings) shows the hex + copy button so you can move
-  it to another device.
+  it to another device. A **Show QR code** toggle renders the same hex as a QR
+  (offline, `qrcode.react` SVG — CSP-safe) for the mobile camera to scan.
 - **Import recovery key** (Settings) accepts a 64-hex key from another device,
-  stores it, and restarts the worker (`importRecoveryKey`).
+  stores it, and restarts the worker (`importRecoveryKey`). On mobile, the same
+  key can be transferred by scanning the desktop QR (**Scan QR from desktop**,
+  `expo-camera`) instead of pasting — both paths converge on `setSyncKey`.
 - Encryption-at-rest is **sticky**: once a device has a key it's always injected
   into the worker, even when sync is OFF. See the footgun below for why.
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,6 +89,9 @@ importers:
       jose:
         specifier: ^6.2.3
         version: 6.2.3
+      qrcode.react:
+        specifier: ^4.2.0
+        version: 4.2.0(react@19.2.7)
       tesseract.js:
         specifier: ^7.0.0
         version: 7.0.0
@@ -171,6 +174,9 @@ importers:
       expo-auth-session:
         specifier: ^56.0.14
         version: 56.0.14(expo@56.0.12)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3)
+      expo-camera:
+        specifier: ~56.0.8
+        version: 56.0.8(@types/emscripten@1.41.5)(expo@56.0.12)(react-native-web@0.21.2(react-dom@19.2.7(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3)
       expo-constants:
         specifier: ^56.0.18
         version: 56.0.18(expo@56.0.12)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))
@@ -3606,6 +3612,9 @@ packages:
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
+  '@types/emscripten@1.41.5':
+    resolution: {integrity: sha512-cMQm7pxu6BxtHyqJ7mQZ2kXWV5SLmugybFdHCBbJ5eHzOo6VhBckEgAT3//rP5FwPHNPeEiq4SmQ5ucBwsOo4Q==}
+
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
@@ -4108,6 +4117,9 @@ packages:
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
+
+  barcode-detector@3.2.0:
+    resolution: {integrity: sha512-MrT5TT058ptG5YB157pHLfXKVpp0BKEfQBOb8QvzTbatzmLDu85JJ0Gd/sCYwbwdwStJvxsYflrSN6D6E4Ndyw==}
 
   bare-events@2.9.1:
     resolution: {integrity: sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg==}
@@ -5236,6 +5248,17 @@ packages:
     peerDependencies:
       react: '*'
       react-native: '*'
+
+  expo-camera@56.0.8:
+    resolution: {integrity: sha512-UDOpUUMisFRmCv1XQV1MJCKGAH2CsIC1Rs6P9Bbc6JLVmbxEKAd5dK68y6cScOdWURxVfJ0PRcjYnSuc8ayyIQ==}
+    peerDependencies:
+      expo: '*'
+      react: '*'
+      react-native: '*'
+      react-native-web: '*'
+    peerDependenciesMeta:
+      react-native-web:
+        optional: true
 
   expo-constants@56.0.18:
     resolution: {integrity: sha512-8AMtbDGl/WVPnWlmbpGmvcdnNCy9E4PFnwdVwj600vljkMDPSxcAcjw8GVXEPk3PpZ+ngTqsrkltWyj0UKYAxw==}
@@ -7385,6 +7408,11 @@ packages:
     resolution: {integrity: sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA==}
     engines: {node: '>=16.0.0'}
 
+  qrcode.react@4.2.0:
+    resolution: {integrity: sha512-QpgqWi8rD9DsS9EP3z7BT+5lY5SFhsqGjpgW5DY/i3mK4M9DTBNz3ErMi8BWYEfI3L0d8GIbGmcdFAS1uIRGjA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   qs@6.15.2:
     resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
     engines: {node: '>=0.6'}
@@ -8143,6 +8171,10 @@ packages:
     os: [darwin, linux, win32, freebsd, openbsd, netbsd, sunos, android]
     hasBin: true
 
+  tagged-tag@1.0.0:
+    resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
+    engines: {node: '>=20'}
+
   tailwindcss@4.3.1:
     resolution: {integrity: sha512-hk+TB1m+K8CYNrP6rjQaq/Y+4Zylwpa87mLYBKCunwnnQ9p+fHb7kmSfGqyEJoxF/O6CDyABWVFEafNSYKll+Q==}
 
@@ -8304,6 +8336,10 @@ packages:
   type-fest@2.19.0:
     resolution: {integrity: sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==}
     engines: {node: '>=12.20'}
+
+  type-fest@5.7.0:
+    resolution: {integrity: sha512-1URUxUqfHFM1c+zfSPsa3gnkO7Aq21qyH75SIduNYz4SzY964rn1X2vCMQaHSHhktiw+0kPa2iyb6PUpXqB6Vg==}
+    engines: {node: '>=20'}
 
   type-is@2.1.0:
     resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
@@ -8870,6 +8906,11 @@ packages:
 
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
+
+  zxing-wasm@3.1.0:
+    resolution: {integrity: sha512-5+3V1wPRx4gvbeLH2jB7n2cKrYJ1q4i3QgjnBUtrDPeqxJSi6BdzKJg4y6aF6bgW8zfntnYJyrkqFMevDhL2NA==}
+    peerDependencies:
+      '@types/emscripten': '>=1.39.6'
 
 snapshots:
 
@@ -12058,7 +12099,9 @@ snapshots:
       metro-runtime: 0.84.4
     transitivePeerDependencies:
       - '@babel/core'
+      - bufferutil
       - supports-color
+      - utf-8-validate
 
   '@react-native/normalize-colors@0.74.89':
     optional: true
@@ -12473,6 +12516,8 @@ snapshots:
       '@types/ms': 2.1.0
 
   '@types/deep-eql@4.0.2': {}
+
+  '@types/emscripten@1.41.5': {}
 
   '@types/estree@1.0.9': {}
 
@@ -13166,6 +13211,12 @@ snapshots:
   balanced-match@1.0.2: {}
 
   balanced-match@4.0.4: {}
+
+  barcode-detector@3.2.0(@types/emscripten@1.41.5):
+    dependencies:
+      zxing-wasm: 3.1.0(@types/emscripten@1.41.5)
+    transitivePeerDependencies:
+      - '@types/emscripten'
 
   bare-events@2.9.1: {}
 
@@ -14489,6 +14540,17 @@ snapshots:
     transitivePeerDependencies:
       - expo
       - supports-color
+
+  expo-camera@56.0.8(@types/emscripten@1.41.5)(expo@56.0.12)(react-native-web@0.21.2(react-dom@19.2.7(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3):
+    dependencies:
+      barcode-detector: 3.2.0(@types/emscripten@1.41.5)
+      expo: 56.0.12(@babel/core@7.29.7)(@expo/dom-webview@56.0.5)(@expo/metro-runtime@56.0.15)(expo-router@56.2.11)(react-dom@19.2.7(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.7(react@19.2.3))(react@19.2.3))(react-native-worklets@0.9.1(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
+      react: 19.2.3
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3)
+    optionalDependencies:
+      react-native-web: 0.21.2(react-dom@19.2.7(react@19.2.3))(react@19.2.3)
+    transitivePeerDependencies:
+      - '@types/emscripten'
 
   expo-constants@56.0.18(expo@56.0.12)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3)):
     dependencies:
@@ -17001,6 +17063,10 @@ snapshots:
 
   pvutils@1.1.5: {}
 
+  qrcode.react@4.2.0(react@19.2.7):
+    dependencies:
+      react: 19.2.7
+
   qs@6.15.2:
     dependencies:
       side-channel: 1.1.0
@@ -17986,6 +18052,8 @@ snapshots:
 
   systeminformation@5.31.9: {}
 
+  tagged-tag@1.0.0: {}
+
   tailwindcss@4.3.1: {}
 
   tapable@2.3.3: {}
@@ -18175,6 +18243,10 @@ snapshots:
   type-fest@0.7.1: {}
 
   type-fest@2.19.0: {}
+
+  type-fest@5.7.0:
+    dependencies:
+      tagged-tag: 1.0.0
 
   type-is@2.1.0:
     dependencies:
@@ -18698,3 +18770,8 @@ snapshots:
   zod@4.4.3: {}
 
   zwitch@2.0.4: {}
+
+  zxing-wasm@3.1.0(@types/emscripten@1.41.5):
+    dependencies:
+      '@types/emscripten': 1.41.5
+      type-fest: 5.7.0


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Swaps the manual copy/paste of the 64-hex sync encryption key for a one-tap QR transfer, while keeping copy/paste as a fallback on both ends.

- **Desktop**: under Settings → Cloud sync → Reveal recovery key, a new **Show QR code** toggle renders the revealed key as a QR (`qrcode.react` `QRCodeSVG`). Default hidden, since the QR is exactly as sensitive as the key.
- **Mobile**: a **Scan QR from desktop** button opens an `expo-camera` `CameraView` scanner (QR only). The first valid frame is fed through the existing `setSyncKey()` + `setCurrentKey()` path. The manual paste input + Save remain as a fallback (now styled secondary).

No new IPC, no schema, no network — pure transport. Payload is the raw 64-hex string, which mobile's existing `^[0-9a-f]{64}$` validator already accepts/rejects unchanged.

## Notes

- Production CSP (`script-src 'self'; img-src 'self' data:`) is satisfied: `QRCodeSVG` is inline SVG DOM, no scripts/remote/`blob:` fetches.
- `expo-camera` is a native module → requires a dev-client rebuild (`expo run:ios/android`), not Expo Go. Camera permission registered via the `expo-camera` config plugin in `app.json`.

## Testing

- Desktop `typecheck` / `build` / `lint`.
- Payload round-trip decode of the rendered QR back to the 64-hex key (deterministic, no camera).
- Mobile `typecheck`.
- Desktop GUI smoke screenshot of the QR in Settings.
- Live camera scan left for on-device verification (no camera/dev-client in CI VM).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-43e86332-342c-42f8-a585-bf63b7d4fd28"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-43e86332-342c-42f8-a585-bf63b7d4fd28"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

