### PR TITLE
fix(desktop): consolidate at-rest secrets into one keychain-sealed vault

### DIFF
--- a/apps/desktop/CLAUDE.md
+++ b/apps/desktop/CLAUDE.md
@@ -69,3 +69,23 @@ tests against a real libSQL file (pipeline-service, todo-service, draft-service)
 The non-negotiable Electron invariants live in the root `CLAUDE.md` and `docs/SECURITY.md`.
 They are enforced here (`src/main/window`, `src/preload`) — don't loosen sandbox / context
 isolation / nav lockdown, and only expose scoped methods over `contextBridge`.
+
+### Secrets & the macOS keychain prompt
+
+All at-rest secrets (Logto refresh token, Google connector tokens, broker sync token,
+per-device sync key) live in **one** `safeStorage`-sealed vault, `src/main/secrets/store.ts`
+(`neeme-secrets.bin`). `loadAll()` runs first in `app.whenReady()` — one Keychain decrypt at
+boot; every owner then reads its slice from memory. Add a new secret as a key on `SecretsShape`
+(`get`/`set`), not a new sealed file — N files = N Keychain prompts on launch.
+
+The macOS "… wants to use … Safe Storage" prompt is a **code-signing** artifact, not a bug:
+the keychain ACL is granted to a stable signing identity. So —
+- **`pnpm dev` is ad-hoc-signed → it re-prompts on every launch** (expected; "Always Allow"
+  can't persist). Live with it, or re-sign `node_modules/electron/dist/Electron.app` with a
+  stable self-signed identity so the ACL sticks.
+- **A properly Developer-ID-signed + notarized release prompts once**, then "Always Allow"
+  (not "Allow") persists forever. The CI release signs (`.github/workflows/release.yml`:
+  `CSC_LINK` + `APPLE_*`). If a *packaged* build re-prompts every launch, verify it's the
+  signed DMG: `codesign -dv --verbose=4 <app>` (expect Developer ID + stable identifier/team)
+  and `spctl -a -vv <app>` (expect Notarized). An unsigned local `build:unpack` /
+  `electron-vite preview` will behave like dev.

--- a/apps/desktop/src/main/auth/logto.ts
+++ b/apps/desktop/src/main/auth/logto.ts
@@ -22,10 +22,9 @@
  */
 import { brand } from '@nimi/brand'
 import type { AuthClaims, AuthState } from '@nimi/contract/ipc'
-import { app, safeStorage, shell } from 'electron'
+import { shell } from 'electron'
 import { createRemoteJWKSet } from 'jose'
-import { readFile, rm, writeFile } from 'node:fs/promises'
-import { join } from 'node:path'
+import * as secrets from '../secrets/store'
 import {
   buildAuthorizeUrl,
   claimsFromPayload,
@@ -71,36 +70,20 @@ let jwks: JwksResolver | null = null
 let session: Session | null = null
 let pending: { verifier: string; state: string; nonce: string } | null = null
 let listener: Listener | null = null
-// Last plaintext written to (or read from) the session file. Lets persist() skip a
-// redundant re-seal — a macOS Keychain touch — when nothing actually changed.
-let lastPersisted: string | null = null
 
 export function isConfigured(): boolean {
   return Boolean(endpoint && appId)
 }
 
-function sessionFile(): string {
-  return join(app.getPath('userData'), 'neeme-auth.bin')
-}
-
 async function persist(): Promise<void> {
   if (!session?.refreshToken) {
-    lastPersisted = null
-    await rm(sessionFile(), { force: true }).catch(() => {})
+    await secrets.set('auth', undefined)
     return
   }
   // Only the refresh token + display claims are persisted; access tokens stay in memory.
-  const plain = JSON.stringify({ refreshToken: session.refreshToken, claims: session.claims })
-  // Skip the re-seal when nothing changed — e.g. a boot refresh that returns the
-  // SAME refresh token. encryptString is a Keychain access; an unsigned dev build
-  // re-prompts for each one, so eliding the no-op write halves the boot prompts.
-  // In a signed release it just avoids a pointless disk write.
-  if (plain === lastPersisted) return
-  const blob = safeStorage.isEncryptionAvailable()
-    ? safeStorage.encryptString(plain)
-    : Buffer.from(plain, 'utf8') // fallback (e.g. Linux w/o keyring); still inside userData
-  await writeFile(sessionFile(), blob)
-  lastPersisted = plain
+  // The vault elides the re-seal (a Keychain touch) when nothing changed — e.g. a boot
+  // refresh that returns the SAME refresh token. See secrets/store.ts.
+  await secrets.set('auth', { refreshToken: session.refreshToken, claims: session.claims })
 }
 
 async function discover(): Promise<OidcConfig> {
@@ -281,30 +264,20 @@ function emit(): void {
 /** Restore a persisted session on startup (silent refresh). Safe when unconfigured. */
 export async function init(): Promise<void> {
   if (!isConfigured()) return
-  try {
-    const blob = await readFile(sessionFile())
-    const plain = safeStorage.isEncryptionAvailable()
-      ? safeStorage.decryptString(blob)
-      : blob.toString('utf8')
-    // Remember what's already sealed on disk so a boot refresh that returns the
-    // same refresh token + claims won't trigger a redundant re-seal (Keychain touch).
-    lastPersisted = plain
-    const parsed = JSON.parse(plain) as { refreshToken?: string; claims?: AuthClaims | null }
-    if (parsed.refreshToken) {
-      session = {
-        accessToken: '',
-        refreshToken: parsed.refreshToken,
-        expiresAt: 0,
-        claims: parsed.claims ?? null
-      }
-      // Silent refresh on boot. If it fails only because we're offline (or the
-      // server is briefly down), keep the restored session so the login gate
-      // still opens to the user's local data; only a real auth rejection drops it.
-      await refresh().catch((err) => {
-        if (isAuthRejection(err)) session = null
-      })
+  // Read from the in-memory vault (loaded once at startup — no Keychain touch here).
+  const stored = secrets.get('auth')
+  if (stored?.refreshToken) {
+    session = {
+      accessToken: '',
+      refreshToken: stored.refreshToken,
+      expiresAt: 0,
+      claims: stored.claims ?? null
     }
-  } catch {
-    /* no stored session */
+    // Silent refresh on boot. If it fails only because we're offline (or the
+    // server is briefly down), keep the restored session so the login gate
+    // still opens to the user's local data; only a real auth rejection drops it.
+    await refresh().catch((err) => {
+      if (isAuthRejection(err)) session = null
+    })
   }
 }

--- a/apps/desktop/src/main/connectors/google-auth.ts
+++ b/apps/desktop/src/main/connectors/google-auth.ts
@@ -9,8 +9,8 @@
  *   - Redirect: Google Desktop-app OAuth clients reject custom schemes, so we use a
  *     **loopback redirect** (`http://127.0.0.1:<port>`). An ephemeral `http.createServer`
  *     runs only during the flow (listening for the `?code` callback), then closes.
- *   - Tokens: refresh token sealed in OS keychain via `safeStorage` (`neeme-connectors.bin`).
- *     Access tokens (short-lived) stay in memory only.
+ *   - Tokens: refresh token sealed in OS keychain via `safeStorage`, held in the shared
+ *     secrets vault (`../secrets/store`). Access tokens (short-lived) stay in memory only.
  *   - PKCE helpers reused from `../auth/oidc.ts` (provider-agnostic; see PR #35 notes).
  *
  * Env knobs (MAIN_VITE_* are baked by electron-vite; NEEME_* are runtime process.env):
@@ -22,10 +22,9 @@
  * Combined with `prompt=consent`, this reliably re-issues the refresh token even for
  * previously-authorized clients, which matters for developer iteration.
  */
-import { app, safeStorage, shell } from 'electron'
+import { shell } from 'electron'
 import { createServer } from 'node:http'
-import { readFile, writeFile, rm } from 'node:fs/promises'
-import { join } from 'node:path'
+import * as secrets from '../secrets/store'
 import { randomVerifier, pkceChallenge, randomState } from '../auth/oidc'
 import type { ConnectorId, ConnectorsState, ProviderState } from '@nimi/contract/ipc'
 
@@ -76,25 +75,14 @@ function scopes(): string {
 
 // ── Persistence (refresh tokens only) ──────────────────────────────────────
 
-function sessionsFile(): string {
-  return join(app.getPath('userData'), 'neeme-connectors.bin')
-}
-
 interface PersistedData {
   gmail?: { refreshToken: string }
   gcal?: { refreshToken: string }
 }
 
 async function loadPersisted(): Promise<PersistedData> {
-  try {
-    const blob = await readFile(sessionsFile())
-    const plain = safeStorage.isEncryptionAvailable()
-      ? safeStorage.decryptString(blob)
-      : blob.toString('utf8')
-    return JSON.parse(plain) as PersistedData
-  } catch {
-    return {}
-  }
+  // From the in-memory vault (loaded once at startup — no Keychain touch here).
+  return secrets.get('connectors') ?? {}
 }
 
 async function savePersisted(): Promise<void> {
@@ -103,15 +91,7 @@ async function savePersisted(): Promise<void> {
   const gcalSession = sessions.get('gcal')
   if (gmailSession) data.gmail = { refreshToken: gmailSession.refreshToken }
   if (gcalSession) data.gcal = { refreshToken: gcalSession.refreshToken }
-  if (!data.gmail && !data.gcal) {
-    await rm(sessionsFile(), { force: true }).catch(() => {})
-    return
-  }
-  const plain = JSON.stringify(data)
-  const blob = safeStorage.isEncryptionAvailable()
-    ? safeStorage.encryptString(plain)
-    : Buffer.from(plain, 'utf8')
-  await writeFile(sessionsFile(), blob)
+  await secrets.set('connectors', data.gmail || data.gcal ? data : undefined)
 }
 
 // ── Token exchange + refresh ────────────────────────────────────────────────
@@ -212,7 +192,10 @@ export async function getAccessToken(provider: ConnectorId): Promise<string | un
  * Resolves once tokens are stored (or rejects on error/timeout).
  */
 export async function connect(provider: ConnectorId): Promise<void> {
-  if (!isConfigured()) throw new Error('Google OAuth is not configured (set MAIN_VITE_GOOGLE_CLIENT_ID + _SECRET in .env)')
+  if (!isConfigured())
+    throw new Error(
+      'Google OAuth is not configured (set MAIN_VITE_GOOGLE_CLIENT_ID + _SECRET in .env)'
+    )
 
   return new Promise<void>((resolve, reject) => {
     // Spin up an ephemeral loopback server on a random OS-assigned port.
@@ -253,7 +236,9 @@ export async function connect(provider: ConnectorId): Promise<void> {
       exchangeCode(code, redirectUri, verifier)
         .then((t) => {
           if (!t.refresh_token) {
-            throw new Error('Google did not return a refresh_token — ensure access_type=offline and prompt=consent')
+            throw new Error(
+              'Google did not return a refresh_token — ensure access_type=offline and prompt=consent'
+            )
           }
           sessions.set(provider, {
             accessToken: t.access_token,
@@ -296,13 +281,16 @@ export async function connect(provider: ConnectorId): Promise<void> {
     })
 
     // Timeout after 5 minutes if the user doesn't complete the flow.
-    setTimeout(() => {
-      if (pending?.provider === provider) {
-        pending = null
-        server.close()
-        reject(new Error('Google OAuth flow timed out (5 min)'))
-      }
-    }, 5 * 60 * 1000)
+    setTimeout(
+      () => {
+        if (pending?.provider === provider) {
+          pending = null
+          server.close()
+          reject(new Error('Google OAuth flow timed out (5 min)'))
+        }
+      },
+      5 * 60 * 1000
+    )
   })
 }
 

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -7,6 +7,7 @@ import { join } from 'path'
 import * as auth from './auth/logto'
 import * as googleAuth from './connectors/google-auth'
 import { installApplicationMenu } from './menu'
+import * as secrets from './secrets/store'
 import { clearSyncToken, restoreCachedToken } from './sync/broker'
 import {
   getRecoveryKey,
@@ -95,6 +96,11 @@ function assertConnectorId(value: unknown): asserts value is ConnectorId {
 app.whenReady().then(async () => {
   // Set app user model id for windows
   electronApp.setAppUserModelId('com.electron')
+
+  // Load all at-rest secrets from the single sealed vault FIRST, in one Keychain
+  // decrypt. Every downstream init (auth, broker, sync key, connectors) then reads
+  // its slice from memory — no further Keychain touches at boot. See secrets/store.ts.
+  await secrets.loadAll()
 
   // --- Security: Content-Security-Policy as a response header (defense-in-depth) ---
   // The renderer's index.html carries the same policy in a <meta> tag, but a

--- a/apps/desktop/src/main/secrets/store.ts
+++ b/apps/desktop/src/main/secrets/store.ts
@@ -1,0 +1,149 @@
+/**
+ * Single encrypted secrets vault for the main process.
+ *
+ * The desktop client holds a handful of at-rest secrets — the Logto refresh
+ * token, Google connector refresh tokens, the broker sync token, and the
+ * per-device encryption key. Historically each lived in its own
+ * `safeStorage`-sealed file under `userData`, and each was decrypted separately
+ * at startup. On macOS every `safeStorage.decryptString()` is a fetch of the
+ * app's Keychain master key, and an untrusted (ad-hoc / unsigned dev) build
+ * re-prompts for every fetch — so four files meant four Keychain prompts on
+ * every launch.
+ *
+ * This module collapses them into ONE sealed file (`neeme-secrets.bin`) read
+ * exactly once at boot via `loadAll()`. After that, `get()` is a pure in-memory
+ * lookup (zero Keychain touches); only `set()` — driven by user actions like
+ * login / connect / sync-toggle — re-seals, and that's elided when nothing
+ * changed. Net result: a single Keychain decrypt per launch (which a properly
+ * code-signed build only ever prompts for once, via "Always Allow").
+ *
+ * `safeStorage` stays the at-rest primitive (Keychain on macOS, DPAPI on
+ * Windows, libsecret/kwallet on Linux); we keep the existing plaintext fallback
+ * for platforms without a backing keyring.
+ */
+import type { AuthClaims, BrokerTokenResponse } from '@nimi/contract/ipc'
+import { app, safeStorage } from 'electron'
+import { readFile, rm, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+
+/** Everything sealed in the vault. Each key is owned by one main-process module. */
+export interface SecretsShape {
+  /** Logto: refresh token + display claims (auth/logto.ts). */
+  auth?: { refreshToken: string; claims: AuthClaims | null }
+  /** Google OAuth refresh tokens (connectors/google-auth.ts). */
+  connectors?: { gmail?: { refreshToken: string }; gcal?: { refreshToken: string } }
+  /** Broker-issued Turso sync token (sync/broker.ts). */
+  broker?: BrokerTokenResponse
+  /** Per-device AES-256-GCM key, 64-hex (sync/sync-prefs.ts). */
+  syncKey?: string
+}
+
+let mem: SecretsShape = {}
+// Last plaintext sealed to disk; lets flush() skip a redundant re-seal — a
+// Keychain touch — when a write doesn't actually change anything.
+let lastSealed: string | null = null
+let loaded = false
+
+function vaultFile(): string {
+  return join(app.getPath('userData'), 'neeme-secrets.bin')
+}
+
+function seal(plain: string): Buffer {
+  return safeStorage.isEncryptionAvailable()
+    ? safeStorage.encryptString(plain)
+    : Buffer.from(plain, 'utf8') // fallback (e.g. Linux w/o keyring); still inside userData
+}
+
+function open(blob: Buffer): string {
+  return safeStorage.isEncryptionAvailable()
+    ? safeStorage.decryptString(blob)
+    : blob.toString('utf8')
+}
+
+/**
+ * Load the vault into memory. Idempotent; the one Keychain decrypt at startup.
+ * Falls back to a one-time migration of the legacy per-secret files when the
+ * consolidated vault doesn't exist yet.
+ */
+export async function loadAll(): Promise<void> {
+  if (loaded) return
+  loaded = true
+  try {
+    const plain = open(await readFile(vaultFile()))
+    mem = JSON.parse(plain) as SecretsShape
+    lastSealed = plain
+  } catch {
+    // No consolidated vault yet — try migrating the legacy files (or start empty).
+    await migrateLegacy()
+  }
+}
+
+/** In-memory read; never touches the Keychain. */
+export function get<K extends keyof SecretsShape>(key: K): SecretsShape[K] {
+  return mem[key]
+}
+
+/** Set (or clear, when value is undefined) a slice and re-seal the vault. */
+export async function set<K extends keyof SecretsShape>(
+  key: K,
+  value: SecretsShape[K]
+): Promise<void> {
+  if (value === undefined) delete mem[key]
+  else mem[key] = value
+  await flush()
+}
+
+async function flush(): Promise<void> {
+  const plain = JSON.stringify(mem)
+  if (plain === lastSealed) return // nothing changed — skip the re-seal (Keychain touch)
+  await writeFile(vaultFile(), seal(plain))
+  lastSealed = plain
+}
+
+/**
+ * One-time migration from the four legacy `safeStorage` files into the vault.
+ * Each decrypt is the same Keychain access those files cost today, so the first
+ * launch after upgrading may still show up to four prompts; afterwards the
+ * legacy files are gone and every launch is a single vault read.
+ */
+async function migrateLegacy(): Promise<void> {
+  const dir = app.getPath('userData')
+  const legacy = {
+    auth: join(dir, 'neeme-auth.bin'),
+    connectors: join(dir, 'neeme-connectors.bin'),
+    broker: join(dir, 'neeme-sync-token.bin'),
+    syncKey: join(dir, 'neeme-sync-key.bin')
+  }
+  let migrated = false
+
+  // Each file decrypts + parses independently so one corrupt/absent file can't
+  // sink the rest. The sync key is a bare hex string; the others are JSON.
+  const readJson = async <T>(path: string): Promise<T | undefined> => {
+    try {
+      return JSON.parse(open(await readFile(path))) as T
+    } catch {
+      return undefined
+    }
+  }
+
+  mem.auth = await readJson<SecretsShape['auth']>(legacy.auth)
+  mem.connectors = await readJson<SecretsShape['connectors']>(legacy.connectors)
+  mem.broker = await readJson<SecretsShape['broker']>(legacy.broker)
+  try {
+    const hex = open(await readFile(legacy.syncKey)).trim()
+    if (hex) mem.syncKey = hex
+  } catch {
+    /* no legacy sync key */
+  }
+
+  for (const key of Object.keys(mem) as (keyof SecretsShape)[]) {
+    if (mem[key] === undefined) delete mem[key]
+    else migrated = true
+  }
+
+  if (!migrated) return // nothing to carry over — leave the vault unwritten
+
+  await flush() // write the consolidated vault once...
+  // ...then drop the legacy files so subsequent boots take the single-read path.
+  await Promise.all(Object.values(legacy).map((p) => rm(p, { force: true }).catch(() => {})))
+}

--- a/apps/desktop/src/main/sync/broker.ts
+++ b/apps/desktop/src/main/sync/broker.ts
@@ -18,18 +18,12 @@
  *     by electron-vite, so packaged releases (no shell env) still find the broker.
  *   e.g. https://sync.getmikan.com
  */
-import { app, safeStorage } from 'electron'
-import { readFile, writeFile, rm } from 'node:fs/promises'
-import { join } from 'node:path'
 import type { BrokerTokenResponse } from '@nimi/contract/ipc'
+import * as secrets from '../secrets/store'
 
 const REFRESH_BUFFER_MS = 60_000 // refresh when < 60 s from expiry
 
 let cached: BrokerTokenResponse | null = null
-
-function cacheFile(): string {
-  return join(app.getPath('userData'), 'neeme-sync-token.bin')
-}
 
 function brokerUrl(): string | undefined {
   // Runtime override (dev/tests/cloud agents) takes priority over the build-time
@@ -48,36 +42,24 @@ function isTokenFresh(token: BrokerTokenResponse): boolean {
   return token.expiresAt - Date.now() > REFRESH_BUFFER_MS
 }
 
-/** Persist the token to the OS keychain via safeStorage. */
+/** Persist the token to the secrets vault (OS keychain via safeStorage). */
 async function persist(token: BrokerTokenResponse): Promise<void> {
-  const plain = JSON.stringify(token)
-  const blob = safeStorage.isEncryptionAvailable()
-    ? safeStorage.encryptString(plain)
-    : Buffer.from(plain, 'utf8')
-  await writeFile(cacheFile(), blob)
+  await secrets.set('broker', token)
 }
 
-/** Remove the cached token from disk. */
+/** Remove the cached token from the vault. */
 async function clearPersisted(): Promise<void> {
-  await rm(cacheFile(), { force: true }).catch(() => {})
+  await secrets.set('broker', undefined)
   cached = null
 }
 
-/** Restore a persisted token from disk (called at startup). */
+/** Restore a persisted token from the vault (called at startup; no Keychain touch). */
 export async function restoreCachedToken(): Promise<void> {
   if (!isBrokerConfigured()) return
-  try {
-    const blob = await readFile(cacheFile())
-    const plain = safeStorage.isEncryptionAvailable()
-      ? safeStorage.decryptString(blob)
-      : blob.toString('utf8')
-    const token = JSON.parse(plain) as BrokerTokenResponse
-    if (isTokenFresh(token)) {
-      cached = token
-    }
-    // Expired tokens are discarded; a fresh fetch will happen at first use.
-  } catch {
-    /* no stored token */
+  const token = secrets.get('broker')
+  // Expired tokens are ignored; a fresh fetch will happen at first use.
+  if (token && isTokenFresh(token)) {
+    cached = token
   }
 }
 

--- a/apps/desktop/src/main/sync/sync-prefs.ts
+++ b/apps/desktop/src/main/sync/sync-prefs.ts
@@ -1,12 +1,12 @@
 /**
  * Persisted sync preferences + the per-device at-rest encryption key.
  *
- * Two artifacts under Electron `userData`:
- *   - neeme-sync-prefs.json — plain JSON `{ enabled }`. The Settings toggle's
- *     *intent*; not a secret.
- *   - neeme-sync-key.bin — the 64-hex AES-256-GCM key (see db/crypto.ts), sealed
- *     in the OS keychain via `safeStorage` (same approach as the Logto refresh
- *     token and the broker token).
+ * Two artifacts:
+ *   - neeme-sync-prefs.json (plain JSON `{ enabled }` under `userData`) — the
+ *     Settings toggle's *intent*; not a secret.
+ *   - the 64-hex AES-256-GCM key (see db/crypto.ts), held in the shared secrets
+ *     vault (secrets/store.ts) under `syncKey` — sealed in the OS keychain via
+ *     `safeStorage`, alongside the Logto refresh token and the broker token.
  *
  * The key is generated once on this device the first time sync is enabled, and is
  * "sticky": once it exists it's always injected into the worker env so any rows
@@ -14,19 +14,17 @@
  * second device, the user reveals the key here and imports it there
  * (setRecoveryKey) — this is the recovery/export path in ADR 0008.
  */
-import { app, safeStorage } from 'electron'
+import { app } from 'electron'
 import { randomBytes } from 'node:crypto'
 import { readFile, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
+import * as secrets from '../secrets/store'
 
 /** A 32-byte key encoded as exactly 64 hex characters (matches db/crypto.ts). */
 const KEY_HEX = /^[0-9a-f]{64}$/i
 
 function prefsFile(): string {
   return join(app.getPath('userData'), 'neeme-sync-prefs.json')
-}
-function keyFile(): string {
-  return join(app.getPath('userData'), 'neeme-sync-key.bin')
 }
 
 /** Whether the user has turned the cloud replica on (persisted intent). */
@@ -45,22 +43,13 @@ export async function setSyncEnabledPref(enabled: boolean): Promise<void> {
 
 /** The device key if one exists, normalized to lowercase hex; null otherwise. */
 export async function getExistingKey(): Promise<string | null> {
-  try {
-    const blob = await readFile(keyFile())
-    const hex = safeStorage.isEncryptionAvailable()
-      ? safeStorage.decryptString(blob)
-      : blob.toString('utf8')
-    return KEY_HEX.test(hex) ? hex.toLowerCase() : null
-  } catch {
-    return null
-  }
+  // From the in-memory vault (loaded once at startup — no Keychain touch here).
+  const hex = secrets.get('syncKey')
+  return hex && KEY_HEX.test(hex) ? hex.toLowerCase() : null
 }
 
 async function persistKey(hex: string): Promise<void> {
-  const blob = safeStorage.isEncryptionAvailable()
-    ? safeStorage.encryptString(hex)
-    : Buffer.from(hex, 'utf8') // fallback (e.g. Linux w/o keyring); still inside userData
-  await writeFile(keyFile(), blob)
+  await secrets.set('syncKey', hex)
 }
 
 /** Return the device key, generating + sealing a fresh one on first use. */


### PR DESCRIPTION
## Problem

Opening the app triggered the macOS keychain prompt **4 times** every launch. The client kept **four** separate `safeStorage`-sealed files and decrypted each at startup:

| Startup step | File |
|---|---|
| `auth.init()` | `neeme-auth.bin` |
| `restoreCachedToken()` | `neeme-sync-token.bin` |
| `prepareSyncEnv()` → `getExistingKey()` | `neeme-sync-key.bin` |
| `googleAuth.init()` | `neeme-connectors.bin` |

On macOS each `safeStorage.decryptString()` is a fetch of the app's Keychain master key, and an untrusted (ad-hoc / unsigned dev) build re-prompts per fetch → 4 prompts/launch.

## Fix

**Pillar A — one keychain touch.** New `apps/desktop/src/main/secrets/store.ts`: a single sealed vault (`neeme-secrets.bin`) loaded once via `secrets.loadAll()` at the top of `app.whenReady()`. Owners (`auth/logto`, `connectors/google-auth`, `sync/broker`, `sync/sync-prefs`) now read their slice from memory (`get()`) and write via `set()` (re-seal elided when unchanged). Net: **1** keychain decrypt per launch. A one-time migration folds existing legacy files into the vault and deletes them (best-effort per file, so a corrupt secret can't brick boot).

**Pillar B — make the one prompt stick (docs).** Documented in `apps/desktop/CLAUDE.md` that the prompt is a **code-signing** artifact: `pnpm dev` (ad-hoc) re-prompts by design; a Developer-ID-signed + notarized release prompts once and "Always Allow" persists. Includes `codesign`/`spctl` checks to confirm a packaged build is genuinely signed.

`safeStorage` stays the at-rest primitive (Keychain / DPAPI / libsecret); no new crypto or keytar.

## Verification

- `pnpm typecheck` — green
- `pnpm --filter @nimi/desktop build` — green
- eslint on changed files — clean
- **Dev confirmed by author:** after the one-time migration, launches now show a single prompt.

### Reviewer note (no Electron in CI)
Worker/Electron behavior needs a live `pnpm dev` smoke: first launch migrates (≤4 prompts once) → `neeme-secrets.bin` created, legacy `neeme-*.bin` removed; relaunch → 1 prompt. Exercise `set()` paths: Logto login, Google connect, sync toggle + recovery-key import. Prod (0 prompts after "Always Allow") to be confirmed on the next signed release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)