### PR TITLE
feat(renderer): growing-card component (Group 07)

### DIFF
--- a/apps/desktop/src/renderer/src/mikan/growing-card.tsx
+++ b/apps/desktop/src/renderer/src/mikan/growing-card.tsx
@@ -1,0 +1,185 @@
+// growing-card.tsx — Group 07: the growing card, the atomic unit of the task
+// lifecycle everywhere else renders (Today's stack, the expanded workspace, Auto
+// mode). One pixel-stable header (avatar · title · orb) over a body that morphs
+// through six render states as `Task.state` advances; the orb is the whole
+// state machine — it fills as `Task.steps` complete, then flips to a check.
+// Mock-driven shell: reads only contract types, no `window.api` dependency.
+import type { JSX } from 'react'
+import { NIcon } from './icons'
+import { Dots, MikanSay } from './mark'
+import type { PlanStep, RunReceipt, Task, TaskState } from '@mikan/contract/views'
+
+export type CardRenderState =
+  'collapsed' | 'searching' | 'running' | 'reasoning' | 'summary' | 'complete'
+
+// Positional mapping onto the six-state lifecycle (CONTEXT.md § Group 07): each
+// `TaskState` has exactly one visual mechanism, in the same order the states occur.
+const RENDER_STATE_BY_TASK_STATE: Record<TaskState, CardRenderState> = {
+  listed: 'collapsed',
+  planning: 'searching',
+  planned: 'running',
+  working: 'reasoning',
+  awaiting: 'summary',
+  done: 'complete'
+}
+
+/** `Task.state` is optional during the additive S0 rollout — absence reads as `listed`. */
+function renderStateFor(task: Task): CardRenderState {
+  return RENDER_STATE_BY_TASK_STATE[task.state ?? 'listed']
+}
+
+function stepFill(steps: PlanStep[] | undefined): number {
+  if (!steps || steps.length === 0) return 0
+  return steps.filter((s) => s.status === 'done').length / steps.length
+}
+
+function receiptLine(receipt: RunReceipt | undefined): string {
+  if (!receipt) return 'Done — nice work.'
+  const where = receipt.ranOnDevice ? 'on device' : 'in the cloud'
+  const sent = receipt.sentAnything ? 'sent' : 'nothing sent yet'
+  return `Ran ${where} · ${sent}.`
+}
+
+const ORB_R = 8
+const ORB_C = 2 * Math.PI * ORB_R
+
+function GrowingOrb({
+  renderState,
+  steps
+}: {
+  renderState: CardRenderState
+  steps: PlanStep[] | undefined
+}): JSX.Element {
+  const complete = renderState === 'complete'
+  const fill = stepFill(steps)
+  return (
+    <span
+      className={'gcard-orb state-' + renderState + (complete ? ' done' : '')}
+      aria-hidden="true"
+    >
+      {complete ? (
+        <NIcon name="check" size={12} stroke={2.4} />
+      ) : (
+        <svg width="20" height="20" viewBox="0 0 20 20">
+          <circle className="gcard-orb-track" cx="10" cy="10" r={ORB_R} />
+          <circle
+            className="gcard-orb-ring"
+            cx="10"
+            cy="10"
+            r={ORB_R}
+            style={{ strokeDasharray: ORB_C, strokeDashoffset: ORB_C * (1 - fill) }}
+          />
+        </svg>
+      )}
+    </span>
+  )
+}
+
+function StepRow({ step }: { step: PlanStep }): JSX.Element {
+  return (
+    <div className={'gcard-step status-' + step.status}>
+      <span className="gcard-step-ico">
+        {step.status === 'done' ? (
+          <NIcon name="check" size={11} />
+        ) : step.status === 'blocked' ? (
+          <NIcon name="close" size={10} />
+        ) : (
+          <span className="gcard-step-dot" />
+        )}
+      </span>
+      <span className="gcard-step-t">{step.title}</span>
+      {step.tool && <span className="gcard-step-tool">{step.tool}</span>}
+      <span className="gcard-step-run">{step.run === 'auto' ? 'Auto' : 'Ask'}</span>
+    </div>
+  )
+}
+
+export function GrowingCard({
+  task,
+  onOpen,
+  onSaveSkill
+}: {
+  task: Task
+  onOpen?: () => void
+  /** "Save as a skill" — offered on a good run (complete state only). */
+  onSaveSkill?: () => void
+}): JSX.Element {
+  const renderState = renderStateFor(task)
+  const steps = task.steps
+  const runningStep = steps?.find((s) => s.status === 'running')
+
+  return (
+    <div
+      className="gcard"
+      data-render={renderState}
+      onClick={onOpen}
+      role={onOpen ? 'button' : undefined}
+    >
+      <div className="gcard-hd">
+        <span className="gcard-avatar" aria-hidden="true">
+          <NIcon name="spark" size={13} />
+        </span>
+        <span className="gcard-title">{task.title}</span>
+        <GrowingOrb renderState={renderState} steps={steps} />
+      </div>
+
+      <div className="gcard-body">
+        {renderState === 'searching' && (
+          <div className="gcard-searching">
+            <MikanSay state="thinking" size={18}>
+              Searching your memory
+              <Dots />
+            </MikanSay>
+          </div>
+        )}
+
+        {(renderState === 'running' || renderState === 'reasoning') && (
+          <div className="gcard-steps">
+            {steps && steps.length > 0 ? (
+              steps.map((s) => <StepRow key={s.id} step={s} />)
+            ) : (
+              <div className="gcard-empty">The plan is still coming together.</div>
+            )}
+            {renderState === 'reasoning' && runningStep && (
+              <div className="gcard-reasoning">
+                <MikanSay state="gathering" size={16}>
+                  {runningStep.title}
+                  <Dots />
+                </MikanSay>
+              </div>
+            )}
+          </div>
+        )}
+
+        {renderState === 'summary' && (
+          <div className="gcard-gate">
+            <div className="gcard-gate-t">Nothing sent yet — review and approve.</div>
+            <div className="gcard-gate-acts">
+              <button className="btn btn-sm" onClick={(e) => e.stopPropagation()}>
+                Iterate
+              </button>
+              <button className="btn primary btn-sm" onClick={(e) => e.stopPropagation()}>
+                Approve
+              </button>
+            </div>
+          </div>
+        )}
+
+        {renderState === 'complete' && (
+          <div className="gcard-complete">
+            <div className="gcard-receipt">{receiptLine(task.receipt)}</div>
+            <button
+              className="gcard-save"
+              onClick={(e) => {
+                e.stopPropagation()
+                onSaveSkill?.()
+              }}
+            >
+              <NIcon name="bolt" size={13} /> Save as a skill
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/apps/desktop/src/renderer/src/mikan/mikan.css
+++ b/apps/desktop/src/renderer/src/mikan/mikan.css
@@ -4371,7 +4371,8 @@ html[data-density='compact'] .mem {
   .nm-mote,
   .ctx-orb,
   .draft-badge svg,
-  .pool-cloud .pc {
+  .pool-cloud .pc,
+  .gcard-orb-ring {
     animation: none !important;
   }
   .view,
@@ -4380,8 +4381,10 @@ html[data-density='compact'] .mem {
   .mem,
   .sheet,
   .push,
-  .draft {
+  .draft,
+  .gcard-body {
     animation-duration: 0.01ms !important;
+    transition-duration: 0.01ms !important;
   }
 }
 
@@ -4851,4 +4854,263 @@ html[data-density='compact'] .mem {
   font-size: 12px;
   line-height: 1.5;
   color: var(--ink-3);
+}
+
+/* ── Growing card (Group 07) ───────────────────────────────────────────────── */
+/* One stable header (avatar · title · orb) over a body that morphs through
+   collapsed → searching → running → reasoning → summary → complete, driven by
+   the `data-render` attribute. The body height is state-keyed rather than
+   measured, so it stays a plain CSS transition — tallest at reasoning. */
+.gcard {
+  position: relative;
+  border: 1px solid var(--hairline);
+  border-radius: 18px;
+  background: var(--surface-2);
+  box-shadow: var(--shadow-soft);
+  overflow: hidden;
+  cursor: pointer;
+  transition:
+    border-color 0.18s,
+    transform 0.18s var(--ease-out);
+}
+.gcard:hover {
+  border-color: var(--hairline-strong);
+  transform: translateY(-2px);
+}
+.gcard-hd {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 14px 15px;
+}
+.gcard-avatar {
+  flex: 0 0 auto;
+  width: 26px;
+  height: 26px;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  background: var(--surface-3);
+  color: var(--ink-2);
+  border: 1px solid var(--hairline);
+}
+.gcard-title {
+  flex: 1 1 auto;
+  min-width: 0;
+  font-size: 15.5px;
+  font-weight: 550;
+  line-height: 1.3;
+  letter-spacing: -0.01em;
+  color: var(--ink);
+  text-wrap: pretty;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* the orb — one element carries the whole state machine */
+.gcard-orb {
+  flex: 0 0 auto;
+  width: 20px;
+  height: 20px;
+  display: grid;
+  place-items: center;
+  color: var(--ink-2);
+}
+.gcard-orb-track {
+  fill: none;
+  stroke: var(--hairline-strong);
+  stroke-width: 2;
+}
+.gcard-orb-ring {
+  fill: none;
+  stroke: var(--accent);
+  stroke-width: 2;
+  stroke-linecap: round;
+  transform: rotate(-90deg);
+  transform-origin: 50% 50%;
+  transition: stroke-dashoffset 0.35s var(--ease-out);
+}
+.gcard-orb.state-searching .gcard-orb-ring,
+.gcard-orb.state-running .gcard-orb-ring,
+.gcard-orb.state-reasoning .gcard-orb-ring {
+  animation: gcard-orb-pulse 2.4s var(--ease-out) infinite;
+}
+@keyframes gcard-orb-pulse {
+  0%,
+  100% {
+    opacity: 0.55;
+  }
+  50% {
+    opacity: 1;
+  }
+}
+html[data-ambient='off'] .gcard-orb-ring {
+  animation: none;
+}
+.gcard-orb.done {
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: var(--accent);
+  color: #0a0a0b;
+}
+
+/* morphing body — state-keyed max-height, not measured */
+.gcard-body {
+  overflow: hidden;
+  max-height: 0;
+  opacity: 0;
+  transition:
+    max-height 0.42s var(--ease-out),
+    opacity 0.3s var(--ease-out);
+}
+.gcard[data-render='searching'] .gcard-body {
+  max-height: 90px;
+  opacity: 1;
+}
+.gcard[data-render='running'] .gcard-body {
+  max-height: 280px;
+  opacity: 1;
+}
+.gcard[data-render='reasoning'] .gcard-body {
+  max-height: 360px;
+  opacity: 1;
+}
+.gcard[data-render='summary'] .gcard-body {
+  max-height: 170px;
+  opacity: 1;
+}
+.gcard[data-render='complete'] .gcard-body {
+  max-height: 130px;
+  opacity: 1;
+}
+
+.gcard-searching {
+  padding: 0 15px 16px;
+}
+
+.gcard-steps {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 0 15px 14px;
+}
+.gcard-step {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  padding: 7px 0;
+  border-bottom: 1px solid var(--hairline);
+  font-size: 13.5px;
+  color: var(--ink-2);
+}
+.gcard-step:last-child {
+  border-bottom: none;
+}
+.gcard-step.status-done {
+  color: var(--ink);
+}
+.gcard-step-ico {
+  flex: 0 0 auto;
+  width: 16px;
+  height: 16px;
+  display: grid;
+  place-items: center;
+  border-radius: 50%;
+  border: 1.4px solid var(--hairline-strong);
+  color: var(--ink-3);
+}
+.gcard-step.status-done .gcard-step-ico {
+  background: var(--accent);
+  border-color: transparent;
+  color: #0a0a0b;
+}
+.gcard-step.status-blocked .gcard-step-ico {
+  border-color: var(--rose);
+  color: var(--rose);
+}
+.gcard-step-dot {
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: currentColor;
+}
+.gcard-step.status-running .gcard-step-dot {
+  background: var(--accent);
+  animation: nm-pulse 1.6s var(--ease-out) infinite;
+}
+html[data-ambient='off'] .gcard-step.status-running .gcard-step-dot {
+  animation: none;
+}
+.gcard-step-t {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.gcard-step-tool,
+.gcard-step-run {
+  flex: 0 0 auto;
+  font-family: var(--mono);
+  font-size: 9.5px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ink-3);
+}
+.gcard-empty {
+  padding: 6px 0 2px;
+  font-size: 13px;
+  color: var(--ink-3);
+}
+
+.gcard-reasoning {
+  padding-top: 8px;
+  border-top: 1px solid var(--hairline);
+}
+
+.gcard-gate {
+  padding: 0 15px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.gcard-gate-t {
+  font-size: 13.5px;
+  color: var(--ink-2);
+}
+.gcard-gate-acts {
+  display: flex;
+  gap: 8px;
+}
+
+.gcard-complete {
+  padding: 0 15px 16px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+.gcard-receipt {
+  font-size: 13px;
+  color: var(--ink-2);
+}
+.gcard-save {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 7px 12px;
+  border-radius: 999px;
+  border: 1px solid var(--accent-line);
+  background: var(--accent-faint);
+  color: var(--accent-ink);
+  font-size: 12.5px;
+  font-weight: 550;
+  cursor: pointer;
+  transition: background 0.18s;
+}
+.gcard-save:hover {
+  background: var(--accent-soft);
 }

--- a/apps/desktop/src/renderer/src/mikan/mock.ts
+++ b/apps/desktop/src/renderer/src/mikan/mock.ts
@@ -217,6 +217,116 @@ const SEED_TASKS: Task[] = [
   }
 ]
 
+// ── growing-card (Group 07) reference tasks — one per render state ──────────
+// Not wired into makeMockApi: these exist purely so the growing card has a
+// living hi-fi reference across all six lifecycle states, independent of the
+// three "current renderer" seed tasks above (which predate `Task.state`).
+export const GROWING_CARD_DEMO_TASKS: Task[] = [
+  {
+    id: 'gc_listed',
+    title: 'Book the dentist follow-up',
+    when: 'today',
+    status: 'gathered',
+    state: 'listed',
+    mode: 'plan',
+    done: false,
+    ctx: [],
+    pinned: [],
+    draft: null,
+    draftNote: null
+  },
+  {
+    id: 'gc_planning',
+    title: 'Reply to Sarah about the cabin weekend',
+    when: 'today',
+    status: 'gathering',
+    state: 'planning',
+    mode: 'plan',
+    done: false,
+    ctx: ['m_cabin_note', 'm_cabin_mail'],
+    pinned: [],
+    draft: null,
+    draftNote: null
+  },
+  {
+    id: 'gc_planned',
+    title: 'Send Priya the Q3 one-pager',
+    when: 'by Friday',
+    status: 'gathered',
+    state: 'planned',
+    mode: 'plan',
+    done: false,
+    ctx: ['m_q3_mail', 'm_q3_pdf'],
+    pinned: [],
+    draft: null,
+    draftNote: null,
+    steps: [
+      {
+        id: 's1',
+        title: 'Checked your calendar',
+        run: 'auto',
+        tool: 'CALENDAR',
+        status: 'pending'
+      },
+      { id: 's2', title: 'Pulled the Q3 numbers', run: 'auto', tool: null, status: 'pending' },
+      { id: 's3', title: 'Draft the one-pager', run: 'ask', tool: null, status: 'pending' }
+    ]
+  },
+  {
+    id: 'gc_working',
+    title: "Book mom's birthday dinner",
+    when: 'this week',
+    status: 'gathering',
+    state: 'working',
+    mode: 'auto',
+    done: false,
+    ctx: ['m_rest_note', 'm_rest_shot'],
+    pinned: [],
+    draft: null,
+    draftNote: null,
+    steps: [
+      { id: 's1', title: 'Checked your calendar', run: 'auto', tool: 'CALENDAR', status: 'done' },
+      { id: 's2', title: 'Looked up nearby spots', run: 'auto', tool: 'MAPS', status: 'running' },
+      { id: 's3', title: 'Book the table', run: 'ask', tool: null, status: 'pending' }
+    ]
+  },
+  {
+    id: 'gc_awaiting',
+    title: 'Reply to Sarah about the cabin weekend',
+    when: 'today',
+    status: 'drafted',
+    state: 'awaiting',
+    mode: 'plan',
+    done: false,
+    ctx: ['m_cabin_note', 'm_cabin_mail', 'm_cabin_cal'],
+    pinned: ['m_cabin_mail'],
+    draft: ["Hey Sarah! Let's do **Apr 18–20**"],
+    draftNote: 'From her email + your calendar.',
+    steps: [
+      { id: 's1', title: 'Checked your calendar', run: 'auto', tool: 'CALENDAR', status: 'done' },
+      { id: 's2', title: 'Drafted the reply', run: 'ask', tool: null, status: 'done' }
+    ]
+  },
+  {
+    id: 'gc_done',
+    title: 'Use the United travel credit',
+    when: 'yesterday',
+    status: 'done',
+    state: 'done',
+    mode: 'auto',
+    done: true,
+    ctx: [],
+    pinned: [],
+    draft: null,
+    draftNote: null,
+    steps: [
+      { id: 's1', title: 'Checked the credit balance', run: 'auto', tool: null, status: 'done' },
+      { id: 's2', title: 'Applied it to the booking', run: 'auto', tool: null, status: 'done' }
+    ],
+    receipt: { ranOnDevice: true, durationMs: 4200, touched: ['United'], sentAnything: false }
+  }
+]
+
 // ── the daily-planning backlog ───────────────────────────────────────────────
 const BACKLOG: BacklogItem[] = [
   {


### PR DESCRIPTION
## Summary
- Implements RETRO-11 (S1 · Mikan Flows task-lifecycle spine): the growing-card component, the atomic unit the rest of the spine (Today's stack, the expanded workspace, Auto mode) will render.
- One pixel-stable header (avatar · title · orb) over a body that morphs through the six render states — `collapsed → searching → running → reasoning → summary → complete` — mapped positionally off `Task.state`. The orb is the whole state machine: an SVG ring that fills as `PlanStep.status` flips to `done`, then flips to a check at `complete`. Includes the "Save as a skill" affordance on a good run.
- Token-driven for both themes (no hard-coded hex), reduced-motion / `data-ambient="off"` safe (wired into the existing consolidated media query + per-selector overrides, matching house style).
- Mock-driven shell: `GROWING_CARD_DEMO_TASKS` in `mock.ts` (one sample task per state) — separate from `SEED_TASKS`/`makeMockApi`, so existing Today/Feed behavior is untouched. No backend dependency.

No `@mikan/contract` changes needed — S0 (RETRO-10, #110) already landed `TaskState`/`TaskMode`/`PlanStep`/`RunReceipt` on `main`.

## Test plan
- [x] `pnpm --filter @mikan/desktop typecheck` — green
- [x] `pnpm --filter @mikan/desktop build` — green
- [x] `pnpm lint` — clean on all touched files (pre-existing eslint debt elsewhere in the repo is unrelated)
- [x] Visual smoke test: temporarily mounted a gallery of all six demo tasks, verified in both dark and light themes, confirmed orb fill math (`stepFill` → `stroke-dashoffset`) and the `data-ambient="off"` override kill the pulse animations; reverted the temporary wiring before committing
- [ ] S2/S3 (separate issues) wire `GrowingCard` into `today.tsx`/`task.tsx` for real

🤖 Generated with [Claude Code](https://claude.com/claude-code)