### PR TITLE
fix: inline feedback for Settings "Check for updates" (RETRO-7)

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -315,11 +315,23 @@ app.whenReady().then(async () => {
     setupAutoUpdater()
   } else {
     // Dev-mode stubs so the renderer's update IPC calls don't throw
-    // "No handler registered" errors at startup.
-    const devStatus: UpdateStatus = { stage: 'idle', version: null, progress: null, error: null }
+    // "No handler registered" errors at startup. Reports `unavailable` (not
+    // `idle`) so the Settings row doesn't misleadingly read "Up to date" —
+    // dev never actually checks. check-now re-pushes the same status so a
+    // click always produces a visible IPC round-trip.
+    const devStatus: UpdateStatus = {
+      stage: 'unavailable',
+      version: null,
+      progress: null,
+      error: null
+    }
     ipcMain.handle(IPC.updateGetStatus, () => devStatus)
     ipcMain.handle(IPC.updateQuitAndInstall, () => {})
-    ipcMain.handle(IPC.updateCheckNow, () => {})
+    ipcMain.handle(IPC.updateCheckNow, () => {
+      for (const win of BrowserWindow.getAllWindows()) {
+        win.webContents.send(IPC.updateChanged, devStatus)
+      }
+    })
   }
 
   // Native app-menu "Check for Updates…" (macOS-standard, like Cursor/Slack).

--- a/apps/desktop/src/renderer/src/mikan/settings.tsx
+++ b/apps/desktop/src/renderer/src/mikan/settings.tsx
@@ -10,7 +10,7 @@
 //   - Updates: current version + check / restart-to-update.
 import { useBrand } from '@mikan/brand/web'
 import { QRCodeSVG } from 'qrcode.react'
-import { useState, type JSX } from 'react'
+import { useEffect, useState, type JSX } from 'react'
 import { useAuth } from '../hooks/useAuth'
 import { useSync, useSyncSettings } from '../hooks/useSync'
 import { useUpdate } from '../hooks/useUpdate'
@@ -225,18 +225,53 @@ function UpdateSection(): JSX.Element {
 
   const busy = stage === 'checking' || stage === 'downloading'
 
+  // Tracks whether the in-flight check was started by this button (vs. the
+  // automatic startup/daily-interval checks, which push the same
+  // checking→idle transition over the same channel). Only a user-initiated
+  // check that settles with nothing found gets the transient confirmation —
+  // otherwise "Up to date" would flicker with no perceptible signal.
+  const [pendingUserCheck, setPendingUserCheck] = useState(false)
+  const [prevStage, setPrevStage] = useState(stage)
+  const [justChecked, setJustChecked] = useState(false)
+
+  // Adjust state during render (not in an effect) when `stage` changes —
+  // see https://react.dev/learn/you-might-not-need-an-effect.
+  if (stage !== prevStage) {
+    setPrevStage(stage)
+    if (prevStage === 'checking' && pendingUserCheck) {
+      setPendingUserCheck(false)
+      setJustChecked(stage === 'idle')
+    }
+  }
+
+  useEffect(() => {
+    if (!justChecked) return undefined
+    const t = setTimeout(() => setJustChecked(false), 3000)
+    return () => clearTimeout(t)
+  }, [justChecked])
+
+  const onCheckNow = (): void => {
+    setJustChecked(false)
+    setPendingUserCheck(true)
+    checkNow()
+  }
+
   const statusLine =
-    stage === 'checking'
-      ? 'Checking for updates…'
-      : stage === 'available'
-        ? `Downloading ${version ?? 'update'}…`
-        : stage === 'downloading'
-          ? `Downloading${progress !== null ? ` ${progress}%` : '…'}`
-          : stage === 'ready'
-            ? `v${version} ready — restart to install`
-            : stage === 'error'
-              ? (error ?? 'Update check failed')
-              : 'Up to date'
+    stage === 'unavailable'
+      ? 'Updates run only in the packaged app.'
+      : stage === 'checking'
+        ? 'Checking for updates…'
+        : stage === 'available'
+          ? `Downloading ${version ?? 'update'}…`
+          : stage === 'downloading'
+            ? `Downloading${progress !== null ? ` ${progress}%` : '…'}`
+            : stage === 'ready'
+              ? `v${version} ready — restart to install`
+              : stage === 'error'
+                ? (error ?? 'Update check failed')
+                : justChecked
+                  ? 'Up to date · checked just now'
+                  : 'Up to date'
 
   return (
     <section className="settings-section">
@@ -245,7 +280,9 @@ function UpdateSection(): JSX.Element {
         <div className="settings-row-main">
           <div className="settings-row-ttl">{brand.productName}</div>
           <div className="settings-row-sub">
-            {stage === 'error' ? statusLine : `v${__APP_VERSION__} — ${statusLine}`}
+            {stage === 'error' || stage === 'unavailable'
+              ? statusLine
+              : `v${__APP_VERSION__} — ${statusLine}`}
           </div>
         </div>
         {stage === 'ready' ? (
@@ -253,7 +290,7 @@ function UpdateSection(): JSX.Element {
             Restart to update
           </button>
         ) : (
-          <button className="settings-btn" disabled={busy} onClick={checkNow}>
+          <button className="settings-btn" disabled={busy} onClick={onCheckNow}>
             {stage === 'checking' ? 'Checking…' : 'Check for updates'}
           </button>
         )}

--- a/packages/contract/src/ipc.ts
+++ b/packages/contract/src/ipc.ts
@@ -269,7 +269,8 @@ export interface MikanApi {
 
 // --- Auto-updater (ROADMAP #12 — electron-updater via GitHub Releases) ----
 
-export type UpdateStage = 'idle' | 'checking' | 'available' | 'downloading' | 'ready' | 'error'
+export type UpdateStage =
+  'idle' | 'checking' | 'available' | 'downloading' | 'ready' | 'error' | 'unavailable'
 
 /**
  * Snapshot of the auto-updater state pushed to the renderer via `update:changed`


### PR DESCRIPTION
## Summary

Clicking **Check for updates** in Settings → Updates showed no sign anything happened, unlike the menubar "Check for Updates…" item which pops a native dialog. Two root causes, both fixed with inline (no popup) feedback:

- **Dev/unpackaged builds**: the button hit a no-op IPC stub — nothing changed, and the resting row misleadingly read "Up to date" even though dev never actually checks.
- **Packaged builds**: a real check ran, but when already current the status only flickered `checking → idle`, landing back on the same "Up to date" text with no perceptible "a check just ran" signal.

## Changes

- `packages/contract/src/ipc.ts` — added an `'unavailable'` stage to `UpdateStage`.
- `apps/desktop/src/main/index.ts` — dev stub now reports `unavailable` (was `idle`) and re-pushes it on `check-now`.
- `apps/desktop/src/renderer/src/mikan/settings.tsx` — shows "Updates run only in the packaged app." for `unavailable`, and tracks user-initiated checks to show a transient "Up to date · checked just now" confirmation when a check settles with nothing found.

## Test plan

- [x] `pnpm typecheck` — green
- [x] `pnpm build` — green
- [x] `pnpm lint` on changed files — clean
- [x] Standards + Spec review (parallel sub-agents) — no blocking findings
- [x] Live smoke test via `pnpm dev` — confirmed the Electron app now builds and starts without error (fixed a separate local `node_modules/electron` binary-install issue along the way); confirmed the dev-mode Settings row now reads "Updates run only in the packaged app." instead of the misleading "Up to date"
- [ ] Full interactive click-through of the transient "checked just now" confirmation in a **packaged** build — needs a signed build, out of scope for this fix (consistent with `setupAutoUpdater` having no existing test coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)