### PR TITLE
fix(desktop): wire renderer prototype stubs to real backend (UX punch list §A–C)

### DIFF
--- a/apps/desktop/src/renderer/src/nimi/NimiApp.tsx
+++ b/apps/desktop/src/renderer/src/nimi/NimiApp.tsx
@@ -218,6 +218,21 @@ export default function NimiApp(): JSX.Element {
   }
   const onFed = (): void => cheer()
 
+  // After a capture resolves, re-pull the archive so new memories show up in the
+  // MemoryContext lookup (card thumbs, task ctx, search rows) without a reload.
+  // Archive-only: captures don't mutate the todo list, and refetching tasks here
+  // would clobber optimistic state. Keep the stale archive if the refresh fails.
+  const refreshArchive = (): void => {
+    void data.pipeline
+      .archive()
+      .then((arch) => setArchive(arch))
+      .catch(() => undefined)
+  }
+  const onCaptured = (): void => {
+    cheer()
+    refreshArchive()
+  }
+
   // carry `keep` onto today + pull `add` backlog ids in; plan() sweeps the rest.
   const applyPlan = async (keep: string[], add: string[]): Promise<void> => {
     setOverlay(null)
@@ -346,6 +361,9 @@ export default function NimiApp(): JSX.Element {
                     carriedCount={carriedCount}
                     backlogCount={backlog.length}
                     badge={waiting}
+                    userName={auth.claims?.name ?? null}
+                    memoryCount={archive.length}
+                    lastFed={archive[0]?.when ?? null}
                     onOpen={setOpenId}
                     onToggle={toggleTask}
                     onAdd={() => setOverlay('add')}
@@ -358,8 +376,9 @@ export default function NimiApp(): JSX.Element {
                 ) : (
                   <FeedView
                     captureStyle={TWEAKS.captureStyle}
-                    onCaptured={cheer}
+                    onCaptured={onCaptured}
                     onAddTodo={addTodo}
+                    onAdd={() => setOverlay('add')}
                     onRecordingChange={setFeedRecording}
                     nimiState={headState}
                     badge={waiting}
@@ -385,6 +404,7 @@ export default function NimiApp(): JSX.Element {
                   <AddSheet
                     onClose={() => setOverlay(null)}
                     onFed={onFed}
+                    onCaptured={onCaptured}
                     onAddTodo={addTodo}
                     onRecordingChange={setAddRecording}
                   />
@@ -395,6 +415,7 @@ export default function NimiApp(): JSX.Element {
                     cap={CAP}
                     fresh={!planned}
                     backlog={backlog}
+                    userName={auth.claims?.name ?? null}
                     onClose={cancelPlan}
                     onApply={applyPlan}
                   />

--- a/apps/desktop/src/renderer/src/nimi/add.tsx
+++ b/apps/desktop/src/renderer/src/nimi/add.tsx
@@ -9,7 +9,7 @@ import { NimiMark, Dots } from './mark'
 import { VoiceRecorder } from './voice'
 import { data } from './api'
 import { captureFiles, kindOfFile } from './capture-file'
-import { TASK_SUGGESTIONS, uncoverTodos, nextTranscript } from './ui-stubs'
+import { TASK_SUGGESTIONS, nextTranscript } from './ui-stubs'
 import type { MemoryKind, Task, UncoveredTodo, BacklogItem } from '@nimi/contract/views'
 
 type AddTodo = (
@@ -25,11 +25,15 @@ const ADD_MODES = [
 export function AddSheet({
   onClose,
   onFed,
+  onCaptured,
   onAddTodo,
   onRecordingChange
 }: {
   onClose: () => void
+  /** Fired when feeding starts (drives the immediate "cheer" feedback). */
   onFed: () => void
+  /** Fired once the real capture(s) resolve — drives the archive refresh. */
+  onCaptured?: () => void
   onAddTodo: AddTodo
   onRecordingChange?: (v: boolean) => void
 }): JSX.Element {
@@ -73,6 +77,7 @@ export function AddSheet({
         {mode === 'feed' ? (
           <FeedPane
             onFed={onFed}
+            onCaptured={onCaptured}
             onAddTodo={onAddTodo}
             onClose={onClose}
             recording={recording}
@@ -99,12 +104,14 @@ interface Attach {
 // ── Feed: capture → index → uncover candidate to-dos ────────────────────────
 function FeedPane({
   onFed,
+  onCaptured,
   onAddTodo,
   onClose,
   recording,
   setRecording
 }: {
   onFed: () => void
+  onCaptured?: () => void
   onAddTodo: AddTodo
   onClose: () => void
   recording: boolean
@@ -115,7 +122,8 @@ function FeedPane({
   const [mode, setMode] = useState<'note' | 'voice' | 'link'>('note')
   const [attaches, setAttaches] = useState<Attach[]>([])
   const [text, setText] = useState('')
-  const [conns, setConns] = useState(0)
+  const [filed, setFiled] = useState(0)
+  const [failed, setFailed] = useState(false)
   const [todos, setTodos] = useState<UncoveredTodo[]>([])
   const [added, setAdded] = useState<Set<string>>(new Set())
   const taRef = useRef<HTMLTextAreaElement>(null)
@@ -172,23 +180,34 @@ function FeedPane({
   const feed = (): void => {
     if (!text.trim() && !hasAttach) return
     setPhase('indexing')
+    setFailed(false)
     onFed && onFed()
-    // capture text and files in parallel; AI-uncovered todos are still stubbed (roadmap #3)
-    const captures: Promise<unknown>[] = []
-    if (text.trim()) captures.push(data.pipeline.captureText(text.trim()))
-    if (hasAttach) captures.push(captureFiles(attaches.map((a) => a.file)))
-    void Promise.all(captures)
-    const found = 2 + Math.floor(Math.random() * 4)
-    let i = 0
-    const tick = setInterval(() => {
-      i++
-      setConns(Math.min(found, i))
-      if (i >= found) clearInterval(tick)
-    }, 130)
-    setTimeout(() => {
-      setTodos(uncoverTodos())
+    // Capture text + files in parallel and report what actually landed. We wait
+    // for the real captures (no fixed timer), with a small minimum dwell so
+    // "Reading it in" doesn't flash past when the worker answers instantly.
+    // captureText resolves to one CaptureResult; captureFiles to an array.
+    void (async () => {
+      const captures: Promise<unknown>[] = []
+      if (text.trim()) captures.push(data.pipeline.captureText(text.trim()))
+      if (hasAttach) captures.push(captureFiles(attaches.map((a) => a.file)))
+      try {
+        const [results] = await Promise.all([
+          Promise.all(captures),
+          new Promise((r) => setTimeout(r, 900))
+        ])
+        let n = 0
+        for (const r of results) n += Array.isArray(r) ? r.length : 1
+        setFiled(n)
+        // New memories landed — let the app refresh the archive (thumbs, ctx
+        // lookups, search rows) instead of waiting for a reload.
+        onCaptured && onCaptured()
+        // Real inferred to-dos (AI-gap: `[]` until the drafter is configured).
+        setTodos(await data.pipeline.uncoverTodos())
+      } catch {
+        setFailed(true)
+      }
       setPhase('done')
-    }, 1750)
+    })()
   }
 
   if (phase === 'input') {
@@ -356,9 +375,6 @@ function FeedPane({
         <div className="gather-prog" style={{ marginTop: '4px' }}>
           <i style={{ width: '100%' }} />
         </div>
-        <div className="add-conns">
-          <b>{conns}</b> connection{conns === 1 ? '' : 's'} so far
-        </div>
       </div>
     )
   }
@@ -368,12 +384,21 @@ function FeedPane({
     <>
       <div className="sheet-body">
         <div className="add-done-head">
-          <NimiMark state="done" fill={9} size={30} />
+          <NimiMark state={failed ? 'idle' : 'done'} fill={9} size={30} />
           <div>
-            <div className="add-done-t">
-              Filed away — {conns} connection{conns === 1 ? '' : 's'} found
-            </div>
-            <div className="add-done-s">It&apos;ll surface beside anything it relates to.</div>
+            {failed ? (
+              <>
+                <div className="add-done-t">Couldn&apos;t file that</div>
+                <div className="add-done-s">Something went wrong — give it another try.</div>
+              </>
+            ) : (
+              <>
+                <div className="add-done-t">
+                  Filed away — {filed} {filed === 1 ? 'memory' : 'memories'}
+                </div>
+                <div className="add-done-s">It&apos;ll surface beside anything it relates to.</div>
+              </>
+            )}
           </div>
         </div>
         {todos.length > 0 && (
@@ -445,7 +470,8 @@ function FeedPane({
           onClick={() => {
             setPhase('input')
             setText('')
-            setConns(0)
+            setFiled(0)
+            setFailed(false)
             setTodos([])
             setAdded(new Set())
             setAttaches([])
@@ -472,6 +498,9 @@ function TodoPane({
   const [phase, setPhase] = useState<'input' | 'ranking' | 'done'>('input')
   const [text, setText] = useState('')
   const [kept, setKept] = useState(0)
+  // onAddTodo resolves to a Task when it landed on Today, or null on the backlog
+  // fallback (day full / worker unreachable). Drives the honest "where it went" copy.
+  const [landedToday, setLandedToday] = useState(false)
   const taRef = useRef<HTMLTextAreaElement>(null)
   useEffect(() => {
     taRef.current && taRef.current.focus()
@@ -490,6 +519,7 @@ function TodoPane({
       const task = onAddTodo
         ? await onAddTodo({ title: tx, why: 'You added this', conf: null })
         : null
+      setLandedToday(!!task)
       setKept(task?.ctx?.length ?? 0)
       setPhase('done')
     })()
@@ -511,7 +541,9 @@ function TodoPane({
     return (
       <div className="add-stage">
         <NimiMark state="done" fill={9} size={66} />
-        <div className="add-stage-t">Added to your backlog</div>
+        <div className="add-stage-t">
+          {landedToday ? 'Added to today' : 'Added to your backlog'}
+        </div>
         <div className="add-stage-s">
           {kept > 0 ? (
             <>
@@ -527,6 +559,7 @@ function TodoPane({
             onClick={() => {
               setText('')
               setKept(0)
+              setLandedToday(false)
               setPhase('input')
             }}
           >

--- a/apps/desktop/src/renderer/src/nimi/feed.tsx
+++ b/apps/desktop/src/renderer/src/nimi/feed.tsx
@@ -52,6 +52,7 @@ export function FeedView({
   captureStyle,
   onCaptured,
   onAddTodo,
+  onAdd,
   onRecordingChange,
   nimiState,
   badge,
@@ -62,6 +63,8 @@ export function FeedView({
   captureStyle: string
   onCaptured?: () => void
   onAddTodo?: AddTodo
+  /** Open the real Add composer (the FAB sheet) — used by the Note/Link quick-tools. */
+  onAdd: () => void
   onRecordingChange?: (v: boolean) => void
   nimiState: NimiMarkState
   badge: number
@@ -251,7 +254,10 @@ export function FeedView({
             <button
               key={k.kind}
               className="feed-tool"
-              onClick={() => (k.kind === 'voice' ? setRecording(true) : feedOne(k.kind))}
+              // Note/Link have no inline input to capture — open the real Add
+              // composer (which calls captureText/captureFile). Voice opens the
+              // recorder (real mic → ASR wiring is still pending — see ROADMAP W4).
+              onClick={() => (k.kind === 'voice' ? setRecording(true) : onAdd())}
             >
               <NIcon name={k.ico} size={16} /> {k.label}
             </button>

--- a/apps/desktop/src/renderer/src/nimi/plan.tsx
+++ b/apps/desktop/src/renderer/src/nimi/plan.tsx
@@ -10,6 +10,7 @@ export function PlanRitual({
   cap,
   fresh,
   backlog,
+  userName,
   onClose,
   onApply
 }: {
@@ -17,6 +18,8 @@ export function PlanRitual({
   cap: number
   fresh: boolean
   backlog: BacklogItem[]
+  /** Signed-in display name, or null in a local/unconfigured build. */
+  userName: string | null
   onClose: () => void
   // hand up the kept task ids + chosen backlog ids; NimiApp drives plan()+schedule()
   onApply: (keep: string[], add: string[]) => void
@@ -54,7 +57,11 @@ export function PlanRitual({
         <div className="plan-intro">
           <NimiMark state="idle" size={56} />
           <div className="plan-intro-h">
-            {fresh ? 'Good morning, Jordan' : 'A clean slate for today'}
+            {fresh
+              ? userName
+                ? `Good morning, ${userName}`
+                : 'Good morning'
+              : 'A clean slate for today'}
           </div>
           <div className="plan-intro-s">
             {fresh

--- a/apps/desktop/src/renderer/src/nimi/task.tsx
+++ b/apps/desktop/src/renderer/src/nimi/task.tsx
@@ -193,6 +193,11 @@ function DraftCard({
           aria-label={copied ? 'Copied' : 'Copy draft'}
           onClick={(e) => {
             e.stopPropagation()
+            // Write the real draft text (blank line between paragraphs). The
+            // sandboxed renderer is a secure context, so the async Clipboard API
+            // is available; ignore rejection (e.g. focus lost) — the icon still
+            // confirms intent.
+            void navigator.clipboard?.writeText(draft.join('\n\n')).catch(() => {})
             setCopied(true)
             setTimeout(() => setCopied(false), 1400)
           }}
@@ -472,7 +477,7 @@ export function TaskDetail({
                         key={id}
                         m={m}
                         rel={relFor(task, id)}
-                        why={null}
+                        why={task.whyMap?.[id] ?? null}
                         pinned
                         swept={swept.has(id)}
                         fresh={fresh.has(id)}
@@ -543,7 +548,7 @@ export function TaskDetail({
                         key={id}
                         m={m}
                         rel={relFor(task, id)}
-                        why={null}
+                        why={task.whyMap?.[id] ?? null}
                         pinned={false}
                         swept={swept.has(id)}
                         fresh={fresh.has(id)}

--- a/apps/desktop/src/renderer/src/nimi/today.tsx
+++ b/apps/desktop/src/renderer/src/nimi/today.tsx
@@ -17,8 +17,6 @@ function greeting(): string {
   if (h < 18) return 'Afternoon'
   return 'Evening'
 }
-// TODO(memory-weather): re-enable with the MemoryWeather banner below.
-// const FIRST_NAME = 'Jordan'
 function dateLabel(): string {
   return new Date().toLocaleDateString(undefined, {
     weekday: 'long',
@@ -68,21 +66,42 @@ export function AppHeader({
   )
 }
 
-// TODO(memory-weather): temporarily disabled — re-enable this component, its
-// render below, the `onWeather` destructure, and the FIRST_NAME const together.
-// function MemoryWeather({ count, onOpen }: { count: number; onOpen: () => void }): JSX.Element {
-//   return (
-//     <div className="weather" onClick={onOpen} style={{ cursor: 'pointer' }}>
-//       <div className="weather-main">
-//         <div className="weather-t">
-//           Hey {FIRST_NAME} — overnight I lined up <b>{count} things</b> beside today&apos;s list.
-//         </div>
-//         <div className="weather-meta">1,284 memories · last fed 9h ago</div>
-//       </div>
-//       <NIcon name="chevRight" size={16} style={{ color: 'var(--ink-3)', flex: '0 0 auto' }} />
-//     </div>
-//   )
-// }
+// The ambient "memory weather" banner. `count` is how many context items Nimi
+// surfaced beside today's tasks (real, from each task's ctx pool); `memoryCount`
+// + `lastFed` come from the live archive (newest-first). `userName` is the signed-
+// in identity (null in a local/unconfigured build → the greeting drops the name).
+function MemoryWeather({
+  count,
+  userName,
+  memoryCount,
+  lastFed,
+  onOpen
+}: {
+  count: number
+  userName: string | null
+  memoryCount: number
+  lastFed: string | null
+  onOpen: () => void
+}): JSX.Element {
+  const meta = [
+    `${memoryCount.toLocaleString()} ${memoryCount === 1 ? 'memory' : 'memories'}`,
+    lastFed ? `last fed ${lastFed.toLowerCase()}` : null
+  ]
+    .filter(Boolean)
+    .join(' · ')
+  return (
+    <div className="weather" onClick={onOpen} style={{ cursor: 'pointer' }}>
+      <div className="weather-main">
+        <div className="weather-t">
+          {userName ? `Hey ${userName} — ` : ''}overnight I lined up <b>{count} things</b> beside
+          today&apos;s list.
+        </div>
+        <div className="weather-meta">{meta}</div>
+      </div>
+      <NIcon name="chevRight" size={16} style={{ color: 'var(--ink-3)', flex: '0 0 auto' }} />
+    </div>
+  )
+}
 
 // stacked mini-thumbnails for the ambient strip
 function CtxThumbs({ memIds }: { memIds: string[] }): JSX.Element {
@@ -208,6 +227,12 @@ interface TodayViewProps {
   carriedCount: number
   backlogCount: number
   badge: number
+  /** Signed-in display name, or null in a local/unconfigured build. */
+  userName: string | null
+  /** Live archive size (real). */
+  memoryCount: number
+  /** Pre-formatted relative time of the most-recent capture, or null if empty. */
+  lastFed: string | null
   onOpen: (id: string) => void
   onToggle: (id: string) => void
   onAdd: () => void
@@ -227,12 +252,15 @@ export function TodayView({
   carriedCount,
   backlogCount,
   badge,
+  userName,
+  memoryCount,
+  lastFed,
   onOpen,
   onToggle,
   onPlan,
   onTomorrow,
   onSearch,
-  // onWeather, // TODO(memory-weather): re-enable with the MemoryWeather render
+  onWeather,
   onSettings,
   nimiState
 }: TodayViewProps): JSX.Element {
@@ -281,12 +309,15 @@ export function TodayView({
           onTomorrow={onTomorrow}
           onSettings={onSettings}
         />
-        {/* TODO(memory-weather): temporarily disabled — re-enable with the component above.
-        <MemoryWeather
-          count={tasks.reduce((a, t) => a + (t.ctx ? t.ctx.length : 0), 0)}
-          onOpen={onWeather}
-        />
-        */}
+        {memoryCount > 0 && (
+          <MemoryWeather
+            count={tasks.reduce((a, t) => a + (t.ctx ? t.ctx.length : 0), 0)}
+            userName={userName}
+            memoryCount={memoryCount}
+            lastFed={lastFed}
+            onOpen={onWeather}
+          />
+        )}
         <div className="today-top">
           <span className="today-cap">
             Today · <b>{left}</b> of {cap}


### PR DESCRIPTION
## What & why

The shipping Electron renderer still ran on **prototype stand-ins** ported from the design mockup — even where the real `window.api` backend already exists (`nimi/ui-stubs.ts` was the tell). This wires the UI to the real backend and makes the copy tell the truth. Sourced from `docs/agent-sync/UX-PUNCHLIST.md` §A–C.

**Renderer-only — no `@nimi/contract` change.**

## Changes

- **today.tsx / plan.tsx** — real signed-in name (was hardcoded `"Jordan"`); re-enabled the `MemoryWeather` banner with **live archive count + most-recent-capture timestamp** (was the literal `"1,284 memories · last fed 9h ago"`). Banner hides on an empty archive, and the greeting drops the name gracefully in a local/unconfigured build.
- **add.tsx (feed)** — replaced the `2 + Math.random()*4` "connections" tick + fixed 1750ms timer with the **real count of captured memories**, awaiting the actual captures; swapped the `ui-stubs` `uncoverTodos()` for the real `data.pipeline.uncoverTodos()`; added a failure state.
- **add.tsx (to-do)** — "Added to your backlog" now correctly says **"Added to today"** when the to-do lands on Today (under the cap-5).
- **feed.tsx** — the Note/Link quick-tools open the **real Add composer** (which calls `captureText`/`captureFile`) instead of fabricating local `FedItem`s.
- **task.tsx** — context cards render the real `Task.whyMap`; the draft **Copy** button actually writes to the clipboard.
- **NimiApp.tsx** — added `refreshArchive()` fired via a post-capture `onCaptured` callback (dropzone + Add sheet), so new memories show up (thumbs, ctx, search rows) **without a reload**.

## Verification

- `tsc` (node + web), eslint, and `electron-vite build` all green.
- **Live smoke test** against the built Electron app (Playwright `_electron`, `NEEME_EMBEDDER=hash NEEME_DRAFTER=off`):
  - feeding text → **"Filed away — 1 memory"** (real count)
  - weather banner **hidden when empty → appeared after capture** reading **"1 MEMORY · LAST FED JUST NOW"** (Stage 3 refresh, no reload)
  - adding a to-do → **"Added to today"** (Today had room), and it surfaced the just-captured memory as context
  - feed **Note** tool → opens the real Add composer

## Notes / follow-ups (not in this PR)

- **Backend gaps (separate, contract-first):** on-demand draft (`todos.draft(id)`), "Open source"/"Open in Mail" (needs `Memory.uri` + a main-process `openExternal` IPC), and voice→ASR wiring. The `tryDraft` CTA and these buttons are intentionally left until those land.
- **Task chat ("Ask Nimi")** still uses scripted `CHAT_REPLIES` — left as-is by request, to revisit with the W7 product pass.
- Because there's no Electron runtime in CI, this was smoke-tested locally (per `apps/desktop/CLAUDE.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)