### PR TITLE
fix: route chunks to vecClient, trim NEEME_* env flags (RETRO-6)

### DIFF
--- a/apps/desktop/src/main/db/index.ts
+++ b/apps/desktop/src/main/db/index.ts
@@ -310,6 +310,19 @@ async function createChunksLocal(): Promise<void> {
 }
 
 /**
+ * Drop and recreate the chunks table + vector index in neeme-vec.db.
+ *
+ * A plain DELETE FROM chunks leaves the libsql_vector_idx shadow tables in an
+ * inconsistent state, causing subsequent INSERTs to fail. Drop+recreate is the
+ * safe reset for tests and any other caller that needs a clean slate.
+ */
+export async function resetVecChunks(): Promise<void> {
+  await vecClient.execute('DROP INDEX IF EXISTS chunks_vec_idx').catch(() => {})
+  await vecClient.execute('DROP TABLE IF EXISTS chunks').catch(() => {})
+  await createChunksLocal()
+}
+
+/**
  * Add a column to an existing table only if it doesn't already exist.
  *
  * SQLite can't parameterize identifiers, so table/column/type are interpolated.

--- a/apps/desktop/src/main/pipeline/asr.ts
+++ b/apps/desktop/src/main/pipeline/asr.ts
@@ -151,7 +151,7 @@ function detectHelper(): string | null {
 
 // ── singleton ─────────────────────────────────────────────────────────────
 
-const extMode = process.env.NEEME_EXTRACTOR
+const extMode = process.env.NEEME_EXTRACTOR?.trim()
 const helper = extMode === 'off' || extMode === 'portable' ? null : detectHelper()
 
 /**

--- a/apps/desktop/src/main/pipeline/draft.ts
+++ b/apps/desktop/src/main/pipeline/draft.ts
@@ -380,7 +380,7 @@ export class CloudDrafter implements Drafter {
  * Mirrors `embedder` in `embed.ts`.
  */
 export const drafter: Drafter =
-  process.env.NEEME_DRAFTER === 'off' || !process.env.NEEME_ANTHROPIC_KEY
+  process.env.NEEME_DRAFTER?.trim() === 'off' || !process.env.NEEME_ANTHROPIC_KEY
     ? new NullDrafter()
     : new CloudDrafter(
         process.env.NEEME_ANTHROPIC_KEY,

--- a/apps/desktop/src/main/pipeline/embed.ts
+++ b/apps/desktop/src/main/pipeline/embed.ts
@@ -92,4 +92,4 @@ export class LocalEmbedder implements Embedder {
  * vector index is a rebuildable artifact derived from `items.text`.
  */
 export const embedder: Embedder =
-  process.env.NEEME_EMBEDDER === 'hash' ? new HashEmbedder() : new LocalEmbedder()
+  process.env.NEEME_EMBEDDER?.trim() === 'hash' ? new HashEmbedder() : new LocalEmbedder()

--- a/apps/desktop/src/main/pipeline/ocr.ts
+++ b/apps/desktop/src/main/pipeline/ocr.ts
@@ -144,7 +144,7 @@ function detectHelper(): string | null {
 
 // ── singleton ─────────────────────────────────────────────────────────────
 
-const extMode = process.env.NEEME_EXTRACTOR
+const extMode = process.env.NEEME_EXTRACTOR?.trim()
 const helper = extMode === 'off' || extMode === 'portable' ? null : detectHelper()
 
 /**

--- a/apps/desktop/src/main/services/pipeline-service.ts
+++ b/apps/desktop/src/main/services/pipeline-service.ts
@@ -1,5 +1,5 @@
 import { desc, eq, inArray, sql } from 'drizzle-orm'
-import { client, db, vecClient } from '../db'
+import { client, db, vecClient, resetVecChunks } from '../db'
 import { items, connectorState, type Item as ItemRow } from '../db/schema'
 import { chunkText } from '../pipeline/chunk'
 import { embedder } from '../pipeline/embed'
@@ -70,7 +70,7 @@ async function capture(bytes: Uint8Array, name: string, mime?: string): Promise<
   if (
     (contentType === 'image' || contentType === 'audio') &&
     storedPath &&
-    process.env.NEEME_EXTRACTOR !== 'off'
+    process.env.NEEME_EXTRACTOR?.trim() !== 'off'
   ) {
     scheduleExtraction(id, storedPath, contentType, mime)
   }
@@ -315,7 +315,9 @@ export const pipelineService = {
    *  Reads and decrypts text before re-indexing so the vector space uses plaintext. */
   async reindexAll(): Promise<number> {
     const rows = await db.select().from(items)
-    await vecClient.execute('DELETE FROM chunks')
+    // DELETE FROM chunks leaves the libsql_vector_idx shadow tables inconsistent;
+    // drop+recreate is the safe reset before re-inserting all vectors.
+    await resetVecChunks()
     let n = 0
     for (const row of rows) {
       const plaintext = decrypt(row.text)
@@ -332,7 +334,7 @@ export const pipelineService = {
    * Best-effort — failure must not block the worker from starting.
    */
   async resumeMediaExtraction(): Promise<void> {
-    if (process.env.NEEME_EXTRACTOR === 'off') return
+    if (process.env.NEEME_EXTRACTOR?.trim() === 'off') return
     const pending = await db
       .select()
       .from(items)

--- a/apps/desktop/test/helpers.ts
+++ b/apps/desktop/test/helpers.ts
@@ -3,12 +3,16 @@
  * (not from pure unit tests) — importing this module triggers the db/index.ts
  * singleton, which requires NEEME_USER_DATA to be set (done by test/setup.ts).
  */
-import { client } from '../src/main/db/index'
+import { client, resetVecChunks } from '../src/main/db/index'
 
 /** Wipe all rows between tests — preserves schema, resets state. */
 export async function clearTables(): Promise<void> {
-  // Delete in dependency order (FKs may or may not be enforced, but order is safe)
+  // Delete in dependency order (FKs may or may not be enforced, but order is safe).
   await client.executeMultiple(
-    'DELETE FROM todo_ai; DELETE FROM todo_context; DELETE FROM todos; DELETE FROM chunks; DELETE FROM items; DELETE FROM meta; DELETE FROM connector_state;'
+    'DELETE FROM todo_ai; DELETE FROM todo_context; DELETE FROM todos; DELETE FROM items; DELETE FROM meta; DELETE FROM connector_state;'
   )
+  // chunks lives in neeme-vec.db (vecClient) since commit 00b72eb (#86). A plain
+  // DELETE leaves the libsql_vector_idx shadow tables inconsistent; drop+recreate
+  // is the safe reset path.
+  await resetVecChunks()
 }

--- a/apps/desktop/test/pipeline/draft.test.ts
+++ b/apps/desktop/test/pipeline/draft.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi, afterEach } from 'vitest'
 import { NullDrafter } from '../../src/main/pipeline/draft'
 import type { DraftInput } from '../../src/main/pipeline/draft'
 
@@ -60,5 +60,30 @@ describe('NullDrafter', () => {
 
   it('resolves (does not throw or reject)', async () => {
     await expect(drafter.draft(EMPTY_INPUT)).resolves.toBeDefined()
+  })
+})
+
+describe('drafter singleton — whitespace-trimmed env flags', () => {
+  const savedDrafter = process.env.NEEME_DRAFTER
+  const savedKey = process.env.NEEME_ANTHROPIC_KEY
+
+  afterEach(() => {
+    if (savedDrafter === undefined) delete process.env.NEEME_DRAFTER
+    else process.env.NEEME_DRAFTER = savedDrafter
+    if (savedKey === undefined) delete process.env.NEEME_ANTHROPIC_KEY
+    else process.env.NEEME_ANTHROPIC_KEY = savedKey
+    vi.resetModules()
+  })
+
+  it('NEEME_DRAFTER="off " (trailing space) resolves to NullDrafter', async () => {
+    // Set an API key so the pre-fix code would have built a CloudDrafter; only the
+    // trim fix makes NEEME_DRAFTER="off " select NullDrafter correctly.
+    process.env.NEEME_DRAFTER = 'off '
+    process.env.NEEME_ANTHROPIC_KEY = 'sk-test-dummy-key'
+    vi.resetModules()
+    const { drafter: freshDrafter } = await import('../../src/main/pipeline/draft')
+    // instanceof fails across vi.resetModules() boundaries (two class objects); use
+    // the stable name property instead.
+    expect(freshDrafter.name).toBe('null-drafter')
   })
 })

--- a/apps/desktop/test/services/pipeline-service.test.ts
+++ b/apps/desktop/test/services/pipeline-service.test.ts
@@ -3,7 +3,7 @@
  * Requires NEEME_USER_DATA + NEEME_EMBEDDER=hash (set by test/setup.ts).
  */
 import { describe, it, expect, beforeAll, beforeEach } from 'vitest'
-import { initDb, client } from '../../src/main/db/index'
+import { initDb, client, vecClient } from '../../src/main/db/index'
 import { pipelineService } from '../../src/main/services/pipeline-service'
 import { clearTables } from '../helpers'
 
@@ -195,13 +195,13 @@ describe('pipelineService.syncEmbedder', () => {
     await pipelineService.captureText('sync embedder idempotency test', 'doc.md')
     await pipelineService.syncEmbedder()
 
-    // Count chunks after first sync
-    const before = await client.execute('SELECT COUNT(*) AS n FROM chunks')
+    // Count chunks after first sync (chunks live in neeme-vec.db via vecClient)
+    const before = await vecClient.execute('SELECT COUNT(*) AS n FROM chunks')
     const countBefore = Number(before.rows[0]!.n)
 
     await pipelineService.syncEmbedder()
 
-    const after = await client.execute('SELECT COUNT(*) AS n FROM chunks')
+    const after = await vecClient.execute('SELECT COUNT(*) AS n FROM chunks')
     const countAfter = Number(after.rows[0]!.n)
 
     // No additional chunks created — reindexAll was not called

--- a/apps/desktop/test/smoke/capture-file.ts
+++ b/apps/desktop/test/smoke/capture-file.ts
@@ -31,7 +31,7 @@ function check(label: string, ok: boolean): void {
 
 async function main(): Promise<void> {
   console.log(`[smoke] data dir: ${process.env.NEEME_USER_DATA}`)
-  const { client } = await import('../../src/main/db')
+  const { client, vecClient } = await import('../../src/main/db')
   const { initDb } = await import('../../src/main/db')
   const { pipelineService } = await import('../../src/main/services/pipeline-service')
 
@@ -45,8 +45,9 @@ async function main(): Promise<void> {
     const r = res.rows[0]
     return r ? { status: String(r.status), text: String(r.text) } : null
   }
+  // chunks live in neeme-vec.db (vecClient) since commit 00b72eb (#86)
   const chunkCount = async (id: string): Promise<number> => {
-    const res = await client.execute({
+    const res = await vecClient.execute({
       sql: 'SELECT count(*) AS n FROM chunks WHERE item_id = ?',
       args: [id]
     })


### PR DESCRIPTION
## Summary

Fixes two bugs from the post-rename handoff (`docs/agent-sync/HANDOFF-known-bugs-2026-06-27.md`). Linear: [RETRO-6](https://linear.app/retrospct/issue/RETRO-6).

**BUG 1 — P0: `no such table: chunks` (81 test failures, smoke crash)**

The `chunks` table moved to `neeme-vec.db` (accessed via `vecClient`) in commit 00b72eb (#86), but four call sites still targeted the main `client`:

- `test/helpers.ts` `clearTables()`: removed `DELETE FROM chunks` from `client.executeMultiple`; replaced with `resetVecChunks()`.
- `test/smoke/capture-file.ts` `chunkCount()`: switched to `vecClient`.
- `pipeline-service.ts` `reindexAll()`: switched to `resetVecChunks()`.
- `test/services/pipeline-service.test.ts` `syncEmbedder` test: switched chunk-count assertions to `vecClient`.

Also added `db/index.ts` `resetVecChunks()` (exported). A plain `DELETE FROM chunks` leaves the `libsql_vector_idx` shadow tables inconsistent, causing subsequent INSERTs to fail with `vector index(insert): failed to insert shadow row`. Drop+recreate is the correct reset.

**BUG 2 — whitespace-fragile `NEEME_*` env flag comparisons**

Applied `?.trim()` before strict equality checks in:
- `pipeline/draft.ts` (`NEEME_DRAFTER === 'off'`)
- `pipeline/embed.ts` (`NEEME_EMBEDDER === 'hash'`)
- `services/pipeline-service.ts` (`NEEME_EXTRACTOR`, ×2)
- `pipeline/asr.ts` and `pipeline/ocr.ts` (`extMode` from `NEEME_EXTRACTOR`)

Added a unit test asserting `NEEME_DRAFTER="off "` (trailing space) + a dummy API key still resolves to `NullDrafter`.

## Test plan

- [x] `pnpm --filter @mikan/desktop test` — 267/269 pass (2 pre-existing `broker-client` failures unrelated to this change)
- [x] `NEEME_EMBEDDER=hash NEEME_EXTRACTOR=off pnpm --filter @mikan/desktop test:smoke` — 24/24 checks pass
- [x] `pnpm --filter @mikan/desktop typecheck` — clean
- [x] `pnpm lint` (before build) — no new errors in changed files

> Worker smoke note: `reindexAll()` now calls `resetVecChunks()` (drop+recreate on `neeme-vec.db`). This is a local-only rebuild; no schema changes affect the synced primary. Verify with `NEEME_EMBEDDER=hash pnpm dev` after merging.