### PR TITLE
Set up dev environment + document pnpm lint-after-build gotcha

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,6 +75,15 @@ The E2E reads ground truth back through `window.api.pipeline.archive()` (the app
 connection — a separate SQLite reader hits WAL-visibility races). It launches with
 `--user-data-dir=<tmp>` for an isolated throwaway DB.
 
+> **Logto-gate gotcha (cloud agents with secrets):** `electron-vite build` inlines
+> `MAIN_VITE_*` env at build time. When `MAIN_VITE_LOGTO_ENDPOINT` + `MAIN_VITE_LOGTO_APP_ID`
+> are present (they're injected as Cloud Agent secrets here), the **built** app boots behind
+> the Logto sign-in gate, so `.nav` never appears and every `_electron` spec times out in
+> `launchBuiltApp` (`waiting for locator('.nav')`). `pnpm dev` is unaffected. To run the E2E
+> tier / a built-app smoke in this environment, build with those vars unset, e.g.
+> `env -u MAIN_VITE_LOGTO_ENDPOINT -u MAIN_VITE_LOGTO_APP_ID -u MAIN_VITE_LOGTO_RESOURCE pnpm --filter @nimi/desktop build`
+> then run `test:e2e` (also with them unset). All 7 specs pass once unconfigured.
+
 ### Sync + encryption-at-rest tests (#10)
 
 Opt-in Turso sync with mandatory field encryption. Full procedure:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,14 @@ See **`CLAUDE.md`** for the full shared spine (architecture, contract, verify st
 
 From repo root: `pnpm typecheck`, `pnpm build`, `pnpm lint`, `pnpm test`. Pre-existing ESLint failures in `packages/contract/src/api/generated/**` are expected (hey-api output).
 
+> **Lint after build gotcha:** `pnpm build` writes the gitignored, regenerable
+> `services/mastra/.mastra/` bundles (multi-MB `.mjs`). They are **not** in
+> `eslint.config.mjs`'s ignore list, so running `pnpm lint` *after* a build makes
+> ESLint type-lint those giant files — ~20 min runtime that ends in
+> `RangeError: Invalid string length` (the `stylish` formatter overflows). Lint
+> *before* building, or `rm -rf services/mastra/.mastra` first; a clean `pnpm lint`
+> then finishes in ~6 s and reports only the pre-existing debt (exit 1).
+
 `pnpm test` fans out to `@nimi/desktop` vitest: 158 tests in plain Node (no Electron, no model download). Covers pipeline unit tests + integration tests for pipeline-service / todo-service / draft-service / uncover-service against a temp libSQL DB with `NEEME_EMBEDDER=hash` + `NEEME_DRAFTER=off`.
 
 ### Run the desktop app


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Set up + verified the Cloud Agent dev environment for the nimi/Mikan monorepo, and ran the GUI smoke test to verify the **nimi → Mikan rename** boots correctly. The only repo change is documentation in `AGENTS.md` (two durable, non-obvious gotchas found during setup). Everything else is environment setup verified live.

## Environment verification

| Step | Command | Result |
|---|---|---|
| Install | `pnpm install` | ✅ all workspaces (native deps + electron) |
| Typecheck | `pnpm typecheck` | ✅ 5/5 packages |
| Build | `pnpm build` | ✅ desktop + mastra + token-broker |
| Lint | `pnpm lint` | ✅ ~6s, pre-existing debt only (45 err / 117 warn) — run **before** build / without `.mastra` |
| Test | `pnpm test` | ⚠️ 187 pass / 81 fail — **pre-existing** code regression, not env (chunks table moved in #86, `test/helpers.ts` not updated) |
| Run (dev) | `NEEME_EMBEDDER=hash pnpm --filter @nimi/desktop dev` | ✅ boots to Today, worker + libSQL up |
| E2E | `pnpm --filter @nimi/desktop test:e2e` (Logto unset) | ✅ 7/7 (capture→IPC→worker→DB, CSP, fonts) |

## Rename (nimi → Mikan) smoke results

| Check | Result |
|---|---|
| Window title shows "Mikan" | ✅ `BrowserWindow.getTitle()` = `"Mikan"`, `document.title` = `"Mikan"` (note: frameless tray window, no visible OS title-bar chrome) |
| Capture appears in Feed | ✅ captured memories show under "Lately fed" |
| Search returns results | ✅ semantic search finds captured memory |
| No console errors referencing old `nimi/` paths / missing modules | ✅ 0 console/page errors in built renderer |
| Tray menu labels "Show Mikan" / "Quit Mikan" | ❌ **still hardcoded "Show Nimi" / "Quit Nimi"** + tooltip `'Nimi'` in `apps/desktop/src/main/window/tray-window.ts` (lines ~159–184) |

### Hello-world: capture → embed → index → semantic search
[nimi_capture_and_search_hello_world.mp4](https://cursor.com/agents/bc-6b2553c0-755b-4fdd-b16b-2f37a9a257f4/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fnimi_capture_and_search_hello_world.mp4)

### Capture appears in the Feed (renamed "Mikan" app)
[Feed shows captured memory](https://cursor.com/agents/bc-6b2553c0-755b-4fdd-b16b-2f37a9a257f4/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmikan_feed_coffee_beans.webp)
[Filed away — 1 memory](https://cursor.com/agents/bc-6b2553c0-755b-4fdd-b16b-2f37a9a257f4/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmikan_filed_away_dentist.webp)
[New capture appears in Feed](https://cursor.com/agents/bc-6b2553c0-755b-4fdd-b16b-2f37a9a257f4/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmikan_feed_dentist.webp)

## Findings worth a follow-up (no code changed here)

1. **Tray labels not renamed** — `tray-window.ts` hardcodes `Show Nimi` / `Quit Nimi` / tooltip `Nimi`. The user's checklist expects `Mikan`. Source-confirmed; needs a one-line code fix (out of scope for env setup).
2. **Package names are still `@nimi/*`** — there is no `@mikan/desktop`; use `--filter @nimi/desktop` (not `@mikan/desktop`).
3. **Pre-existing test failures** — `pnpm test` 81 failures: `no such table: chunks` (moved to local-only `neeme-vec.db` in `00b72eb`/#86; `apps/desktop/test/helpers.ts` still `DELETE FROM chunks` on the main client).

## AGENTS.md gotchas added

- **Lint-after-build:** `pnpm build` writes gitignored multi-MB `services/mastra/.mastra/` bundles not in eslint's ignore list → `pnpm lint` after a build hangs ~20 min and crashes the `stylish` formatter (`RangeError: Invalid string length`). Lint before building, or `rm -rf services/mastra/.mastra` first (then ~6s).
- **Logto-baked-build E2E gate:** `MAIN_VITE_LOGTO_*` are injected as Cloud Agent secrets and inlined by `electron-vite build`, so the **built** app boots behind the sign-in gate → all `_electron` specs time out on `.nav`. Build/run E2E with those vars unset.

## Update script

```
pnpm install
node node_modules/electron/install.js
```

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6b2553c0-755b-4fdd-b16b-2f37a9a257f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6b2553c0-755b-4fdd-b16b-2f37a9a257f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

