### PR TITLE
feat(renderer): plan mode — the plan review/accept + auto/ask (Group 12, RETRO-14)

### DIFF
--- a/apps/desktop/src/renderer/src/mikan/MikanApp.tsx
+++ b/apps/desktop/src/renderer/src/mikan/MikanApp.tsx
@@ -29,7 +29,7 @@ import { FeedView } from './feed'
 import { NIcon } from './icons'
 import { Dots, MikanMark } from './mark'
 import './mikan.css'
-import { PlanRitual } from './plan'
+import { PlanRitual, PlanReview } from './plan'
 import { SearchOverlay } from './search'
 import { SettingsView } from './settings'
 import { TaskDetail } from './task'
@@ -388,17 +388,24 @@ export default function MikanApp(): JSX.Element {
                   />
                 )}
 
-                {openTask && (
-                  <TaskDetail
-                    task={openTask}
-                    index={openIndex}
-                    onBack={() => setOpenId(null)}
-                    onToggle={toggleTask}
-                    onUpdate={updateTask}
-                    onDig={openTaskSearch}
-                    onSearch={openGlobalSearch}
-                  />
-                )}
+                {openTask &&
+                  (openTask.state === 'planned' ? (
+                    <PlanReview
+                      task={openTask}
+                      onBack={() => setOpenId(null)}
+                      onUpdate={updateTask}
+                    />
+                  ) : (
+                    <TaskDetail
+                      task={openTask}
+                      index={openIndex}
+                      onBack={() => setOpenId(null)}
+                      onToggle={toggleTask}
+                      onUpdate={updateTask}
+                      onDig={openTaskSearch}
+                      onSearch={openGlobalSearch}
+                    />
+                  ))}
 
                 {overlay === 'add' && (
                   <AddSheet

--- a/apps/desktop/src/renderer/src/mikan/mikan.css
+++ b/apps/desktop/src/renderer/src/mikan/mikan.css
@@ -4209,6 +4209,15 @@ html[data-ambient='off'] .mem.fresh::after {
   color: var(--ink);
   box-shadow: inset 0 0 0 1px var(--hairline);
 }
+.plan-seg button.on-auto {
+  background: var(--accent);
+  color: #0a0a0b;
+}
+.plan-seg button.on-ask {
+  background: var(--surface-2);
+  color: var(--ink);
+  box-shadow: inset 0 0 0 1px var(--hairline);
+}
 
 /* ───────────────────────── misc ───────────────────────── */
 .empty-note {
@@ -5037,6 +5046,14 @@ html[data-ambient='off'] .gcard-orb-ring {
   flex-direction: column;
   gap: 2px;
   padding: 0 15px 14px;
+}
+.gcard-step-wrap.editable {
+  cursor: pointer;
+  border-radius: 8px;
+  transition: background 0.15s;
+}
+.gcard-step-wrap.editable:hover {
+  background: var(--surface-2);
 }
 .gcard-step {
   display: flex;

--- a/apps/desktop/src/renderer/src/mikan/plan.tsx
+++ b/apps/desktop/src/renderer/src/mikan/plan.tsx
@@ -1,9 +1,11 @@
-// plan.tsx — the daily planning ritual. Keep a few, sweep the rest to the backlog.
+// plan.tsx — the daily planning ritual, and "the plan" (Group 12: Plan mode) —
+// reviewing/accepting a single task's steps before they run.
 import { useState } from 'react'
 import type { JSX } from 'react'
+import { StepRow } from './growing-card'
 import { NIcon } from './icons'
 import { MikanMark } from './mark'
-import type { BacklogItem, Task } from '@mikan/contract/views'
+import type { BacklogItem, PlanStep, StepRun, Task } from '@mikan/contract/views'
 
 export function PlanRitual({
   tasks,
@@ -163,6 +165,116 @@ export function PlanRitual({
           <NIcon name="check" size={15} /> Start the day
         </button>
       </div>
+    </div>
+  )
+}
+
+// a single step, opened for editing — same look as the read-only `StepRow`
+// (growing-card.tsx) but swaps the static run label for an auto/ask segment
+function EditableStepRow({
+  step,
+  onSetRun
+}: {
+  step: PlanStep
+  onSetRun: (run: StepRun) => void
+}): JSX.Element {
+  return (
+    <div className={'gcard-step status-' + step.status}>
+      <span className="gcard-step-ico">
+        {step.status === 'done' ? (
+          <NIcon name="check" size={11} />
+        ) : step.status === 'blocked' ? (
+          <NIcon name="close" size={10} />
+        ) : (
+          <span className="gcard-step-dot" />
+        )}
+      </span>
+      <span className="gcard-step-t">{step.title}</span>
+      {step.tool && <span className="gcard-step-tool">{step.tool}</span>}
+      <div className="plan-seg">
+        <button className={step.run === 'auto' ? 'on-auto' : ''} onClick={() => onSetRun('auto')}>
+          Auto
+        </button>
+        <button className={step.run === 'ask' ? 'on-ask' : ''} onClick={() => onSetRun('ask')}>
+          Ask
+        </button>
+      </div>
+    </div>
+  )
+}
+
+// plan.tsx — Group 12: Plan mode. Planning is the default, not a mode you
+// start — by the time the user opens a `planned` task, the plan already
+// exists. The only decisions are: glance → accept, or open one step to flip
+// it between auto and ask.
+export function PlanReview({
+  task,
+  onBack,
+  onUpdate
+}: {
+  task: Task
+  onBack: () => void
+  onUpdate?: (id: string, patch: Partial<Task>) => void
+}): JSX.Element {
+  const [openId, setOpenId] = useState<string | null>(null)
+  const steps = task.steps
+
+  const setStepRun = (stepId: string, run: StepRun): void => {
+    onUpdate?.(task.id, {
+      steps: (steps || []).map((s) => (s.id === stepId ? { ...s, run } : s))
+    })
+    setOpenId(null)
+  }
+
+  const accept = (): void => {
+    onUpdate?.(task.id, { state: 'working' })
+    onBack()
+  }
+
+  return (
+    <div className="push">
+      <div className="push-hd">
+        <button className="push-back" aria-label="Back" onClick={onBack}>
+          <NIcon name="back" size={18} />
+        </button>
+        <div className="push-hd-main">
+          <div className="push-kicker">The plan</div>
+          <div className="push-ttl">{task.title}</div>
+        </div>
+      </div>
+
+      <div className="plan-body">
+        {!steps || steps.length === 0 ? (
+          <div className="empty-note">Mikan hasn&apos;t put together a plan for this yet.</div>
+        ) : (
+          <div className="gcard-steps">
+            {steps.map((s) =>
+              s.id === openId ? (
+                <EditableStepRow key={s.id} step={s} onSetRun={(run) => setStepRun(s.id, run)} />
+              ) : (
+                <div
+                  key={s.id}
+                  className="gcard-step-wrap editable"
+                  onClick={() => setOpenId(s.id)}
+                >
+                  <StepRow step={s} />
+                </div>
+              )
+            )}
+          </div>
+        )}
+      </div>
+
+      {steps && steps.length > 0 && (
+        <div className="dt-foot">
+          <div className="today-cap" style={{ flex: '1 1 auto', paddingLeft: '4px' }}>
+            Glance and accept, or open a step to change how it runs.
+          </div>
+          <button className="btn primary btn-sm" style={{ padding: '0 18px' }} onClick={accept}>
+            <NIcon name="check" size={15} /> Accept the plan
+          </button>
+        </div>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary

Implements **RETRO-14 / S4 · Plan mode (Group 12)** from the Mikan Flows PRD (`docs/plans/mikan-flows.prd.md`).

- Adds `PlanReview` to `plan.tsx`: renders a `planned` task's `Task.steps`, lets one step be opened at a time to flip `StepRun` between `auto`/`ask`, and accepts the plan (optimistically transitions to `working` — no backend call yet, since there's no run-loop endpoint until S5, matching the AI-gap pattern already used elsewhere in this file, e.g. `RefineChips`).
- Wires `MikanApp.tsx` so opening a task while `state === 'planned'` shows `PlanReview` instead of `TaskDetail`; all other states are unaffected.
- Small `mikan.css` additions: `.gcard-step-wrap.editable` (hover affordance) and `.plan-seg button.on-auto`/`.on-ask` (mirrors the existing `on-keep`/`on-drop` segment styling).
- No `packages/contract` changes — `PlanStep`/`StepRun`/`Task.steps` already landed in S0 (RETRO-10).

## Notes for reviewers

- Graceful AI-gap shell: when `task.steps` is empty/undefined, the screen shows an empty-note message instead of the step list, per the ticket ("`steps` is AI-gap until the planner lands").
- Known gap (flagged in review, not blocking): accepting the plan / editing a step's run value is local React state only — there's no `TodoApi` write-back channel yet, so it doesn't survive a reload. This tracks with the ticket's framing of `steps` as read-only AI-gap for now; a follow-up (likely paired with S5's run-loop) should add persistence.
- Manually smoke-tested via a live `pnpm dev` session (browser-preview mock backend): opened the `planned` mock task, edited a step's auto/ask value and confirmed it persisted in-session, accepted the plan and confirmed it returns to Today with the growing card now rendering the `working` state, and confirmed non-`planned` tasks still route to the normal `TaskDetail` workspace (no regression).

## Test plan

- [x] `pnpm typecheck && pnpm build && pnpm lint` green (lint's pre-existing errors are all in generated code under `packages/contract/src/api/generated/**`, unrelated to this change)
- [x] Manual GUI smoke test via `pnpm dev` (see notes above)
- [ ] Reviewer: confirm the no-persistence gap is acceptable for this slice, or should be called out as a blocking follow-up