### PR TITLE
feat(contract): Mikan Flows task lifecycle foundation (RETRO-10)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,158 @@
+# CONTEXT — Mikan product & UX model
+
+> Single-context domain doc (per `CLAUDE.md` → "Domain docs"). Durable truth about
+> *what Mikan is* and *how its UX is shaped*. Initiative-specific delivery plans live
+> in `docs/plans/`; architectural decisions in `docs/adr/`.
+
+Mikan is an all-TypeScript, **on-device-first** personal-memory desktop app (Electron):
+capture multi-modal input → surface it (semantic search + a daily focus list) and **do
+the work** (draft, plan, act) to get things done. The product personality: *a warm, quiet
+system that comes alive when it matters* — minimalist resting states that expand into rich,
+multimodal AI surfaces, greyscale with **one restrained live accent** (matcha) marking only
+what is AI-active or actionable.
+
+---
+
+## The design source of record
+
+The product UX is defined by a Claude Design handoff: **`Mikan Flows.dc.html`** — a mid-fi
+wireframe canvas of ~60 screens across 14 groups. The current `apps/desktop` renderer was
+**already ported from an earlier handoff** (`mikan.css` header notes "Ported from the Claude
+Design handoff bundle"); *Mikan Flows* is the **evolved, more complete iteration** of that
+same language. The bundle's design system (`tokens.css`) is near-identical to the tokens
+already in `apps/desktop/src/renderer/src/mikan/mikan.css`.
+
+The canvas decomposes into **four buckets** (not 14 independent groups):
+
+| Bucket | Canvas groups | Essence | Reduces to |
+|---|---|---|---|
+| **A · Task-lifecycle spine** | 01, 02, 03, 07, 12, 14 | Six views of *one* flow | **one** lifecycle + **one** card-morph + a mode system |
+| **B · Onboarding** | 09, 10, 13 | First-run belief + model download | a tunable 4-window cadence (variants to choose) |
+| **C · Upgrade** | 11 | Free → Pro, contextual CTAs | paywall surfaces (no timer/wall) |
+| **D · Multimodal input** | 04, 05, 08 | Capture / jot / input | **one** input component used everywhere |
+
+A is the spine; D embeds inside it; B frames it; C monetizes it.
+
+---
+
+## The canonical task lifecycle (bucket A)
+
+Every task is **one state machine**. Groups 01/02/03/07/12/14 are this machine viewed at
+different zoom levels (Group 14 is the explicit end-to-end; Group 07 is its visual mechanism;
+Group 03 is the same spine with human gates collapsed; Group 12 zooms the plan-review states).
+
+### States
+
+| # | State | What's happening | The human's job |
+|---|---|---|---|
+| 1 | **listed** (on the list) | resting todo; carries a **mode** badge | — |
+| 2 | **planning** | Mikan decides the steps (searches memory, gathers context) | wait / steer |
+| 3 | **planned** (the plan) | plan ready; each step marked **Auto** or **Ask** | glance → accept, or edit a step |
+| 4 | **working** | executing steps; card expanded (reasoning, sources, tools) | watch / steer / pause |
+| 5 | **awaiting** (awaiting you) | hit an approval gate — *"nothing sent yet"* | approve & send/merge, or iterate |
+| 6 | **done** (report) | receipt: what it did, where it ran, what stayed on device | done, or iterate |
+
+**Planning is the default, not a mode you start** — by the time the user looks, the plan
+already exists, so the decision is small (glance → accept). The current contract's 4-state
+`TaskStatus` (`gathering|gathered|drafted|done`) is a coarser, email-draft-shaped ancestor of
+this; the canonical model **splits planning (decide) from working (execute)** and adds an
+explicit approval gate + a report receipt. It is task-type-agnostic, not reply-specific.
+
+### Mode (orthogonal to state)
+
+A **per-task switch**, set on the list — no separate hand-off screen:
+
+- **Plan** (default) — Mikan plans, the human reviews the plan and approves at gates.
+- **Auto** — Mikan runs the plan autonomously **on device**, pausing only at approval gates
+  (*steer anytime · pause*); every run closes with a plain-language **on-device receipt**.
+- Input-time modes also include **Save** and **Todo** (the input "mode menu", Group 5E).
+- Within a plan, **each step** independently runs `auto` or `ask`.
+
+### The card-morph (Group 07 — the visual mechanism)
+
+The same task card is the atomic unit everywhere. It **morphs** through the lifecycle while
+its **header stays pixel-stable** (avatar · title · orb hold position; only the body grows/
+shrinks):
+
+`collapsed → searching → running → reasoning → summary → complete`
+
+- **Tallest mid-run** (peaks at *reasoning*), then collapses back to a one-line header once
+  done — biggest when you most need to watch it.
+- **One orb = the whole state machine**: a ring that fills as steps complete, then flips to a
+  check. No separate status badges.
+- A good run offers **"Save as a skill"** — turning it into a reusable action.
+
+### The expanded workspace (Group 02)
+
+Opening a task line reveals a workspace Mikan **pre-filled while you slept**: a brief (with
+subtle citations), a collapsible **reasoning** card, a **Sources** component, and a **dock**
+of the skills/tools/connectors Mikan set up. The guided workflow is a stepper
+(`gathered → your voice → drafting → approve & send`) ending in an editable draft with
+**tap-don't-type refine** chips (Warmer / Shorter / Attach photos). **Chat ("Ask Mikan") is
+built from the same parts** — reasoning, tool-result cards, citations, sources — and is the
+escape hatch, not the main event.
+
+---
+
+## The one multimodal input (bucket D)
+
+One calm input bar, used everywhere (home composer, capture, jot, task composer). **Suggestions
+lead** so most days you tap, not type. Text, photo, file, voice, and tools all collapse back
+into the single bar. It carries the **mode chip** (Plan/Save/Todo/Auto) and a `+` menu. Voice
+and capture run **on device** ("listening · on device", "reading it in"). Adding a to-do sizes
+inline and lands on Today or in Next.
+
+---
+
+## Visual system (how it's expressed)
+
+- **Token-driven, dual-theme.** The shipping app is **dark-first** with a full token system
+  (`mikan.css`); a warm **cream light mode** is a first-class peer. The *Mikan Flows* wireframes
+  are drawn in **light/greyscale because they are mid-fi** — their literal hexes (`#faf9f6` bg,
+  `#1a1a1a` ink, `#6f7d63` accent, `#e7e6e2` hairline) are the existing **light-mode token
+  values**. Implement against the token vars (`--bg`, `--ink`, `--accent`, `--hairline`, …) for
+  *both* themes; **never hard-code the wireframe hexes**, and don't flip the app to light-first.
+- **One accent, spent sparingly** — accent marks only what is *alive or actionable*, never
+  decoration. Greyscale does the rest.
+- **Type:** Hanken Grotesk (human) + JetBrains Mono (the `.ovr` overline: uppercase, wide-tracked
+  status/labels/numerics, joined by the middot `·`). Sentence case for everything human.
+- **Motion is the personality**, restrained until a moment earns it: `pop/settle`, `breathe`
+  (idle-live mark), `pulse` (live orb), `sheen`, and **morph / stack / slide** for long-running
+  work. All motion gated by `prefers-reduced-motion` / `data-ambient="off"`.
+- **Cards** = `--surface-2` + 1px `--hairline` + `--r-card` + soft shadow, lifting on hover; an
+  inset **context strip** (pulsing orb + mono status) is the recurring "what's happening" pattern.
+- Icons: **Lucide** (light, single-weight line; round caps; 24px grid). Brand mark = rotated
+  rounded-square diamond framing a 5-dot node cluster, with the `breathe` animation when idle-live.
+
+---
+
+## How the canvas maps to the existing renderer
+
+`apps/desktop/src/renderer/src/mikan/` already implements an earlier cut. This redesign
+**evolves these in place** (they are already wired to `window.api` via `api.ts`):
+
+| Canvas | Existing file | Net-new? |
+|---|---|---|
+| 01 Today / Stack | `today.tsx` | evolve |
+| 02 Expand / Workspace / Guided / Ask | `task.tsx` | evolve |
+| 12 Plan mode | `plan.tsx` | evolve |
+| 04/05/08 Capture / Jot / Input | `add.tsx`, `voice.tsx`, `capture-file.ts` | converge to one input |
+| 07 Growing card | — | **new shared component** |
+| 03 Auto mode | — | **new** (front + run loop) |
+| 09/10/13 Onboarding + model download | — | **new** |
+| 11 Upgrade | — | **new** |
+| 14 Lifecycle | (integration of the above) | integration |
+
+The view-model contract is `@mikan/contract` (`packages/contract/src/views.ts`). The lifecycle
+above **supersedes `TaskStatus`** and is **contract-first work** — it lands in `@mikan/contract`
+(and `docs/INTEGRATION.md`) before any renderer change. Per "wire real, plain": structural
+fields are served for real; AI-driven transitions (planning/drafting/working) stay AI-gapped
+(`null`/empty, UI degrades gracefully) until the LLM layer lands.
+
+---
+
+## Pointers
+
+- Delivery plan + slices: [`docs/plans/mikan-flows.prd.md`](docs/plans/mikan-flows.prd.md)
+- Contract: [`packages/contract/src/views.ts`](packages/contract/src/views.ts) · [`docs/INTEGRATION.md`](docs/INTEGRATION.md)
+- Design source: the *Mikan Flows* handoff bundle (`Mikan Flows.dc.html` + `_ds/.../tokens.css`)

--- a/apps/desktop/src/main/services/project.ts
+++ b/apps/desktop/src/main/services/project.ts
@@ -18,6 +18,7 @@ import type {
   MemoryKind,
   NoteKind,
   Task,
+  TaskState,
   TaskStatus,
   UncoveredTodo
 } from '@mikan/contract/views'
@@ -148,11 +149,20 @@ export function toTask(todo: Todo, context: ContextEntry[], ai?: TaskDraft): Tas
     status = 'gathered'
   }
 
+  // Canonical lifecycle (Mikan Flows). Derived from the structural `status` the
+  // projector emits today: `done`→done, a landed draft→awaiting (the approval
+  // gate), otherwise the resting `listed`. `planning`/`planned`/`working` become
+  // real once the planner + run-loop land (slices S4/S5). See docs/adr/0010.
+  const state: TaskState = done ? 'done' : status === 'drafted' ? 'awaiting' : 'listed'
+
   return {
     id: todo.id,
     title: todo.title,
     when: whenOfDay(todo.day),
     status,
+    state,
+    // No stored per-task mode yet — defaults to Plan until the mode switch lands.
+    mode: 'plan',
     done,
     ctx: context.map((c) => c.itemId),
     pinned: context.filter((c) => c.state === 'pinned').map((c) => c.itemId),

--- a/docs/INTEGRATION.md
+++ b/docs/INTEGRATION.md
@@ -10,6 +10,26 @@
 
 Structural data is **served for real** from the on-device pipeline. **AI-generated fields come back `null`/empty** until the drafting layer lands. The UI degrades gracefully — no brief, no draft, neutral status.
 
+## Task lifecycle (Mikan Flows)
+
+The renderer redesign (`docs/plans/mikan-flows.prd.md`, model in `CONTEXT.md`) introduces a
+canonical six-state lifecycle that **supersedes `TaskStatus`**. It is rolled out **additively**
+so the build stays green — `Task.status` stays; new fields are added alongside:
+
+| Field | Type | Real / AI-gap |
+| --- | --- | --- |
+| `Task.state` | `'listed' \| 'planning' \| 'planned' \| 'working' \| 'awaiting' \| 'done'` | **Real** — derived from `status` at the projector (`toTask`) |
+| `Task.mode` | `'plan' \| 'auto'` | **Real** — defaults to `'plan'` (no stored per-task mode yet) |
+| `Task.steps` | `PlanStep[]` | **AI-gap** — `undefined` until the planner lands |
+| `Task.receipt` | `RunReceipt` | **AI-gap** — present once a run settles |
+
+Projector mapping today (`services/project.ts` → `toTask`): `done → 'done'`,
+drafted (a landed AI draft) `→ 'awaiting'` (the approval gate), otherwise `→ 'listed'`. The
+intermediate `'planning' / 'planned' / 'working'` states become real once the planner +
+run-loop land (slices S4/S5). Group-01 presentation states are **derived in the renderer**,
+not stored: `delegated = mode:auto & working`, `deferred = planning`, `in-progress = working`,
+`done = done`. Decision of record: `docs/adr/0010-task-lifecycle.md`.
+
 ## Current renderer wiring
 
 Renderer components import `data` from `apps/desktop/src/renderer/src/nimi/api.ts`.

--- a/docs/adr/0010-task-lifecycle.md
+++ b/docs/adr/0010-task-lifecycle.md
@@ -1,0 +1,68 @@
+# ADR 0010 — Canonical task lifecycle supersedes `TaskStatus`
+
+**Status:** Accepted (2026-06-30) — rolling out **additively**; `TaskState` lands in
+`@mikan/contract` first (slice S0), renderer slices migrate onto it, then `TaskStatus` retires.
+**Date:** 2026-06-30
+**Context owners:** jlee (+ Claude)
+**Related:** implements the *Mikan Flows* design (`CONTEXT.md`, `docs/plans/mikan-flows.prd.md`);
+evolves the view-model contract from [[0006-repo-structure]] (`@mikan/contract`); the AI-driven
+transitions stay gated behind [[0003-all-typescript-on-device-pipeline]] / [[0004-ai-drafting-model]].
+
+## Problem
+
+The *Mikan Flows* handoff defines the product as **one task-lifecycle pattern** viewed at six
+zoom levels (canvas Groups 01/02/03/07/12/14). The current contract models a task with a coarse,
+email-draft-shaped status:
+
+```ts
+export type TaskStatus = 'gathering' | 'gathered' | 'drafted' | 'done'
+```
+
+That conflates *deciding what to do* (planning) with *doing it* (working), has no explicit
+human approval gate, and no done/report receipt — all of which the design treats as distinct,
+load-bearing states. It's also reply-specific (`drafted`), whereas the lifecycle must cover any
+task type (plan, act, draft, book…). We need a single source of truth the growing-card morph
+(Group 07) and Auto mode (Group 03) both render.
+
+## Decision
+
+Adopt a six-state, task-type-agnostic lifecycle as the canonical model, plus an orthogonal mode:
+
+```ts
+type TaskState = 'listed' | 'planning' | 'planned' | 'working' | 'awaiting' | 'done'
+type TaskMode  = 'plan' | 'auto'          // per-task, set on the list
+type StepRun   = 'auto' | 'ask'           // per plan step
+interface PlanStep   { id; title; run: StepRun; tool?; status }   // drives the orb fill
+interface RunReceipt { ranOnDevice; durationMs; touched[]; sentAnything }
+```
+
+- **State** = where the task is; **mode** = how it runs (orthogonal). Planning is the *default*,
+  not a mode you start.
+- **Roll out additively to keep the build green.** S0 adds `TaskState`/`TaskMode`/`PlanStep`/
+  `RunReceipt` and adds optional `state`/`mode`/`steps`/`receipt` to `Task` **without removing
+  `status`**. The projector (`services/project.ts` → `toTask`) derives `state` from `status`
+  today. Renderer slices (S1–S6) migrate onto `state`; `status` retires in S6 once unused.
+- **"Wire real, plain" preserved.** `state`/`mode` are real (structural/derived); `steps`/
+  `receipt` are AI-gap (`undefined`/null) until the planner + run-loop land (S4/S5).
+- Group-01 presentation states (done / in-progress / delegated / deferred) are **derived in the
+  renderer** from `(state, mode)`, not stored.
+
+## Options considered
+
+Legend: ✅ strong · ⚠️ caveats · ❌ poor
+
+| Option | Build safety | Fidelity to design | Churn |
+| --- | --- | --- | --- |
+| A. Additive `TaskState` now, retire `TaskStatus` in S6 _(chosen)_ | ✅ green throughout | ✅ full six-state model | ✅ spread across slices |
+| B. Hard replace `TaskStatus` → `TaskState` in one change | ❌ breaks projector + every renderer consumer + mocks at once | ✅ | ❌ one giant change |
+| C. Keep `TaskStatus`, bolt design states onto the renderer only | ✅ | ❌ no single source of truth; Auto/plan diverge | ⚠️ debt |
+
+## Consequences
+
+- **+** One contract truth for the lifecycle; growing-card and Auto mode render the same `state`.
+- **+** Each renderer slice migrates independently; CI stays green between slices.
+- **−** Transient redundancy: `status` and `state` coexist until S6. Mitigation: `state` is the
+  only field new code reads; `status` is frozen (no new writers).
+- **Follow-through:** when `steps`/`receipt`/`mode` gain real backing (planner, run-loop, a stored
+  per-task mode), update `docs/INTEGRATION.md`'s real-vs-AI-gap table and flip the optional
+  `state`/`mode` to required once all consumers set them.

--- a/docs/plans/mikan-flows.prd.md
+++ b/docs/plans/mikan-flows.prd.md
@@ -1,0 +1,133 @@
+# PRD — Mikan Flows (renderer redesign)
+
+> Source: the *Mikan Flows* Claude Design handoff (`Mikan Flows.dc.html`, ~60 screens / 14 groups).
+> Durable UX model: [`CONTEXT.md`](../../CONTEXT.md). This PRD is the **delivery plan** and ends
+> in **spine-first slices** ready to become issues (Linear).
+
+## 1. Problem & goal
+
+The shipping renderer was ported from an **earlier** Claude Design handoff and has drifted from
+the current design thinking. *Mikan Flows* is the evolved language: a single **task-lifecycle**
+pattern, a single **multimodal input**, and a cohesive first-run/upgrade story. Today the
+renderer has Today/Task/Plan/Add as separate, email-draft-shaped screens with a coarse 4-state
+task model and no Auto mode, no growing-card, no onboarding/upgrade.
+
+**Goal:** re-point the renderer onto the canonical lifecycle and component set in `CONTEXT.md`,
+evolving existing screens in place, contract-first, without regressing the "wire real, plain"
+backend integration already in place.
+
+## 2. Non-goals
+
+- Not a theme flip. The app stays **dark-first + token-driven**; the wireframes' light hexes are
+  mid-fi light-mode tokens, not a directive (see Open Decision D1).
+- Not a backend rewrite. New AI-driven transitions stay **AI-gapped** until the LLM layer lands.
+- Not pixel-cloning the prototype's DOM — match layout/hierarchy/behavior, expressed via tokens.
+- Buckets B (onboarding), C (upgrade), D (input convergence) are **phased after** the spine.
+
+## 3. Scope — the four buckets
+
+| Bucket | Groups | Phase |
+|---|---|---|
+| **A · Task-lifecycle spine** | 01, 02, 03, 07, 12, 14 | **Phase 1 (this PRD's focus)** |
+| **D · One multimodal input** | 04, 05, 08 | Phase 2 |
+| **B · Onboarding (+ model download)** | 09, 10, 13 | Phase 3 (design-tune first — variants to choose) |
+| **C · Upgrade CTAs** | 11 | Phase 3 |
+
+## 4. The canonical model (normative — full detail in `CONTEXT.md`)
+
+- **States:** `listed → planning → planned → working → awaiting → done(report)`.
+- **Mode (orthogonal):** per-task `plan` (default) | `auto`; per-step `auto` | `ask`; input
+  modes `plan|save|todo|auto`.
+- **Card-morph:** one stable-header / morphing-body card; `collapsed→searching→running→reasoning→summary→complete`; **one orb = the state machine** (ring fills → check); tallest at *reasoning*.
+- **Workspace:** brief + reasoning + Sources + tool/connector dock; guided stepper → editable
+  draft + tap-don't-type refine chips; **Ask Mikan = same parts**.
+- **Auto mode:** runs on device, steer/pause, approval gate ("nothing sent yet"), on-device receipt.
+
+## 5. Contract changes (land first, in `@mikan/contract`)
+
+Evolve `packages/contract/src/views.ts` (+ `docs/INTEGRATION.md` in the same change). **Proposed**
+shape — confirm in Open Decision A1:
+
+```ts
+// supersedes TaskStatus
+export type TaskState =
+  | 'listed' | 'planning' | 'planned' | 'working' | 'awaiting' | 'done'
+
+export type TaskMode = 'plan' | 'auto'
+export type StepRun  = 'auto' | 'ask'
+
+export interface PlanStep {
+  id: string
+  title: string          // "Checked your calendar"
+  run: StepRun           // auto | ask (the per-step switch, Group 12E)
+  tool?: string          // "CALENDAR" / "MAPS" — connector/tool label
+  status: 'pending' | 'running' | 'done' | 'blocked'   // drives the orb fill
+}
+
+export interface RunReceipt {              // AI-gap until the run loop lands
+  ranOnDevice: boolean
+  durationMs: number | null
+  touched: string[]      // source/connector ids the run read/wrote
+  sentAnything: boolean  // "nothing sent yet" vs "sent · 2:14pm"
+}
+
+// Task gains (additive where possible):
+//   state: TaskState         (replaces status; map old → new at the projector)
+//   mode: TaskMode
+//   steps?: PlanStep[]       (the plan; AI-gap)
+//   receipt?: RunReceipt     (AI-gap)
+// Group-01 presentation states (done/in-progress/delegated/deferred) are DERIVED:
+//   delegated = mode:auto & working;  deferred = planning/queued;  in-progress = working;  done = done.
+```
+
+Projector: `apps/desktop/src/main/services/project.ts` maps the data model → this view model
+(the AI-gap). Old `TaskStatus` → `TaskState`: `gathering→planning|working`, `gathered→planned`,
+`drafted→awaiting`, `done→done`. An **ADR** should record the lifecycle supersession once A1 is
+confirmed (proposed `docs/adr/0010-task-lifecycle.md`).
+
+## 6. Slices (spine-first, independently grabbable)
+
+Lanes per `CLAUDE.md`: **back** = `apps/desktop/src/main/**` + `packages/contract/**`; **front**
+= `apps/desktop/src/renderer/**`. Contract slice lands before the front slices that consume it.
+
+| # | Slice | Lane | Depends on | Real vs shell |
+|---|---|---|---|---|
+| **S0** | **Contract: lifecycle + mode + PlanStep + RunReceipt** (§5) + `INTEGRATION.md` + ADR 0010 | back | — | real types; projector maps old→new |
+| **S1** | **Growing-card component** (Group 07): stable header, morphing body, orb state machine, the six render states, `Save as a skill` affordance. Mock-driven, token-themed, reduced-motion safe. | front | S0 | shell (mock) |
+| **S2** | **Today / Stack** (Group 01): status-carrying checkbox, the stack of S1 cards, cap row (`N done · M left`, `Plan my day`), mode badges. Evolve `today.tsx`. | front | S1 | wire real (existing Today data) |
+| **S3** | **Task expand → workspace** (Group 02): line → workspace (brief, reasoning, Sources, dock), guided stepper → editable draft + refine chips, Ask-Mikan thread (same parts). Evolve `task.tsx`. | front | S1 | real structural + AI-gap |
+| **S4** | **Plan mode** (Group 12): planning-as-default, the plan (edit/accept), edit-step (auto/ask). Evolve `plan.tsx`; consumes `PlanStep`. | front | S0, S3 | real structural + AI-gap |
+| **S5** | **Auto mode** (Group 03): per-task auto switch on the list, running/steer/pause, awaiting-approval gate, on-device receipt. | front + back | S3, S4 | new run loop (AI-gap) + receipt |
+| **S6** | **Lifecycle integration** (Group 14): one task end-to-end `listed→report` across S2–S5; reconcile transitions, empty/edge states. | front | S2–S5 | integration |
+
+Phase 2+ (separate PRD slices later): **D** one-input convergence (`add.tsx`/`voice.tsx`/capture →
+single component); **B** onboarding variants (design-tune 09/10/13, then build the chosen one);
+**C** upgrade CTAs (11).
+
+Each slice: start a fresh session, pass this PRD + the single slice, run the implement flow,
+verify with `pnpm typecheck && pnpm build && pnpm lint` (worker/native changes need a live
+`pnpm dev` smoke test — no Electron in CI).
+
+## 7. Success criteria
+
+- `@mikan/contract` exposes the canonical lifecycle; renderer renders all six states from it.
+- Today, Task, Plan evolved to the *Mikan Flows* layout via tokens (both themes), no hard-coded hexes.
+- Auto mode runs a task to an on-device receipt with a working approval gate.
+- No regression in existing real-data wiring; AI-gapped fields degrade gracefully.
+- `prefers-reduced-motion` / `data-ambient="off"` fully read with motion off.
+
+## 8. Open decisions (need your call before S1 starts)
+
+| id | Decision | Recommendation |
+|---|---|---|
+| **A1** | Lifecycle states + `TaskState` supersedes `TaskStatus`? | **Yes** — adopt the six states (§4/§5). |
+| **D1** | Light/greyscale wireframes = theme flip, or mid-fi light-mode tokens? | **Mid-fi** — keep dark-first + dual-theme, map hexes → vars, never hard-code. |
+| **R1** | Evolve existing screens in place, or parallel rebuild? | **Evolve in place** — they're already wired to `window.api`. |
+| **M1** | Mode model: `mode` per-task + `run` per-step, both orthogonal to state? | **Yes** (§5). |
+| **F1** | Fidelity bar: pixel-clone vs faithful layout/hierarchy via tokens? | **Faithful via tokens**, not DOM-clone. |
+
+## 9. Next steps
+
+1. Confirm/adjust Open Decisions §8 (esp. **D1** — it shapes every front slice).
+2. Land **S0** (contract + ADR 0010) — contract-first.
+3. Fan **S1–S6** into Linear issues (one per slice, lane-tagged), grab spine-first.

--- a/packages/contract/src/views.ts
+++ b/packages/contract/src/views.ts
@@ -56,11 +56,74 @@ export type TaskStatus = 'gathering' | 'gathered' | 'drafted' | 'done'
 /** AI-gap: the kind of note Mikan leaves beside a task. Not emitted yet. */
 export type NoteKind = 'ready' | 'ask' | 'wait' | 'gathered' | 'done'
 
+// ── canonical task lifecycle (Mikan Flows) ───────────────────────────────────
+/**
+ * The six-state lifecycle from the *Mikan Flows* design (see `CONTEXT.md`).
+ * Supersedes the coarser `TaskStatus` above: it splits **planning** (decide the
+ * steps) from **working** (execute them) and adds an explicit approval gate plus a
+ * done/report receipt. It is task-type-agnostic, not reply-specific.
+ *
+ * Rolled out **additively**: `Task.status` stays for now and `Task.state` is
+ * derived from it at the projector (`services/project.ts` → `toTask`); `state`
+ * becomes canonical as the renderer slices migrate, then `status` retires.
+ * Decision of record: `docs/adr/0010-task-lifecycle.md`.
+ */
+export type TaskState =
+  | 'listed' // on the list — resting todo, carries a mode badge
+  | 'planning' // Mikan decides the steps (searches memory, gathers context)
+  | 'planned' // the plan is ready; each step marked auto or ask
+  | 'working' // executing steps; card expanded (reasoning, sources, tools)
+  | 'awaiting' // hit an approval gate — "nothing sent yet"
+  | 'done' // report — receipt: what it did, where it ran, what it touched
+
+/** Per-task mode, set on the list (Groups 03/12). Orthogonal to `TaskState`. */
+export type TaskMode = 'plan' | 'auto'
+
+/** How a single plan step runs: autonomously, or pausing for the human (Group 12E). */
+export type StepRun = 'auto' | 'ask'
+
+/** One step of a task's plan. **AI-gap** — emitted only once the planner lands. */
+export interface PlanStep {
+  id: string
+  /** Human-readable step line, e.g. "Checked your calendar". */
+  title: string
+  /** auto | ask — the per-step switch. */
+  run: StepRun
+  /** Connector/tool label, e.g. "CALENDAR" / "MAPS". `null` when none. */
+  tool?: string | null
+  /** Drives the orb fill (Group 07). */
+  status: 'pending' | 'running' | 'done' | 'blocked'
+}
+
+/** Plain-language receipt shown when a run settles (Group 03D). **AI-gap**. */
+export interface RunReceipt {
+  /** Whether the run stayed on device. */
+  ranOnDevice: boolean
+  /** Wall-clock duration; `null` until measured. */
+  durationMs: number | null
+  /** Source/connector ids the run read or wrote. */
+  touched: string[]
+  /** "nothing sent yet" (false) vs an external action taken (true). */
+  sentAnything: boolean
+}
+
 export interface Task {
   id: string
   title: string
   when: string
   status: TaskStatus
+  /**
+   * Canonical lifecycle state (Mikan Flows). Derived from `status` at the
+   * projector today; supersedes `status` as renderer slices migrate. Optional
+   * during the additive rollout — treat absence as `'listed'`.
+   */
+  state?: TaskState
+  /** Per-task mode badge. Absent → treat as `'plan'`. */
+  mode?: TaskMode
+  /** AI-gap: the task's plan steps. `undefined` until the planner lands. */
+  steps?: PlanStep[]
+  /** AI-gap: run receipt, present once a run settles. */
+  receipt?: RunReceipt
   done: boolean
   /** Context-pool item ids (non-dismissed), pinned-first then by relevance. */
   ctx: string[]


### PR DESCRIPTION
Foundation slice **S0** of the *Mikan Flows* renderer redesign ([RETRO-9 epic](https://linear.app/retrospct/issue/RETRO-9)). Lands the canonical task lifecycle in `@mikan/contract` **contract-first**, plus the planning docs — so slices S1–S6 branch off a common base.

## What's here
- **Contract (additive, build-green):** `TaskState` (`listed|planning|planned|working|awaiting|done`), `TaskMode`, `StepRun`, `PlanStep`, `RunReceipt`; optional `state`/`mode`/`steps`/`receipt` on `Task`. `TaskStatus` is **kept** (retires in S6) so nothing breaks.
- **Projector:** `services/project.ts → toTask` derives `state` from `status` (real/structural) and defaults `mode:'plan'`. `steps`/`receipt` stay AI-gap.
- **Docs:** `CONTEXT.md` (canonical UX model), `docs/plans/mikan-flows.prd.md` (PRD + slices), `docs/adr/0010-task-lifecycle.md` (decision), `docs/INTEGRATION.md` (lifecycle mapping).

## Why additive
Hard-replacing `TaskStatus` would break the projector + every renderer consumer + mocks at once. Instead `state` is derived now and the renderer slices migrate onto it; `TaskStatus` retires in S6 (ADR 0010).

## Verification
- `pnpm typecheck` — green (5/5).
- No behavior change; no Electron runtime needed for this slice (contract + projector only).

Closes RETRO-10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)