### PR TITLE
feat(renderer): task expand → workspace (Group 02, RETRO-13)

### DIFF
--- a/apps/desktop/src/renderer/src/mikan/growing-card.tsx
+++ b/apps/desktop/src/renderer/src/mikan/growing-card.tsx
@@ -75,7 +75,9 @@ function GrowingOrb({
   )
 }
 
-function StepRow({ step }: { step: PlanStep }): JSX.Element {
+/** Exported so other Group-02 surfaces (the task workspace's reasoning card and
+ * guided stepper) render the same step-row look instead of duplicating it. */
+export function StepRow({ step }: { step: PlanStep }): JSX.Element {
   return (
     <div className={'gcard-step status-' + step.status}>
       <span className="gcard-step-ico">

--- a/apps/desktop/src/renderer/src/mikan/mikan.css
+++ b/apps/desktop/src/renderer/src/mikan/mikan.css
@@ -5114,3 +5114,156 @@ html[data-ambient='off'] .gcard-step.status-running .gcard-step-dot {
 .gcard-save:hover {
   background: var(--accent-soft);
 }
+
+/* ─────────── task workspace: reasoning / sources / dock / stepper / refine (Group 02) ─────────── */
+.sources-label {
+  font-size: 10px;
+  color: var(--ink-3);
+  margin: 4px 2px 6px;
+}
+.reasoning-steps {
+  padding: 0 0 4px;
+  margin-bottom: 4px;
+}
+
+/* a small icon+label pill — shared by the dock and chat citation rows */
+.chip-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 5px 10px;
+  border-radius: 999px;
+  border: 1px solid var(--hairline);
+  background: var(--surface-2);
+  color: var(--ink-2);
+  font-size: 11.5px;
+  max-width: 100%;
+  overflow: hidden;
+}
+.chip-pill svg {
+  flex: 0 0 auto;
+  color: var(--ink-3);
+}
+
+.dock {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 7px;
+  margin: 2px 2px 16px;
+}
+
+/* guided stepper — gathered → your voice → drafting → approve & send */
+.stepper {
+  display: flex;
+  align-items: flex-start;
+  gap: 4px;
+  margin: 2px 2px 16px;
+}
+.stepper-step {
+  flex: 1 1 0;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  text-align: center;
+}
+.stepper-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--hairline-strong);
+  border: 1px solid var(--hairline-strong);
+}
+.stepper-step.done .stepper-dot {
+  background: var(--accent);
+  border-color: var(--accent);
+}
+.stepper-step.active .stepper-dot {
+  border-color: var(--accent);
+  background: var(--accent-faint);
+  animation: nm-pulse 1.6s var(--ease-out) infinite;
+}
+html[data-ambient='off'] .stepper-step.active .stepper-dot {
+  animation: none;
+}
+.stepper-lbl {
+  font-family: var(--mono);
+  font-size: 9px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--ink-3);
+}
+.stepper-step.done .stepper-lbl,
+.stepper-step.active .stepper-lbl {
+  color: var(--ink-2);
+}
+
+/* tap-don't-type refine chips, shown alongside the editable draft */
+.refine-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 7px;
+  padding: 0 14px 12px;
+}
+.refine-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 6px 11px;
+  border-radius: 999px;
+  border: 1px solid var(--accent-line);
+  background: var(--accent-faint);
+  color: var(--accent-ink);
+  font-size: 12px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.16s;
+}
+.refine-chip:hover {
+  background: var(--accent-soft);
+}
+
+/* editable draft */
+.draft-edit {
+  margin: 0 14px;
+}
+.draft-edit-ta {
+  width: 100%;
+  padding: 13px 14px;
+  border-radius: 12px;
+  background: var(--bg-2);
+  border: 1px solid var(--hairline);
+  font-size: 13.5px;
+  line-height: 1.6;
+  color: var(--ink);
+  font-family: inherit;
+  resize: vertical;
+}
+.draft-edit-ta:focus {
+  outline: none;
+  border-color: var(--accent-line);
+}
+.draft-edit-acts {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  padding: 10px 0 0;
+}
+
+/* Ask Mikan: replies carry the same citation parts as the workspace's Sources */
+.chat-msg-col {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-width: 0;
+}
+.chat-cites {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+.chat-cites .chip-pill {
+  font-size: 10.5px;
+  padding: 4px 9px;
+}

--- a/apps/desktop/src/renderer/src/mikan/mock.ts
+++ b/apps/desktop/src/renderer/src/mikan/mock.ts
@@ -166,6 +166,13 @@ const SEED_TASKS: Task[] = [
     title: 'Reply to Sarah about the cabin weekend',
     when: 'today',
     status: 'drafted',
+    state: 'awaiting',
+    mode: 'plan',
+    steps: [
+      { id: 's1', title: 'Checked your calendar', run: 'auto', tool: 'CALENDAR', status: 'done' },
+      { id: 's2', title: "Read Sarah's email", run: 'auto', tool: 'MAIL', status: 'done' },
+      { id: 's3', title: 'Drafted the reply', run: 'ask', tool: null, status: 'done' }
+    ],
     done: false,
     noteKind: 'ready',
     note: "Draft's ready — it just needs your yes.",
@@ -190,6 +197,13 @@ const SEED_TASKS: Task[] = [
     title: 'Send Priya the Q3 one-pager',
     when: 'by Friday',
     status: 'gathered',
+    state: 'planned',
+    mode: 'plan',
+    steps: [
+      { id: 's1', title: "Pulled Priya's ask", run: 'auto', tool: 'MAIL', status: 'done' },
+      { id: 's2', title: 'Checked the Q3 draft', run: 'auto', tool: null, status: 'pending' },
+      { id: 's3', title: 'Write the one-pager', run: 'ask', tool: null, status: 'pending' }
+    ],
     done: false,
     noteKind: 'wait',
     note: 'Waiting on the final numbers before I draft.',
@@ -205,6 +219,13 @@ const SEED_TASKS: Task[] = [
     title: "Book mom's birthday dinner",
     when: 'this week',
     status: 'gathered',
+    state: 'working',
+    mode: 'auto',
+    steps: [
+      { id: 's1', title: "Checked mom's favorite spots", run: 'auto', tool: null, status: 'done' },
+      { id: 's2', title: 'Looked up availability', run: 'auto', tool: 'MAPS', status: 'running' },
+      { id: 's3', title: 'Book the table', run: 'ask', tool: null, status: 'pending' }
+    ],
     done: false,
     noteKind: 'ask',
     note: 'One open question — which night works?',

--- a/apps/desktop/src/renderer/src/mikan/task.tsx
+++ b/apps/desktop/src/renderer/src/mikan/task.tsx
@@ -7,7 +7,19 @@ import { NIcon } from './icons'
 import { kindIcon } from './iconKind'
 import { MikanMark, MikanSay, Dots } from './mark'
 import { data, MemoryContext } from './api'
-import type { Memory, Task } from '@mikan/contract/views'
+import { StepRow } from './growing-card'
+import type { Memory, PlanStep, Task, TaskState } from '@mikan/contract/views'
+
+// tool label (from `PlanStep.tool`, e.g. "CALENDAR"/"MAPS") -> dock/reasoning icon
+const TOOL_ICON: Record<string, string> = {
+  CALENDAR: 'calendar',
+  MAPS: 'globe',
+  MAIL: 'mail',
+  GMAIL: 'mail'
+}
+function toolIcon(tool: string): string {
+  return TOOL_ICON[tool] ?? 'bolt'
+}
 
 // Relevance is real (`Task.relMap` from search); fall back to a neutral fit when
 // a ctx id has no score yet.
@@ -145,7 +157,9 @@ function DraftCard({
   confirm,
   done,
   onComplete,
-  onUse
+  onUse,
+  onEdit,
+  onRedo
 }: {
   draft: string[]
   typeLabel?: string
@@ -157,10 +171,15 @@ function DraftCard({
   done: boolean
   onComplete?: () => void
   onUse?: () => void
+  /** Applies both manual edits (Save) and refine-chip taps — same draft-shape contract. */
+  onEdit?: (next: string[]) => void
+  onRedo?: () => void
 }): JSX.Element {
   const [used, setUsed] = useState(false)
   const [copied, setCopied] = useState(false)
   const [collapsed, setCollapsed] = useState(false)
+  const [editing, setEditing] = useState(false)
+  const [editText, setEditText] = useState(() => draft.join('\n\n'))
 
   if (collapsed) {
     return (
@@ -208,11 +227,41 @@ function DraftCard({
           <NIcon name="chevUp" size={14} />
         </span>
       </button>
-      <div className="draft-paper">
-        {draft.map((p, i) => (
-          <p key={i}>{renderBold(p)}</p>
-        ))}
-      </div>
+      {editing ? (
+        <div className="draft-edit">
+          <textarea
+            className="draft-edit-ta"
+            value={editText}
+            onChange={(e) => setEditText(e.target.value)}
+            rows={6}
+            aria-label="Edit draft"
+          />
+          <div className="draft-edit-acts">
+            <button className="btn btn-sm ghost" onClick={() => setEditing(false)}>
+              Cancel
+            </button>
+            <button
+              className="btn btn-sm primary"
+              onClick={() => {
+                const next = editText
+                  .split(/\n{2,}/)
+                  .map((p) => p.trim())
+                  .filter(Boolean)
+                onEdit && onEdit(next.length ? next : [editText.trim()])
+                setEditing(false)
+              }}
+            >
+              Save
+            </button>
+          </div>
+        </div>
+      ) : (
+        <div className="draft-paper">
+          {draft.map((p, i) => (
+            <p key={i}>{renderBold(p)}</p>
+          ))}
+        </div>
+      )}
       {note && (
         <div className="draft-src">
           <NIcon name="layers" size={11} /> {note}
@@ -223,6 +272,7 @@ function DraftCard({
           <NIcon name="arrowRight" size={12} /> {useNote}
         </div>
       )}
+      {!used && !editing && onEdit && <RefineChips draft={draft} onApply={onEdit} />}
       <div className="draft-actions">
         {used ? (
           <div className="draft-confirm">
@@ -250,15 +300,150 @@ function DraftCard({
             >
               <NIcon name="check" size={15} /> {useLabel || 'Use this'}
             </button>
-            <button className="btn btn-sm ghost icon-only" aria-label="Edit">
+            <button
+              className="btn btn-sm ghost icon-only"
+              aria-label="Edit"
+              onClick={() => {
+                setEditText(draft.join('\n\n'))
+                setEditing(true)
+              }}
+            >
               <NIcon name="edit" size={16} />
             </button>
-            <button className="btn btn-sm ghost icon-only" aria-label="Redo">
+            <button
+              className="btn btn-sm ghost icon-only"
+              aria-label="Redo"
+              onClick={() => onRedo && onRedo()}
+            >
               <NIcon name="refresh" size={16} />
             </button>
           </>
         )}
       </div>
+    </div>
+  )
+}
+
+// collapsible "what Mikan did/is doing" — the same step rows the growing card
+// renders (Group 07), reused here at the expanded-workspace zoom level (Group 02)
+function ReasoningCard({ steps }: { steps: PlanStep[] | undefined }): JSX.Element | null {
+  const [open, setOpen] = useState(true)
+  if (!steps || steps.length === 0) return null
+  return (
+    <>
+      <button
+        className={'pool-group-hd as-toggle' + (open ? ' open' : '')}
+        onClick={() => setOpen((o) => !o)}
+      >
+        <NIcon name="layers" size={11} /> Reasoning
+        <span className="ln" />
+        <span className="kept-toggle">
+          {open ? 'Tuck away' : 'Show'} <NIcon name="chevDown" size={13} />
+        </span>
+      </button>
+      {open && (
+        <div className="gcard-steps reasoning-steps">
+          {steps.map((s) => (
+            <StepRow key={s.id} step={s} />
+          ))}
+        </div>
+      )}
+    </>
+  )
+}
+
+// the skills/tools/connectors Mikan used, deduped from the plan's steps
+function Dock({ steps }: { steps: PlanStep[] | undefined }): JSX.Element | null {
+  const tools = Array.from(
+    new Set((steps ?? []).map((s) => s.tool).filter((t): t is string => !!t))
+  )
+  if (tools.length === 0) return null
+  return (
+    <div className="dock">
+      {tools.map((t) => (
+        <span key={t} className="chip-pill">
+          <NIcon name={toolIcon(t)} size={13} /> {t}
+        </span>
+      ))}
+    </div>
+  )
+}
+
+const STEPPER_STAGES = ['Gathered', 'Your voice', 'Drafting', 'Approve & send'] as const
+
+// Maps the six-state lifecycle onto the Group-02 guided-review stepper — a
+// narrower, reply-shaped read of the same lifecycle (CONTEXT.md § "The expanded
+// workspace"). `planned` sits between "gathered" and "your voice" (the plan is
+// ready, waiting on the human's input); `working` is drafting; `awaiting` is the
+// approval gate; `done` completes every stage.
+function stepperIndex(state: TaskState | undefined): number {
+  switch (state) {
+    case 'planned':
+      return 1
+    case 'working':
+      return 2
+    case 'awaiting':
+      return 3
+    case 'done':
+      return 4
+    default:
+      return 0
+  }
+}
+
+function GuidedStepper({ state }: { state: TaskState | undefined }): JSX.Element {
+  const idx = stepperIndex(state)
+  return (
+    <div className="stepper" role="list" aria-label="Task progress">
+      {STEPPER_STAGES.map((label, i) => (
+        <div
+          key={label}
+          role="listitem"
+          className={'stepper-step' + (i < idx ? ' done' : i === idx ? ' active' : '')}
+        >
+          <span className="stepper-dot" aria-hidden="true" />
+          <span className="stepper-lbl">{label}</span>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+// tap-don't-type refine chips — local text transforms over the draft, same
+// AI-gap fidelity as `tryDraft()` (no backend draft-refine call exists yet)
+function RefineChips({
+  draft,
+  onApply
+}: {
+  draft: string[]
+  onApply: (next: string[]) => void
+}): JSX.Element {
+  const apply = (kind: 'warmer' | 'shorter' | 'photos'): void => {
+    if (kind === 'warmer') {
+      const last = draft[draft.length - 1] ?? ''
+      const warmed = last
+        ? last.replace(/[.!]?\s*$/, '') + " — really can't wait!"
+        : "Really can't wait!"
+      onApply(draft.length ? [...draft.slice(0, -1), warmed] : [warmed])
+      return
+    }
+    if (kind === 'shorter') {
+      onApply(draft.map((p) => p.split(/(?<=[.!?])\s+/)[0] || p))
+      return
+    }
+    onApply([...draft, "I'll attach a couple of photos from last time."])
+  }
+  return (
+    <div className="refine-chips">
+      <button className="refine-chip" onClick={() => apply('warmer')}>
+        <NIcon name="sparkle" size={12} /> Warmer
+      </button>
+      <button className="refine-chip" onClick={() => apply('shorter')}>
+        <NIcon name="chevUp" size={12} /> Shorter
+      </button>
+      <button className="refine-chip" onClick={() => apply('photos')}>
+        <NIcon name="camera" size={12} /> Attach photos
+      </button>
     </div>
   )
 }
@@ -415,47 +600,12 @@ export function TaskDetail({
           </div>
         )}
 
-        {/* the draft, or an invitation to make one */}
-        {draft ? (
-          <DraftCard
-            draft={draft}
-            typeLabel={task.draft ? task.draftType : 'Draft message'}
-            typeIcon={task.draft ? task.draftIcon : 'note'}
-            note={task.draft ? task.draftNote : 'Stitched from what you kept.'}
-            useLabel={task.draft ? task.useLabel : 'Use this'}
-            useNote={task.draft ? task.useNote : 'Saves it to this task, ready to edit and send.'}
-            confirm={task.draft ? task.useDone : 'Saved to this task.'}
-            done={done}
-            onComplete={() => {
-              if (!done) onToggle(task.id)
-            }}
-          />
-        ) : drafting ? (
-          <div className="draft draft-working">
-            <MikanMark state="drafting" size={30} />
-            <div className="draft-working-tx">
-              Taking a crack at it
-              <Dots />
-            </div>
-          </div>
-        ) : (
-          !done && (
-            <button className="draft draft-cta" onClick={tryDraft}>
-              <MikanMark state="idle" size={30} />
-              <div className="draft-cta-main">
-                <div className="draft-cta-t">Want me to take a crack at it?</div>
-                <div className="draft-cta-s">I&apos;ll draft a start from what you kept</div>
-              </div>
-              <span className="draft-cta-go">
-                <NIcon name="arrowRight" size={18} />
-              </span>
-            </button>
-          )
-        )}
+        {!done && <ReasoningCard steps={task.steps} />}
 
         {/* context Mikan gathered */}
         {!done && (
           <>
+            <div className="ovr sources-label">Sources</div>
             {keptCount > 0 ? (
               <>
                 <button
@@ -566,7 +716,54 @@ export function TaskDetail({
                 Pool&apos;s empty — everything&apos;s been swept. Ask me to dig deeper whenever.
               </div>
             )}
+
+            <Dock steps={task.steps} />
           </>
+        )}
+
+        {!done && <GuidedStepper state={task.state} />}
+
+        {/* the draft, or an invitation to make one */}
+        {draft ? (
+          <DraftCard
+            draft={draft}
+            typeLabel={task.draft ? task.draftType : 'Draft message'}
+            typeIcon={task.draft ? task.draftIcon : 'note'}
+            note={task.draft ? task.draftNote : 'Stitched from what you kept.'}
+            useLabel={task.draft ? task.useLabel : 'Use this'}
+            useNote={task.draft ? task.useNote : 'Saves it to this task, ready to edit and send.'}
+            confirm={task.draft ? task.useDone : 'Saved to this task.'}
+            done={done}
+            onComplete={() => {
+              if (!done) onToggle(task.id)
+            }}
+            onEdit={(next) => setDraft(next)}
+            onRedo={() => {
+              setDraft(null)
+              tryDraft()
+            }}
+          />
+        ) : drafting ? (
+          <div className="draft draft-working">
+            <MikanMark state="drafting" size={30} />
+            <div className="draft-working-tx">
+              Taking a crack at it
+              <Dots />
+            </div>
+          </div>
+        ) : (
+          !done && (
+            <button className="draft draft-cta" onClick={tryDraft}>
+              <MikanMark state="idle" size={30} />
+              <div className="draft-cta-main">
+                <div className="draft-cta-t">Want me to take a crack at it?</div>
+                <div className="draft-cta-s">I&apos;ll draft a start from what you kept</div>
+              </div>
+              <span className="draft-cta-go">
+                <NIcon name="arrowRight" size={18} />
+              </span>
+            </button>
+          )
         )}
 
         {done && (
@@ -609,18 +806,30 @@ const CHAT_SUGGESTIONS = [
   'What am I still missing?',
   'Summarize the sources'
 ]
-const CHAT_REPLIES: Record<string, string> = {
-  'Make the draft warmer':
-    'Done — I softened the opener and added a little warmth at the end. Take a look at the draft above.',
-  'What am I still missing?':
-    "Honestly, not much. The only open thing is confirming the date on your side — everything else I've got covered.",
-  'Summarize the sources':
-    "Quick version: Sarah's flexible on the weekend, your calendar's clear Apr 18–20, and the photos are from the last trip. That's the whole picture."
+// Replies stay mocked (no backend chat channel — tracked in UX-PUNCHLIST.md), but
+// carry `cites` so the reply can show the same citation/source parts the main
+// workspace uses, per CONTEXT.md: "Chat is built from the same parts."
+interface ChatReply {
+  text: string
+  cites?: string[]
+}
+const CHAT_REPLIES: Record<string, ChatReply> = {
+  'Make the draft warmer': {
+    text: 'Done — I softened the opener and added a little warmth at the end. Take a look at the draft above.'
+  },
+  'What am I still missing?': {
+    text: "Honestly, not much. The only open thing is confirming the date on your side — everything else I've got covered."
+  },
+  'Summarize the sources': {
+    text: "Quick version: Sarah's flexible on the weekend, your calendar's clear Apr 18–20, and the photos are from the last trip. That's the whole picture.",
+    cites: ['m_cabin_mail', 'm_cabin_cal', 'm_cabin_pic']
+  }
 }
 
 interface ChatMsg {
   from: 'mikan' | 'me'
   text: string
+  cites?: string[]
 }
 
 function TaskChat({
@@ -633,6 +842,7 @@ function TaskChat({
   onClose: () => void
 }): JSX.Element {
   const brand = useBrand()
+  const mem = useContext(MemoryContext)
   const [msgs, setMsgs] = useState<ChatMsg[]>([
     {
       from: 'mikan',
@@ -657,10 +867,10 @@ function TaskChat({
     setText('')
     setThinking(true)
     setTimeout(() => {
-      const reply =
-        CHAT_REPLIES[q] ||
-        'Got it — I pulled what I have on that and tucked it into the sources below. Want me to fold it into the draft?'
-      setMsgs((m) => [...m, { from: 'mikan', text: reply }])
+      const reply: ChatReply = CHAT_REPLIES[q] || {
+        text: 'Got it — I pulled what I have on that and tucked it into the sources below. Want me to fold it into the draft?'
+      }
+      setMsgs((m) => [...m, { from: 'mikan', text: reply.text, cites: reply.cites }])
       setThinking(false)
     }, 1200)
   }
@@ -686,12 +896,26 @@ function TaskChat({
         </div>
 
         <div className="chat-thread" ref={threadRef}>
-          {msgs.map((m, i) => (
-            <div key={i} className={'chat-msg ' + (m.from === 'me' ? 'me' : 'ai')}>
-              {m.from === 'mikan' && <MikanMark state="idle" size={20} />}
-              <div className="chat-bubble">{m.text}</div>
-            </div>
-          ))}
+          {msgs.map((m, i) => {
+            const cites = (m.cites ?? []).filter((id) => task.ctx.includes(id) && mem[id])
+            return (
+              <div key={i} className={'chat-msg ' + (m.from === 'me' ? 'me' : 'ai')}>
+                {m.from === 'mikan' && <MikanMark state="idle" size={20} />}
+                <div className="chat-msg-col">
+                  <div className="chat-bubble">{renderBold(m.text)}</div>
+                  {cites.length > 0 && (
+                    <div className="chat-cites">
+                      {cites.map((id) => (
+                        <span key={id} className="chip-pill" title={mem[id].title}>
+                          <NIcon name={kindIcon(mem[id].kind)} size={12} /> {mem[id].title}
+                        </span>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              </div>
+            )
+          })}
           {thinking && (
             <div className="chat-msg ai">
               <MikanMark state="thinking" size={20} />


### PR DESCRIPTION
## Summary

Implements RETRO-13 (S3 of the *Mikan Flows* PRD, `docs/plans/mikan-flows.prd.md`) — evolves the task detail screen (`task.tsx`) into the Group 02 "expanded workspace": brief + reasoning + Sources + dock, a guided stepper leading into an editable draft with tap-don't-type refine chips, and an Ask Mikan thread built from the same shared parts.

- **Reasoning card** — collapsible, renders `Task.steps` via `growing-card.tsx`'s `StepRow` (now exported) instead of duplicating step-row markup/CSS.
- **Sources + Dock** — the existing memory pool gets an explicit "Sources" label; a new `Dock` row shows deduped tool chips (e.g. `CALENDAR`, `MAPS`) from `PlanStep.tool`.
- **Guided stepper** — `Gathered → Your voice → Drafting → Approve & send`, mapped from `Task.state`.
- **Editable draft** — the previously no-op Edit/Redo buttons now open an inline textarea (Save/Cancel) and re-trigger drafting; new `RefineChips` (Warmer/Shorter/Attach photos) apply local text transforms, same AI-gap fidelity as the existing `tryDraft()` mock.
- **Ask Mikan** — refactored to render citation chips under mocked replies, reusing the same source-chip presentation as the workspace (per CONTEXT.md: "Chat is built from the same parts"). Reply logic stays mocked — no new backend/IPC channel, per UX-PUNCHLIST.md.

No `packages/contract` changes — S0 (`TaskState`/`TaskMode`/`PlanStep`/`RunReceipt`) already landed, and this branch is based on `main` post-#115 (S1 growing-card). Out of scope: `today.tsx`/S2, `plan.tsx`/S4, Auto mode/S5, lifecycle integration/S6.

## Test plan

- [x] `pnpm typecheck && pnpm build && pnpm lint` — all green (no new lint issues in changed files)
- [x] Smoke-tested live in a renderer-only browser preview (mock-data path) across `planned`/`working`/`awaiting` task states — reasoning card, Sources, Dock, stepper, editable draft, refine chips, and Ask Mikan citations all render and interact correctly
- [x] Verified both dark and light themes (token-driven, no hard-coded hexes)
- [x] Verified `data-ambient="off"` disables the new stepper pulse animation
- [ ] Live Electron `pnpm dev` pass (not required — this is renderer-only UI work; no worker/native paths touched)