### PR TITLE
feat(renderer): wire Today/Stack to the task lifecycle (RETRO-12, S2)

### DIFF
--- a/apps/desktop/src/renderer/src/mikan/mikan.css
+++ b/apps/desktop/src/renderer/src/mikan/mikan.css
@@ -609,12 +609,54 @@ html[data-ambient='off'] .nm[data-state='idle'] .nm-dot.q {
   border-color: transparent;
   color: #0a0a0b;
 }
+/* status-carrying: the checkbox ring reads task.state, not just done/not-done.
+   listed/planning/planned/working share the resting look until S4/S5 give them
+   their own visual mechanism; awaiting gets an accent ring — it needs a look. */
+.task-check[data-state='awaiting'] {
+  border-color: var(--accent-line);
+}
 .task-main {
   flex: 1 1 auto;
   min-width: 0;
   display: flex;
   flex-direction: column;
   gap: 7px;
+}
+/* the growing-card nests inside the task's own card chrome here (Today/Stack) —
+   flatten its standalone border/background/shadow so we don't double them up. */
+.task-main .gcard {
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
+  cursor: inherit;
+}
+.task-main .gcard:hover {
+  border-color: transparent;
+  transform: none;
+}
+.task-main .gcard-hd {
+  padding: 0;
+}
+/* mode badge — plan is the quiet default; auto is "alive", gets the accent */
+.mode-badge {
+  align-self: flex-start;
+  display: inline-flex;
+  align-items: center;
+  font-family: var(--mono);
+  font-size: 9px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  padding: 3px 8px;
+  border-radius: 999px;
+  color: var(--ink-3);
+  background: var(--surface);
+  box-shadow: inset 0 0 0 1px var(--hairline);
+}
+.mode-badge.auto {
+  color: var(--accent-ink);
+  background: var(--accent-soft);
+  box-shadow: inset 0 0 0 1px var(--accent-line);
 }
 .task-num {
   font-family: var(--mono);

--- a/apps/desktop/src/renderer/src/mikan/mock.ts
+++ b/apps/desktop/src/renderer/src/mikan/mock.ts
@@ -14,6 +14,8 @@ import type {
   Memory,
   MemoryKind,
   Task,
+  TaskState,
+  TaskStatus,
   UncoveredTodo
 } from '@mikan/contract/views'
 import { CAP_REACHED, type CaptureResult, type MikanApi, type Todo } from '@mikan/contract/ipc'
@@ -23,6 +25,13 @@ type MockApi = Pick<MikanApi, 'pipeline' | 'todos' | 'ui' | 'update'>
 // The day's focus cap (mirrors MikanApp's CAP) — lets the mock raise CAP_REACHED
 // so the add-todo → backlog fallback is exercisable in the browser.
 const CAP = 5
+
+// Mirrors the real projector's `toTask` (services/project.ts): `state` is always
+// derived fresh from `status`/`done`, never hand-set, so the mock behaves like
+// the app once GrowingCard reads `Task.state` (Today/Stack, S2).
+function deriveState(status: TaskStatus, done: boolean): TaskState {
+  return done ? 'done' : status === 'drafted' ? 'awaiting' : 'listed'
+}
 
 // ── the memory archive (what you've "fed" Mikan) ────────────────────────────
 export const MEMORIES: Record<string, Memory> = {
@@ -429,7 +438,11 @@ function matchTask(text: string): MatchHit[] {
 
 // ── the mock window.api: shared mutable state behind the real surface ────────
 export function makeMockApi(): MockApi {
-  let tasks: Task[] = SEED_TASKS.map((t) => ({ ...t, relMap: REL[t.id] ?? {} }))
+  let tasks: Task[] = SEED_TASKS.map((t) => ({
+    ...t,
+    relMap: REL[t.id] ?? {},
+    state: deriveState(t.status, t.done)
+  }))
   let backlog: BacklogItem[] = BACKLOG.map((b) => ({ ...b }))
   let feed: FedItem[] = FED_RECENT.map((f) => ({ ...f }))
 
@@ -521,6 +534,7 @@ export function makeMockApi(): MockApi {
           title,
           when: 'today',
           status: 'gathered',
+          state: deriveState('gathered', false),
           done: false,
           ctx: ctxIds,
           pinned: [],
@@ -544,6 +558,7 @@ export function makeMockApi(): MockApi {
         if (!t) return null
         t.done = true
         t.status = 'done'
+        t.state = deriveState(t.status, t.done)
         return clone(t)
       },
       reopen: async (id: string): Promise<Task | null> => {
@@ -551,6 +566,7 @@ export function makeMockApi(): MockApi {
         if (!t) return null
         t.done = false
         t.status = 'gathered'
+        t.state = deriveState(t.status, t.done)
         return clone(t)
       },
       plan: async (keep: string[]): Promise<Task[]> => {

--- a/apps/desktop/src/renderer/src/mikan/mock.ts
+++ b/apps/desktop/src/renderer/src/mikan/mock.ts
@@ -597,6 +597,7 @@ export function makeMockApi(): MockApi {
           title: b.title,
           when: 'today',
           status: 'gathered',
+          state: deriveState('gathered', false),
           done: false,
           ctx: [...(b.ctx ?? [])],
           pinned: [],

--- a/apps/desktop/src/renderer/src/mikan/today.tsx
+++ b/apps/desktop/src/renderer/src/mikan/today.tsx
@@ -4,6 +4,7 @@ import type { Task } from '@mikan/contract/views'
 import type { JSX } from 'react'
 import { useContext, useEffect, useRef, useState } from 'react'
 import { MemoryContext } from './api'
+import { GrowingCard } from './growing-card'
 import { kindIcon } from './iconKind'
 import { NIcon } from './icons'
 import { MikanMark, MikanNote } from './mark'
@@ -173,6 +174,7 @@ function TaskCard({
         <button
           className="task-check"
           aria-label="Complete"
+          data-state={task.state ?? 'listed'}
           onClick={(e) => {
             e.stopPropagation()
             onToggle(task.id)
@@ -182,11 +184,12 @@ function TaskCard({
           {pop && <span className="check-burst" />}
         </button>
         <div className="task-main">
-          <div className="task-title">{task.title}</div>
-          {task.done ? (
-            <MikanNote kind="done">Done — nice work.</MikanNote>
-          ) : (
+          <GrowingCard task={task} />
+          {!task.done && (
             <>
+              <span className={'mode-badge' + (task.mode === 'auto' ? ' auto' : '')}>
+                {task.mode === 'auto' ? 'Auto' : 'Plan'}
+              </span>
               {task.note && <MikanNote kind={task.noteKind || 'gathered'}>{task.note}</MikanNote>}
               <div className="ctx-strip">
                 {ctxN > 0 && <CtxThumbs memIds={task.ctx} />}
@@ -267,6 +270,7 @@ export function TodayView({
   const brand = useBrand()
   const filled = tasks.length
   const open = Math.max(0, cap - filled)
+  const done = tasks.filter((t) => t.done).length
   const left = tasks.filter((t) => !t.done).length
 
   if (!planned) {
@@ -320,10 +324,10 @@ export function TodayView({
         )}
         <div className="today-top">
           <span className="today-cap">
-            Today · <b>{left}</b> of {cap}
+            <b>{done}</b> done · <b>{left}</b> left
           </span>
           <button className="today-link" onClick={onPlan}>
-            Plan
+            Plan my day
           </button>
         </div>
         <div className={'list casc'} data-layout={layout}>


### PR DESCRIPTION
## Summary
- Implements RETRO-12 (S2 · Mikan Flows task-lifecycle spine): evolves `today.tsx` (Group 01 — Today/Stack) onto the canonical six-state lifecycle. Depends on S1 (`RETRO-11`, growing-card component, #115 — merged).
- Each task row now renders `GrowingCard` (S1) for the pixel-stable header/orb + state-morph body, alongside:
  - A status-carrying checkbox — `data-state={task.state ?? 'listed'}` on `.task-check`, with an accent-tinted ring for `awaiting`.
  - A mode badge (`Plan`/`Auto`), muted by default, accent-tinted for `auto`.
  - The cap row reads `N done · M left` + a `Plan my day` button (was `Today · N of {cap}` + `Plan`).
- Real `task.note` + the ctx-strip (kept/things count, tap-to-view context) are preserved alongside `GrowingCard` for open tasks — `GrowingCard`'s body is generic/state-driven and doesn't render per-task context, so dropping them would have regressed real, structural data. For done tasks, `GrowingCard`'s own `complete` body already renders "Done — nice work.", so the old duplicate `MikanNote` block was removed.
- `mock.ts`'s `complete`/`reopen`/`add`/`schedule` previously left `Task.state` out of sync with `status`/`done` (S0/S1 predate these mutators). Added `deriveState()`, mirroring the real projector (`services/project.ts` → `toTask`), so the browser-preview mock actually exercises the new lifecycle states instead of staying stuck at `listed`.

No `@mikan/contract` changes — S0 (`RETRO-10`, #110) already landed `TaskState`/`TaskMode`/`PlanStep`/`RunReceipt` on `main`.

## Test plan
- [x] `pnpm --filter @mikan/desktop typecheck` — green
- [x] `pnpm --filter @mikan/desktop build` — green
- [x] `pnpm lint` — clean on changed files (164 pre-existing problems elsewhere confirmed unrelated via `git stash` diff against `main`)
- [x] Browser-preview smoke test (temporary renderer-only Vite server, since Electron isn't installed in this sandbox — `window.api` absent, so `mock.ts` drives it): verified cap row copy, `GrowingCard` header/orb per row, checkbox + mode badge, ctx-strip/note preserved for open tasks, `listed`/`awaiting`/`done` states all render correctly (including toggling done/reopen), both light/dark themes, and `data-ambient="off"`.
- [ ] Live `pnpm dev` smoke test on a machine with Electron installed (renderer-only change, no worker/native surface touched, but not verified in this sandbox)

🤖 Generated with [Claude Code](https://claude.com/claude-code)