### PR TITLE
fix(desktop): brand tray labels (Nimi → Mikan)

### DIFF
--- a/apps/desktop/src/main/window/tray-window.ts
+++ b/apps/desktop/src/main/window/tray-window.ts
@@ -13,6 +13,7 @@ import { app, BrowserWindow, Tray, Menu, globalShortcut, screen, nativeImage } f
 import type { MenuItem, MenuItemConstructorOptions } from 'electron'
 import { join } from 'path'
 import { is } from '@electron-toolkit/utils'
+import { brand } from '@nimi/brand'
 import trayIconAsset from '../../../resources/trayTemplate.png?asset'
 import appIcon from '../../../resources/icon.png?asset'
 
@@ -156,10 +157,10 @@ export function initTrayWindow(): void {
   const img = nativeImage.createFromPath(trayIconAsset)
   if (process.platform === 'darwin') img.setTemplateImage(true)
   tray = new Tray(img)
-  tray.setToolTip('Nimi')
+  tray.setToolTip(brand.productName)
 
   const template: MenuItemConstructorOptions[] = [
-    { label: 'Show Nimi', click: () => showAnchored() },
+    { label: `Show ${brand.productName}`, click: () => showAnchored() },
     {
       label: 'Pin on top',
       type: 'checkbox',
@@ -181,7 +182,7 @@ export function initTrayWindow(): void {
   template.push(
     { type: 'separator' },
     {
-      label: 'Quit Nimi',
+      label: `Quit ${brand.productName}`,
       accelerator: 'CommandOrControl+Q',
       click: () => {
         quitting = true


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Wires the tray surface to the brand like every other user-facing surface. The tray tooltip and the **Show / Quit** menu items were hardcoded `'Nimi'`, so they still read "Nimi" after the Mikan rebrand.

## Change

`apps/desktop/src/main/window/tray-window.ts`:
- `import { brand } from '@nimi/brand'`
- `tray.setToolTip('Nimi')` → `tray.setToolTip(brand.productName)`
- `'Show Nimi'` → `` `Show ${brand.productName}` ``
- `'Quit Nimi'` → `` `Quit ${brand.productName}` ``

`brand.productName` resolves to `"Mikan"`, so the menu now shows **Show Mikan** / **Quit Mikan** and tooltip **Mikan**.

## Why only this

`electron-builder.config.cjs` documents the intent: *"the internal namespace (nimi/neeme) stays untouched elsewhere — brand lives only at the client edge."* The tray was the one user-facing surface that wasn't reading from the brand. The `@nimi/*` package scope, `neeme*` DB names, and `nimi/` source folders are intentional internal naming and are left as-is. `app.name` is deliberately untouched (it derives the `~/.config/@nimi/desktop` userData path — changing it would orphan existing DBs).

## Testing

- ✅ `pnpm --filter @nimi/desktop typecheck`
- ✅ `pnpm exec eslint apps/desktop/src/main/window/tray-window.ts` (clean)
- ✅ `pnpm --filter @nimi/desktop build` + boot under Xvfb — app reaches ready state (DB created), no crash from the new tray import
- ✅ Verified resolved strings: `productName="Mikan"`, labels `"Show Mikan"`/`"Quit Mikan"`, tooltip `"Mikan"`

Note: the OS-native tray menu can't be screenshotted in this headless VM, so evidence is the resolved strings + a clean boot rather than a tray screenshot.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6b2553c0-755b-4fdd-b16b-2f37a9a257f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6b2553c0-755b-4fdd-b16b-2f37a9a257f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

