### PR TITLE
feat(auto-mode): real run loop + Auto/Plan toggle (RETRO-15, S5)

### DIFF
--- a/apps/desktop/src/main/db/index.ts
+++ b/apps/desktop/src/main/db/index.ts
@@ -226,6 +226,16 @@ export async function initDb(): Promise<void> {
       inputs_hash TEXT NOT NULL DEFAULT '',
       updated_at INTEGER NOT NULL DEFAULT (unixepoch())
     );
+    CREATE TABLE IF NOT EXISTS todo_run (
+      todo_id TEXT PRIMARY KEY REFERENCES todos(id) ON DELETE CASCADE,
+      state TEXT NOT NULL DEFAULT 'listed',
+      ran_on_device INTEGER NOT NULL DEFAULT 1,
+      duration_ms INTEGER,
+      touched TEXT,
+      sent_anything INTEGER NOT NULL DEFAULT 0,
+      started_at INTEGER,
+      updated_at INTEGER NOT NULL DEFAULT (unixepoch())
+    );
   `)
 
   // connector_state: tracks per-provider sync cursors (Gmail historyId / Calendar syncToken).
@@ -253,6 +263,8 @@ export async function initDb(): Promise<void> {
   // missing. Backfill them before any query references them.
   await addColumnIfMissing('items', 'stored_path', 'TEXT')
   await addColumnIfMissing('todos', 'position', 'INTEGER NOT NULL DEFAULT 0')
+  // mode: the Group 03 auto switch — additive, defaults existing rows to 'plan'.
+  await addColumnIfMissing('todos', 'mode', "TEXT NOT NULL DEFAULT 'plan'")
   // todos_day_idx references position, so it's created HERE (after the backfill
   // guarantees the column exists) rather than in the executeMultiple block above —
   // otherwise the primary rejects it with "no such column: position" when mobile
@@ -331,7 +343,9 @@ export async function resetVecChunks(): Promise<void> {
  * caller wires in dynamic input.
  */
 const SQL_IDENT = /^[A-Za-z_][A-Za-z0-9_]*$/
-const SQL_COL_TYPE = /^[A-Za-z0-9_ ()]+$/
+// Allows a quoted string DEFAULT literal (e.g. "TEXT NOT NULL DEFAULT 'plan'") in addition to the
+// bare-word/paren types used elsewhere. Safe because every caller passes a hardcoded literal.
+const SQL_COL_TYPE = /^[A-Za-z0-9_ ()']+$/
 async function addColumnIfMissing(table: string, column: string, type: string): Promise<void> {
   if (!SQL_IDENT.test(table) || !SQL_IDENT.test(column) || !SQL_COL_TYPE.test(type)) {
     throw new Error(`addColumnIfMissing: unsafe identifier (${table}.${column} ${type})`)

--- a/apps/desktop/src/main/db/schema.ts
+++ b/apps/desktop/src/main/db/schema.ts
@@ -86,6 +86,7 @@ export const todos = sqliteTable('todos', {
   status: text('status').notNull().default('open'), // open | done
   day: text('day'), // ISO date; NULL = backlog
   position: integer('position').notNull().default(0),
+  mode: text('mode').notNull().default('plan'), // plan | auto (Group 03 auto switch)
   createdAt: integer('created_at', { mode: 'timestamp' })
     .notNull()
     .default(sql`(unixepoch())`),
@@ -94,6 +95,30 @@ export const todos = sqliteTable('todos', {
 
 export type Todo = typeof todos.$inferSelect
 export type NewTodo = typeof todos.$inferInsert
+
+/**
+ * `todo_run` — the persisted state of a task's Auto-mode run (Group 03), one row
+ * per todo, upserted on every `run()`/`approve()`/`pause()`. Mirrors `todoAi`'s
+ * settled-snapshot pattern: this holds the *run's* state (working/awaiting/done)
+ * and its `RunReceipt`, distinct from `todoAi`'s drafting content — a run may
+ * settle at `awaiting` with no draft accepted yet, or `done` with nothing to
+ * approve at all.
+ */
+export const todoRun = sqliteTable('todo_run', {
+  todoId: text('todo_id').primaryKey(),
+  state: text('state').notNull().default('listed'), // listed | working | awaiting | done
+  ranOnDevice: integer('ran_on_device', { mode: 'boolean' }).notNull().default(true),
+  durationMs: integer('duration_ms'),
+  touched: text('touched'), // JSON: string[] (context item ids the run read)
+  sentAnything: integer('sent_anything', { mode: 'boolean' }).notNull().default(false),
+  startedAt: integer('started_at', { mode: 'timestamp' }),
+  updatedAt: integer('updated_at', { mode: 'timestamp' })
+    .notNull()
+    .default(sql`(unixepoch())`)
+})
+
+export type TodoRunRow = typeof todoRun.$inferSelect
+export type NewTodoRunRow = typeof todoRun.$inferInsert
 
 /**
  * `todoContext` — each todo's persistent, additive pool of surfaced memories

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -195,6 +195,10 @@ app.whenReady().then(async () => {
     IPC.todoContextSearch,
     IPC.todoContextPin,
     IPC.todoContextDismiss,
+    IPC.todoSetMode,
+    IPC.todoRun,
+    IPC.todoApprove,
+    IPC.todoPause,
     // Sync (ROADMAP #10) — forwarded to the worker which owns the DB + sync state.
     IPC.syncGetStatus,
     IPC.syncNow

--- a/apps/desktop/src/main/pipeline/draft.ts
+++ b/apps/desktop/src/main/pipeline/draft.ts
@@ -75,7 +75,9 @@ export interface UncoveredDraft {
 
 export interface Drafter {
   readonly name: string
-  draft(input: DraftInput): Promise<TaskDraft>
+  /** `signal` (Group 03 `pause()`) aborts the in-flight call; the caller treats an
+   *  `AbortError` as cancellation, not a fatal failure. */
+  draft(input: DraftInput, signal?: AbortSignal): Promise<TaskDraft>
   /** Infer candidate to-dos from the recent feed. `[]` when there's nothing
    *  actionable (or the drafter is the null impl). */
   uncover(input: UncoverInput): Promise<UncoveredDraft[]>
@@ -87,7 +89,7 @@ export class NullDrafter implements Drafter {
   readonly name = 'null-drafter'
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  draft(_input: DraftInput): Promise<TaskDraft> {
+  draft(_input: DraftInput, _signal?: AbortSignal): Promise<TaskDraft> {
     return Promise.resolve({
       brief: null,
       draft: null,
@@ -311,8 +313,8 @@ export class CloudDrafter implements Drafter {
     this.model = model
   }
 
-  async draft(input: DraftInput): Promise<TaskDraft> {
-    const text = await this.complete(SYSTEM_PROMPT, buildUserMessage(input))
+  async draft(input: DraftInput, signal?: AbortSignal): Promise<TaskDraft> {
+    const text = await this.complete(SYSTEM_PROMPT, buildUserMessage(input), signal)
     if (text == null) return nullResult()
     try {
       return coerceTaskDraft(JSON.parse(stripJsonFence(text)) as Record<string, unknown>, input)
@@ -335,8 +337,15 @@ export class CloudDrafter implements Drafter {
   }
 
   /** One Anthropic Messages call. Returns the assistant's text, or null on any
-   *  transport/API failure (callers degrade gracefully). */
-  private async complete(system: string, userMessage: string): Promise<string | null> {
+   *  transport/API failure (callers degrade gracefully). An abort via `signal`
+   *  (Group 03 `pause()`) rethrows the `AbortError` instead — that's a
+   *  cancellation, not a failure to swallow, so the caller can revert state
+   *  rather than land on "gathered/nothing to draft". */
+  private async complete(
+    system: string,
+    userMessage: string,
+    signal?: AbortSignal
+  ): Promise<string | null> {
     try {
       const res = await fetch('https://api.anthropic.com/v1/messages', {
         method: 'POST',
@@ -350,7 +359,8 @@ export class CloudDrafter implements Drafter {
           max_tokens: 1024,
           system,
           messages: [{ role: 'user', content: userMessage }]
-        })
+        }),
+        signal
       })
 
       if (!res.ok) {
@@ -367,6 +377,7 @@ export class CloudDrafter implements Drafter {
 
       return data.content?.find((b) => b.type === 'text')?.text ?? ''
     } catch (err) {
+      if (err instanceof Error && err.name === 'AbortError') throw err
       console.error('[drafter] unexpected error', err)
       return null
     }

--- a/apps/desktop/src/main/services/draft-service.ts
+++ b/apps/desktop/src/main/services/draft-service.ts
@@ -129,8 +129,12 @@ export const draftService = {
    *
    * For backlog items (pool is empty, todo.day is null) we run a search to
    * build context for a meaningful `conf` score.
+   *
+   * `signal` (Group 03 `pause()`) aborts the in-flight drafter call; an
+   * `AbortError` propagates to the caller uncaught — regenerate() does not
+   * persist anything for an aborted run.
    */
-  async regenerate(todo: Todo, pool: ContextEntry[]): Promise<void> {
+  async regenerate(todo: Todo, pool: ContextEntry[], signal?: AbortSignal): Promise<void> {
     let input: DraftInput
 
     if (pool.length === 0 && todo.day === null) {
@@ -160,7 +164,7 @@ export const draftService = {
     const existing = await readAiRow(todo.id)
     if (existing && existing.inputsHash === hash) return // nothing changed
 
-    const result = await drafter.draft(input)
+    const result = await drafter.draft(input, signal)
     await upsertAiRow(todo.id, result, hash)
     if (Object.keys(result.why).length > 0) {
       await persistWhyStrings(todo.id, result.why)

--- a/apps/desktop/src/main/services/project.ts
+++ b/apps/desktop/src/main/services/project.ts
@@ -17,12 +17,14 @@ import type {
   Memory,
   MemoryKind,
   NoteKind,
+  RunReceipt,
   Task,
   TaskState,
   TaskStatus,
   UncoveredTodo
 } from '@mikan/contract/views'
 import type { TaskDraft, UncoveredDraft } from '../pipeline/draft'
+import type { TodoRunRow } from '../db/schema'
 
 const DAY_MS = 86_400_000
 
@@ -126,12 +128,19 @@ function whenOfDay(day: string | null): string {
 /**
  * Project a todo + its (already non-dismissed, pinned-first, score-sorted) context
  * pool into a `Task`. When `ai` is provided, AI-generated fields are populated;
- * otherwise they degrade gracefully to null.
+ * otherwise they degrade gracefully to null. When `run` (a `todo_run` row) is
+ * provided and its state isn't `'listed'`, it's a real signal from `todos.run()`
+ * that overrides the derived `state` below, and populates `receipt`.
  *
  * Invariant for the UI: every `ctx` id also appears in `pipeline.archive()` (both
  * come from the `items` table), so `MEMORIES[id]` always resolves.
  */
-export function toTask(todo: Todo, context: ContextEntry[], ai?: TaskDraft): Task {
+export function toTask(
+  todo: Todo,
+  context: ContextEntry[],
+  ai?: TaskDraft,
+  run?: TodoRunRow
+): Task {
   const relMap: Record<string, number> = {}
   const whyMap: Record<string, string> = {}
   for (const c of context) {
@@ -151,9 +160,23 @@ export function toTask(todo: Todo, context: ContextEntry[], ai?: TaskDraft): Tas
 
   // Canonical lifecycle (Mikan Flows). Derived from the structural `status` the
   // projector emits today: `done`→done, a landed draft→awaiting (the approval
-  // gate), otherwise the resting `listed`. `planning`/`planned`/`working` become
-  // real once the planner + run-loop land (slices S4/S5). See docs/adr/0010.
-  const state: TaskState = done ? 'done' : status === 'drafted' ? 'awaiting' : 'listed'
+  // gate), otherwise the resting `listed`. `planned` stays unmapped — there is
+  // still no persisted multi-step plan (S4-scope). See docs/adr/0010.
+  const derivedState: TaskState = done ? 'done' : status === 'drafted' ? 'awaiting' : 'listed'
+  // A todo_run row is a real signal from todos.run() (Group 03) — it overrides
+  // the derivation above whenever it holds a non-resting state. A 'listed' row
+  // (never run, or reverted by pause()) carries no receipt — receipt presence
+  // means "a run settled", not "a row exists".
+  const settledRun = run && run.state !== 'listed' ? run : undefined
+  const state: TaskState = settledRun ? (settledRun.state as TaskState) : derivedState
+  const receipt: RunReceipt | undefined = settledRun
+    ? {
+        ranOnDevice: settledRun.ranOnDevice,
+        durationMs: settledRun.durationMs,
+        touched: settledRun.touched ? (JSON.parse(settledRun.touched) as string[]) : [],
+        sentAnything: settledRun.sentAnything
+      }
+    : undefined
 
   return {
     id: todo.id,
@@ -161,8 +184,8 @@ export function toTask(todo: Todo, context: ContextEntry[], ai?: TaskDraft): Tas
     when: whenOfDay(todo.day),
     status,
     state,
-    // No stored per-task mode yet — defaults to Plan until the mode switch lands.
-    mode: 'plan',
+    mode: todo.mode,
+    receipt,
     done,
     ctx: context.map((c) => c.itemId),
     pinned: context.filter((c) => c.state === 'pinned').map((c) => c.itemId),

--- a/apps/desktop/src/main/services/todo-service.ts
+++ b/apps/desktop/src/main/services/todo-service.ts
@@ -1,6 +1,15 @@
 import { and, count, desc, eq, isNotNull, isNull } from 'drizzle-orm'
 import { client, db } from '../db'
-import { items, todoContext, todos, type Todo as TodoRow, type TodoContextRow } from '../db/schema'
+import {
+  items,
+  todoContext,
+  todoRun,
+  todos,
+  type NewTodoRunRow,
+  type Todo as TodoRow,
+  type TodoContextRow,
+  type TodoRunRow
+} from '../db/schema'
 import { pipelineService } from './pipeline-service'
 import { draftService, rowToTaskDraft } from './draft-service'
 import { drafter } from '../pipeline/draft'
@@ -13,7 +22,7 @@ import {
   type Todo,
   type TodoStatus
 } from '@mikan/contract/ipc'
-import type { BacklogItem, Task } from '@mikan/contract/views'
+import type { BacklogItem, Task, TaskMode } from '@mikan/contract/views'
 import { toBacklogItem, toTask } from './project'
 
 /**
@@ -40,6 +49,7 @@ function toTodo(row: TodoRow): Todo {
     status: row.status as TodoStatus,
     day: row.day,
     position: row.position,
+    mode: row.mode as TaskMode,
     createdAt: row.createdAt,
     completedAt: row.completedAt
   }
@@ -130,11 +140,47 @@ async function surfaceContext(todo: Todo): Promise<ContextEntry[]> {
   return listContext(todo.id)
 }
 
-/** Project a todo + its context pool + AI row into the UI `Task` shape. */
+async function readRunRow(todoId: string): Promise<TodoRunRow | null> {
+  const [row] = await db.select().from(todoRun).where(eq(todoRun.todoId, todoId)).limit(1)
+  return row ?? null
+}
+
+async function upsertRunRow(
+  todoId: string,
+  patch: Partial<Omit<NewTodoRunRow, 'todoId' | 'updatedAt'>>
+): Promise<void> {
+  const now = new Date()
+  await db
+    .insert(todoRun)
+    .values({ todoId, updatedAt: now, ...patch })
+    .onConflictDoUpdate({ target: todoRun.todoId, set: { updatedAt: now, ...patch } })
+}
+
+// --- Auto-mode run loop (Group 03) -----------------------------------------
+//
+// `run()` is a single-shot, synchronous request-response: it gathers context +
+// drafts (the current unit of AI-gap work — there's no persisted multi-step
+// plan yet, that's S4-scope) and settles at `awaiting` (a draft landed — the
+// approval gate) or `done` (nothing to gate on). `pause()` aborts the in-flight
+// drafter call; `runHandles` lets a concurrent `pause()` call wait for that
+// abort to actually land before reading the reverted task back, since `run()`'s
+// own DB write happens asynchronously after the abort signal fires.
+interface RunHandle {
+  controller: AbortController
+  /** Resolves once run()'s own try/catch/finally has settled the DB. */
+  done: Promise<void>
+}
+const runHandles = new Map<string, RunHandle>()
+
+/** Project a todo + its context pool + AI row + run row into the UI `Task` shape. */
 async function taskOf(todo: Todo): Promise<Task> {
-  const [context, aiRow] = await Promise.all([listContext(todo.id), draftService.read(todo.id)])
+  const [context, aiRow, runRow] = await Promise.all([
+    listContext(todo.id),
+    draftService.read(todo.id),
+    readRunRow(todo.id)
+  ])
   const ai = aiRow ? rowToTaskDraft(aiRow) : undefined
-  return toTask(todo, context, ai)
+  return toTask(todo, context, ai, runRow ?? undefined)
 }
 
 /** Re-read a todo by id and project it (used by mutators that return the task). */
@@ -332,6 +378,93 @@ export const todoService = {
     const todo = toTodo(r)
     const pool = await listContext(id)
     await draftService.regenerate(todo, pool)
+    return taskById(id)
+  },
+
+  /** Set a task's run mode (Group 03 auto switch, toggled on the list). */
+  async setMode(id: string, mode: TaskMode): Promise<Task | null> {
+    const [r] = await db.update(todos).set({ mode }).where(eq(todos.id, id)).returning()
+    return r ? taskOf(toTodo(r)) : null
+  },
+
+  /**
+   * Run the task on device: gather context + draft, synchronously, to
+   * settlement. No-op (returns the task unchanged) when the drafter is
+   * unconfigured — there's nothing to run, and a receipt would falsely imply
+   * something happened. Safe to call repeatedly (draftService.regenerate is
+   * idempotent via its inputsHash skip).
+   */
+  async run(id: string): Promise<Task | null> {
+    const [r] = await db.select().from(todos).where(eq(todos.id, id)).limit(1)
+    if (!r) return null
+    const todo = toTodo(r)
+    if (drafter.name === 'null-drafter') return taskOf(todo)
+
+    const controller = new AbortController()
+    const t0 = Date.now()
+    const done = (async (): Promise<void> => {
+      try {
+        const pool = await surfaceContext(todo)
+        await draftService.regenerate(todo, pool, controller.signal)
+        const aiRow = await draftService.read(id)
+        const produced = aiRow?.status === 'drafted'
+        await upsertRunRow(id, {
+          state: produced ? 'awaiting' : 'done',
+          ranOnDevice: true,
+          durationMs: Date.now() - t0,
+          touched: JSON.stringify(pool.map((c) => c.itemId)),
+          sentAnything: false,
+          startedAt: new Date(t0)
+        })
+      } catch (err) {
+        if (err instanceof Error && err.name === 'AbortError') {
+          // pause() landed mid-flight — revert to the resting state, no receipt
+          // (nothing salvageable from an aborted draft call).
+          await upsertRunRow(id, {
+            state: 'listed',
+            durationMs: null,
+            touched: null,
+            sentAnything: false
+          })
+        } else {
+          throw err
+        }
+      } finally {
+        runHandles.delete(id)
+      }
+    })()
+    runHandles.set(id, { controller, done })
+
+    await done
+    return taskById(id)
+  },
+
+  /**
+   * Approve an awaiting run: closes the gate, settles the run at `done`. Not
+   * the same as `complete()` (the todo's own done/reopen toggle stays a
+   * separate user action). No-op when there's nothing awaiting.
+   * `receipt.sentAnything` stays false — there's no outbound send integration.
+   */
+  async approve(id: string): Promise<Task | null> {
+    const runRow = await readRunRow(id)
+    if (runRow && runRow.state === 'awaiting') {
+      await upsertRunRow(id, { state: 'done' })
+    }
+    return taskById(id)
+  },
+
+  /**
+   * Cancel an in-flight run (aborts the drafter call). No-op if nothing is
+   * running for this task. Awaits the aborted run's own settlement so the
+   * returned task reflects the reverted `listed` state rather than a stale
+   * mid-flight snapshot.
+   */
+  async pause(id: string): Promise<Task | null> {
+    const handle = runHandles.get(id)
+    if (handle) {
+      handle.controller.abort()
+      await handle.done.catch(() => {})
+    }
     return taskById(id)
   }
 }

--- a/apps/desktop/src/main/worker/index.ts
+++ b/apps/desktop/src/main/worker/index.ts
@@ -11,6 +11,7 @@
  */
 import { IPC } from '@mikan/contract/ipc'
 import type { ConnectorId, SyncStatus } from '@mikan/contract/ipc'
+import type { TaskMode } from '@mikan/contract/views'
 import { initDb, syncNow, reimportPreSyncBackup } from '../db'
 import { getSyncConfig } from '../db/sync-config'
 import { pipelineService } from '../services/pipeline-service'
@@ -46,7 +47,13 @@ async function runSyncNow(): Promise<void> {
   try {
     await syncNow()
     const durationMs = Date.now() - t0
-    syncState = { ...syncState, syncing: false, lastSyncAt: t0 + durationMs, lastSyncDurationMs: durationMs, error: null }
+    syncState = {
+      ...syncState,
+      syncing: false,
+      lastSyncAt: t0 + durationMs,
+      lastSyncDurationMs: durationMs,
+      error: null
+    }
     console.log(`[sync] synced in ${durationMs}ms`)
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err)
@@ -80,6 +87,10 @@ const handlers: Record<string, Handler> = {
   [IPC.todoContextPin]: ([id, itemId]) => todoService.pinContext(id as string, itemId as string),
   [IPC.todoContextDismiss]: ([id, itemId]) =>
     todoService.dismissContext(id as string, itemId as string),
+  [IPC.todoSetMode]: ([id, mode]) => todoService.setMode(id as string, mode as TaskMode),
+  [IPC.todoRun]: ([id]) => todoService.run(id as string),
+  [IPC.todoApprove]: ([id]) => todoService.approve(id as string),
+  [IPC.todoPause]: ([id]) => todoService.pause(id as string),
 
   // Connector sync: main passes a fresh access token; worker fetches + ingests.
   [IPC.connectorsIngest]: ([provider, accessToken]) =>

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -7,6 +7,7 @@ import {
   type MikanApi,
   type UpdateStatus
 } from '@mikan/contract/ipc'
+import type { TaskMode } from '@mikan/contract/views'
 import { contextBridge, ipcRenderer, type IpcRendererEvent } from 'electron'
 
 // Custom APIs for renderer — the only data surface the renderer can reach.
@@ -33,7 +34,11 @@ const api: MikanApi = {
     searchMoreContext: (id: string) => ipcRenderer.invoke(IPC.todoContextSearch, id),
     pinContext: (id: string, itemId: string) => ipcRenderer.invoke(IPC.todoContextPin, id, itemId),
     dismissContext: (id: string, itemId: string) =>
-      ipcRenderer.invoke(IPC.todoContextDismiss, id, itemId)
+      ipcRenderer.invoke(IPC.todoContextDismiss, id, itemId),
+    setMode: (id: string, mode: TaskMode) => ipcRenderer.invoke(IPC.todoSetMode, id, mode),
+    run: (id: string) => ipcRenderer.invoke(IPC.todoRun, id),
+    approve: (id: string) => ipcRenderer.invoke(IPC.todoApprove, id),
+    pause: (id: string) => ipcRenderer.invoke(IPC.todoPause, id)
   },
   auth: {
     login: () => ipcRenderer.invoke(IPC.authLogin),

--- a/apps/desktop/src/renderer/src/mikan/MikanApp.tsx
+++ b/apps/desktop/src/renderer/src/mikan/MikanApp.tsx
@@ -182,6 +182,40 @@ export default function MikanApp(): JSX.Element {
   const updateTask = (id: string, patch: Partial<Task>): void =>
     setTasks((ts) => ts.map((x) => (x.id === id ? { ...x, ...patch } : x)))
 
+  // Group 03 auto switch: optimistic flip, reconciled against the persisted
+  // value once setMode() resolves (mirrors toggleTask's optimistic pattern).
+  const toggleMode = (id: string): void => {
+    const cur = tasks.find((x) => x.id === id)
+    if (!cur) return
+    const next = cur.mode === 'auto' ? 'plan' : 'auto'
+    const prevMode = cur.mode
+    updateTask(id, { mode: next })
+    void data.todos.setMode(id, next).then((updated) => {
+      if (updated) updateTask(id, { mode: updated.mode })
+      else updateTask(id, { mode: prevMode })
+    })
+  }
+
+  // Group 03 run loop: run()/approve()/pause() each resolve to the settled task
+  // (state + receipt, and possibly a draft once a run lands one) — drop it
+  // straight into state, same pattern as every other todos.* mutator here.
+  // Returns the promise (rather than fire-and-forget) so callers with a local
+  // "busy" flag (e.g. the Today-list card) can clear it deterministically —
+  // an unconfigured drafter resolves to the task UNCHANGED, so a prop-diff-based
+  // reset wouldn't fire in that case.
+  const runTask = (id: string): Promise<void> =>
+    data.todos.run(id).then((updated) => {
+      if (updated) updateTask(id, updated)
+    })
+  const approveTask = (id: string): Promise<void> =>
+    data.todos.approve(id).then((updated) => {
+      if (updated) updateTask(id, updated)
+    })
+  const pauseTask = (id: string): Promise<void> =>
+    data.todos.pause(id).then((updated) => {
+      if (updated) updateTask(id, updated)
+    })
+
   // a new to-do (typed, or accepted from indexing) → today if there's room, else
   // the backlog. The contract has no "add to backlog", so a full day (CAP_REACHED)
   // or an unreachable worker falls back to local backlog state — the to-do is never
@@ -366,6 +400,10 @@ export default function MikanApp(): JSX.Element {
                     lastFed={archive[0]?.when ?? null}
                     onOpen={setOpenId}
                     onToggle={toggleTask}
+                    onToggleMode={toggleMode}
+                    onRun={runTask}
+                    onApprove={approveTask}
+                    onPause={pauseTask}
                     onAdd={() => setOverlay('add')}
                     onPlan={() => setOverlay('plan')}
                     onTomorrow={beginNewDay}

--- a/apps/desktop/src/renderer/src/mikan/growing-card.tsx
+++ b/apps/desktop/src/renderer/src/mikan/growing-card.tsx
@@ -99,16 +99,35 @@ export function StepRow({ step }: { step: PlanStep }): JSX.Element {
 export function GrowingCard({
   task,
   onOpen,
-  onSaveSkill
+  onSaveSkill,
+  onRun,
+  onApprove,
+  onPause,
+  busy
 }: {
   task: Task
   onOpen?: () => void
   /** "Save as a skill" — offered on a good run (complete state only). */
   onSaveSkill?: () => void
+  /** Group 03: kick off an Auto-mode run from the resting (collapsed) state. */
+  onRun?: () => void
+  /** Group 03: close the approval gate — "nothing sent yet" until this fires. */
+  onApprove?: () => void
+  /** Group 03: cancel an in-flight Auto-mode run ("steer anytime · pause"). */
+  onPause?: () => void
+  /**
+   * Local optimistic "running" flag for a real in-flight `run()` call. The run
+   * loop is a single synchronous request-response (no mid-flight push), so
+   * `task.state` never actually passes through `'working'` for a real run —
+   * the caller tracks this instead so the card still shows a running/pause
+   * state between the click and the settled response.
+   */
+  busy?: boolean
 }): JSX.Element {
-  const renderState = renderStateFor(task)
+  const renderState = busy ? 'reasoning' : renderStateFor(task)
   const steps = task.steps
   const runningStep = steps?.find((s) => s.status === 'running')
+  const auto = task.mode === 'auto'
 
   return (
     <div
@@ -126,6 +145,18 @@ export function GrowingCard({
       </div>
 
       <div className="gcard-body">
+        {renderState === 'collapsed' && auto && onRun && (
+          <button
+            className="gcard-run"
+            onClick={(e) => {
+              e.stopPropagation()
+              onRun()
+            }}
+          >
+            <NIcon name="bolt" size={13} /> Run this on device
+          </button>
+        )}
+
         {renderState === 'searching' && (
           <div className="gcard-searching">
             <MikanSay state="thinking" size={18}>
@@ -150,6 +181,17 @@ export function GrowingCard({
                 </MikanSay>
               </div>
             )}
+            {auto && onPause && (
+              <button
+                className="btn btn-sm ghost gcard-pause"
+                onClick={(e) => {
+                  e.stopPropagation()
+                  onPause()
+                }}
+              >
+                Pause
+              </button>
+            )}
           </div>
         )}
 
@@ -160,7 +202,13 @@ export function GrowingCard({
               <button className="btn btn-sm" onClick={(e) => e.stopPropagation()}>
                 Iterate
               </button>
-              <button className="btn primary btn-sm" onClick={(e) => e.stopPropagation()}>
+              <button
+                className="btn primary btn-sm"
+                onClick={(e) => {
+                  e.stopPropagation()
+                  onApprove?.()
+                }}
+              >
                 Approve
               </button>
             </div>

--- a/apps/desktop/src/renderer/src/mikan/mikan.css
+++ b/apps/desktop/src/renderer/src/mikan/mikan.css
@@ -638,11 +638,13 @@ html[data-ambient='off'] .nm[data-state='idle'] .nm-dot.q {
 .task-main .gcard-hd {
   padding: 0;
 }
-/* mode badge — plan is the quiet default; auto is "alive", gets the accent */
+/* mode badge — plan is the quiet default; auto is "alive", gets the accent.
+   A real toggle button (Group 03 auto switch), so reset the native chrome. */
 .mode-badge {
   align-self: flex-start;
   display: inline-flex;
   align-items: center;
+  border: none;
   font-family: var(--mono);
   font-size: 9px;
   letter-spacing: 0.1em;
@@ -652,6 +654,7 @@ html[data-ambient='off'] .nm[data-state='idle'] .nm-dot.q {
   color: var(--ink-3);
   background: var(--surface);
   box-shadow: inset 0 0 0 1px var(--hairline);
+  cursor: pointer;
 }
 .mode-badge.auto {
   color: var(--accent-ink);
@@ -3078,6 +3081,31 @@ html[data-ambient='off'] .vrec-wave span {
   color: var(--accent-ink);
 }
 
+/* Group 03 auto mode: the detail-screen run block (the list-row mode badge is
+   already styled above via .mode-badge / .mode-badge.auto) */
+.auto-gate,
+.auto-run,
+.auto-receipt {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 14px 16px;
+  border: 1px solid var(--accent-line);
+  border-radius: 18px;
+  margin-bottom: 16px;
+  background: linear-gradient(180deg, var(--accent-faint), transparent 46%), var(--surface-2);
+}
+.auto-gate-tx,
+.auto-run-tx,
+.auto-receipt-tx {
+  flex: 1 1 auto;
+  font-size: 14px;
+  color: var(--ink-2);
+}
+.auto-receipt {
+  background: var(--surface-2);
+}
+
 /* pool section */
 .pool-hd {
   display: flex;
@@ -5155,6 +5183,30 @@ html[data-ambient='off'] .gcard-step.status-running .gcard-step-dot {
 }
 .gcard-save:hover {
   background: var(--accent-soft);
+}
+
+/* Group 03 auto mode: the resting "run this" trigger + the in-flight pause */
+.gcard-run {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin: 0 15px 14px;
+  padding: 7px 12px;
+  border-radius: 999px;
+  border: 1px solid var(--accent-line);
+  background: var(--accent-faint);
+  color: var(--accent-ink);
+  font-size: 12.5px;
+  font-weight: 550;
+  cursor: pointer;
+  transition: background 0.18s;
+}
+.gcard-run:hover {
+  background: var(--accent-soft);
+}
+.gcard-pause {
+  align-self: flex-start;
+  margin: 2px 0 0;
 }
 
 /* ─────────── task workspace: reasoning / sources / dock / stepper / refine (Group 02) ─────────── */

--- a/apps/desktop/src/renderer/src/mikan/mock.ts
+++ b/apps/desktop/src/renderer/src/mikan/mock.ts
@@ -14,6 +14,7 @@ import type {
   Memory,
   MemoryKind,
   Task,
+  TaskMode,
   TaskState,
   TaskStatus,
   UncoveredTodo
@@ -657,6 +658,39 @@ export function makeMockApi(): MockApi {
         if (!t) return null
         t.ctx = t.ctx.filter((x) => x !== itemId)
         t.pinned = t.pinned.filter((x) => x !== itemId)
+        return clone(t)
+      },
+      setMode: async (id: string, mode: TaskMode): Promise<Task | null> => {
+        const t = find(id)
+        if (!t) return null
+        t.mode = mode
+        return clone(t)
+      },
+      // Mock always behaves "configured" (no drafter to gate on) so the Auto-mode
+      // flow is exercisable in browser preview. A short delay keeps the caller's
+      // local "busy"/working display visible for a moment, mirroring the real
+      // run's transient working state without persisting an observable snapshot.
+      run: async (id: string): Promise<Task | null> => {
+        const t = find(id)
+        if (!t) return null
+        await new Promise((resolve) => setTimeout(resolve, 700))
+        t.state = 'awaiting'
+        t.receipt = { ranOnDevice: true, durationMs: 700, touched: [...t.ctx], sentAnything: false }
+        if (!t.draft) {
+          t.draft = ['Mock auto-run draft — wire to a live drafter to see the real thing.']
+        }
+        return clone(t)
+      },
+      approve: async (id: string): Promise<Task | null> => {
+        const t = find(id)
+        if (!t) return null
+        t.state = 'done'
+        return clone(t)
+      },
+      pause: async (id: string): Promise<Task | null> => {
+        const t = find(id)
+        if (!t) return null
+        t.state = 'listed'
         return clone(t)
       }
     },

--- a/apps/desktop/src/renderer/src/mikan/task.tsx
+++ b/apps/desktop/src/renderer/src/mikan/task.tsx
@@ -448,6 +448,79 @@ function RefineChips({
   )
 }
 
+// Group 03 auto mode, at the workspace zoom level: the same run/awaiting/receipt
+// states the Today-list growing card renders (growing-card.tsx), replacing the
+// plan-mode "want me to take a crack at it?" CTA for an auto-mode task. Presentational
+// only — TaskDetail owns the actual todos.run/approve/pause calls so it can also
+// sync the local `draft` state when a run lands one (see runAuto below).
+function AutoRunPanel({
+  task,
+  busy,
+  onRun,
+  onApprove,
+  onPause
+}: {
+  task: Task
+  busy: boolean
+  onRun: () => void
+  onApprove: () => void
+  onPause: () => void
+}): JSX.Element {
+  const state = task.state ?? 'listed'
+
+  if (state === 'awaiting') {
+    return (
+      <div className="auto-gate">
+        <MikanMark state="idle" size={26} />
+        <div className="auto-gate-tx">Ready for your OK — nothing sent yet.</div>
+        <button className="btn btn-sm primary" onClick={onApprove}>
+          Approve
+        </button>
+      </div>
+    )
+  }
+  if (state === 'working' || busy) {
+    return (
+      <div className="auto-run">
+        <MikanMark state="drafting" size={26} />
+        <div className="auto-run-tx">
+          Running
+          <Dots />
+        </div>
+        <button className="btn btn-sm ghost" onClick={onPause}>
+          Pause
+        </button>
+      </div>
+    )
+  }
+  if (task.receipt) {
+    const r = task.receipt
+    return (
+      <div className="auto-receipt">
+        <MikanMark state="done" size={26} />
+        <div className="auto-receipt-tx">
+          Ran on device
+          {r.durationMs != null ? ` · ${(r.durationMs / 1000).toFixed(1)}s` : ''}
+          {r.touched.length > 0 ? ` · touched ${r.touched.length}` : ''} ·{' '}
+          {r.sentAnything ? 'sent' : 'nothing sent'}
+        </div>
+      </div>
+    )
+  }
+  return (
+    <button className="draft draft-cta" onClick={onRun}>
+      <MikanMark state="idle" size={30} />
+      <div className="draft-cta-main">
+        <div className="draft-cta-t">Run this on device</div>
+        <div className="draft-cta-s">I&apos;ll gather context and draft, on device</div>
+      </div>
+      <span className="draft-cta-go">
+        <NIcon name="arrowRight" size={18} />
+      </span>
+    </button>
+  )
+}
+
 export function TaskDetail({
   task,
   onBack,
@@ -544,6 +617,31 @@ export function TaskDetail({
       ])
       setDrafting(false)
     }, 1700)
+  }
+
+  // Group 03 auto mode — real run/approve/pause, wired to the same backend as
+  // GrowingCard's Today-list surface. `autoBusy` gives immediate "working"
+  // feedback for the window between clicking Run and the state/receipt landing.
+  const [autoBusy, setAutoBusy] = useState(false)
+  const runAuto = (): void => {
+    setAutoBusy(true)
+    void data.todos.run(task.id).then((t) => {
+      setAutoBusy(false)
+      if (!t) return
+      if (t.draft) setDraft(t.draft)
+      onUpdate && onUpdate(task.id, { state: t.state, receipt: t.receipt, status: t.status })
+    })
+  }
+  const approveAuto = (): void => {
+    void data.todos.approve(task.id).then((t) => {
+      if (t) onUpdate && onUpdate(task.id, { state: t.state, receipt: t.receipt })
+    })
+  }
+  const pauseAuto = (): void => {
+    void data.todos.pause(task.id).then((t) => {
+      setAutoBusy(false)
+      if (t) onUpdate && onUpdate(task.id, { state: t.state, receipt: t.receipt })
+    })
   }
 
   const keptIds = sorted.filter((id) => pinned.has(id))
@@ -752,7 +850,16 @@ export function TaskDetail({
             </div>
           </div>
         ) : (
-          !done && (
+          !done &&
+          (task.mode === 'auto' ? (
+            <AutoRunPanel
+              task={task}
+              busy={autoBusy}
+              onRun={runAuto}
+              onApprove={approveAuto}
+              onPause={pauseAuto}
+            />
+          ) : (
             <button className="draft draft-cta" onClick={tryDraft}>
               <MikanMark state="idle" size={30} />
               <div className="draft-cta-main">
@@ -763,7 +870,7 @@ export function TaskDetail({
                 <NIcon name="arrowRight" size={18} />
               </span>
             </button>
-          )
+          ))
         )}
 
         {done && (

--- a/apps/desktop/src/renderer/src/mikan/today.tsx
+++ b/apps/desktop/src/renderer/src/mikan/today.tsx
@@ -128,13 +128,21 @@ function TaskCard({
   index,
   layout,
   onOpen,
-  onToggle
+  onToggle,
+  onToggleMode,
+  onRun,
+  onApprove,
+  onPause
 }: {
   task: Task
   index: number
   layout: string
   onOpen: (id: string) => void
   onToggle: (id: string) => void
+  onToggleMode: (id: string) => void
+  onRun: (id: string) => Promise<void>
+  onApprove: (id: string) => Promise<void>
+  onPause: (id: string) => Promise<void>
 }): JSX.Element {
   const kept = (task.pinned || []).length
   const ctxN = (task.ctx || []).length
@@ -163,6 +171,12 @@ function TaskCard({
     return undefined
   }, [task.done])
 
+  // Group 03: local optimistic "running" flag for a real in-flight run() call
+  // — see GrowingCard's `busy` prop doc. Cleared via the returned promise
+  // (not a task-prop diff) since an unconfigured drafter resolves with the
+  // task UNCHANGED — a diff-based reset would never fire in that case.
+  const [running, setRunning] = useState(false)
+
   return (
     <div
       className={'task' + (task.done ? ' done-task' : '') + (pop ? ' pop' : '')}
@@ -184,12 +198,30 @@ function TaskCard({
           {pop && <span className="check-burst" />}
         </button>
         <div className="task-main">
-          <GrowingCard task={task} />
+          <GrowingCard
+            task={task}
+            busy={running}
+            onRun={() => {
+              setRunning(true)
+              void onRun(task.id).finally(() => setRunning(false))
+            }}
+            onApprove={() => onApprove(task.id)}
+            onPause={() => {
+              void onPause(task.id).finally(() => setRunning(false))
+            }}
+          />
           {!task.done && (
             <>
-              <span className={'mode-badge' + (task.mode === 'auto' ? ' auto' : '')}>
+              <button
+                className={'mode-badge' + (task.mode === 'auto' ? ' auto' : '')}
+                aria-label={task.mode === 'auto' ? 'Switch to Plan mode' : 'Switch to Auto mode'}
+                onClick={(e) => {
+                  e.stopPropagation()
+                  onToggleMode(task.id)
+                }}
+              >
                 {task.mode === 'auto' ? 'Auto' : 'Plan'}
-              </span>
+              </button>
               {task.note && <MikanNote kind={task.noteKind || 'gathered'}>{task.note}</MikanNote>}
               <div className="ctx-strip">
                 {ctxN > 0 && <CtxThumbs memIds={task.ctx} />}
@@ -238,6 +270,10 @@ interface TodayViewProps {
   lastFed: string | null
   onOpen: (id: string) => void
   onToggle: (id: string) => void
+  onToggleMode: (id: string) => void
+  onRun: (id: string) => Promise<void>
+  onApprove: (id: string) => Promise<void>
+  onPause: (id: string) => Promise<void>
   onAdd: () => void
   onPlan: () => void
   onTomorrow: () => void
@@ -260,6 +296,10 @@ export function TodayView({
   lastFed,
   onOpen,
   onToggle,
+  onToggleMode,
+  onRun,
+  onApprove,
+  onPause,
   onPlan,
   onTomorrow,
   onSearch,
@@ -339,6 +379,10 @@ export function TodayView({
               layout={layout}
               onOpen={onOpen}
               onToggle={onToggle}
+              onToggleMode={onToggleMode}
+              onRun={onRun}
+              onApprove={onApprove}
+              onPause={onPause}
             />
           ))}
           {Array.from({ length: open }).map((_, i) => (

--- a/apps/desktop/test/helpers.ts
+++ b/apps/desktop/test/helpers.ts
@@ -9,7 +9,7 @@ import { client, resetVecChunks } from '../src/main/db/index'
 export async function clearTables(): Promise<void> {
   // Delete in dependency order (FKs may or may not be enforced, but order is safe).
   await client.executeMultiple(
-    'DELETE FROM todo_ai; DELETE FROM todo_context; DELETE FROM todos; DELETE FROM items; DELETE FROM meta; DELETE FROM connector_state;'
+    'DELETE FROM todo_run; DELETE FROM todo_ai; DELETE FROM todo_context; DELETE FROM todos; DELETE FROM items; DELETE FROM meta; DELETE FROM connector_state;'
   )
   // chunks lives in neeme-vec.db (vecClient) since commit 00b72eb (#86). A plain
   // DELETE leaves the libsql_vector_idx shadow tables inconsistent; drop+recreate

--- a/apps/desktop/test/pipeline/draft.test.ts
+++ b/apps/desktop/test/pipeline/draft.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from 'vitest'
-import { NullDrafter } from '../../src/main/pipeline/draft'
+import { NullDrafter, CloudDrafter } from '../../src/main/pipeline/draft'
 import type { DraftInput } from '../../src/main/pipeline/draft'
 
 const EMPTY_INPUT: DraftInput = {
@@ -85,5 +85,81 @@ describe('drafter singleton — whitespace-trimmed env flags', () => {
     // instanceof fails across vi.resetModules() boundaries (two class objects); use
     // the stable name property instead.
     expect(freshDrafter.name).toBe('null-drafter')
+  })
+})
+
+// ── CloudDrafter — abort signal plumbing (Group 03 pause()) ───────────────────
+//
+// pause() cancels an in-flight run via AbortController. These tests verify the
+// signal actually reaches fetch, and that an abort propagates as a real error
+// rather than being swallowed into a null "gathered" result — both without a
+// live/slow network call, so they're safe and fast in CI.
+describe('CloudDrafter — abort signal plumbing', () => {
+  const okResponse = (): { ok: true; json: () => Promise<unknown> } => ({
+    ok: true,
+    json: async () => ({
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify({
+            brief: null,
+            draft: null,
+            draftNote: null,
+            note: null,
+            noteKind: null,
+            status: 'gathered',
+            conf: null,
+            why: {}
+          })
+        }
+      ]
+    })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('passes the signal through to fetch', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(okResponse())
+    vi.stubGlobal('fetch', fetchMock)
+    const drafter = new CloudDrafter('sk-test-dummy-key')
+    const controller = new AbortController()
+
+    await drafter.draft(EMPTY_INPUT, controller.signal)
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const init = fetchMock.mock.calls[0]?.[1] as RequestInit
+    expect(init.signal).toBe(controller.signal)
+  })
+
+  it('works without a signal (optional param)', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(okResponse())
+    vi.stubGlobal('fetch', fetchMock)
+    const drafter = new CloudDrafter('sk-test-dummy-key')
+
+    await expect(drafter.draft(EMPTY_INPUT)).resolves.toMatchObject({ status: 'gathered' })
+    const init = fetchMock.mock.calls[0]?.[1] as RequestInit
+    expect(init.signal).toBeUndefined()
+  })
+
+  it('rethrows an AbortError instead of swallowing it into a null result', async () => {
+    const abortErr = new Error('The operation was aborted')
+    abortErr.name = 'AbortError'
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(abortErr))
+    const drafter = new CloudDrafter('sk-test-dummy-key')
+
+    await expect(drafter.draft(EMPTY_INPUT, new AbortController().signal)).rejects.toThrow(
+      /aborted/i
+    )
+  })
+
+  it('still swallows a non-abort transport failure into a null "gathered" result', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network down')))
+    const drafter = new CloudDrafter('sk-test-dummy-key')
+
+    const result = await drafter.draft(EMPTY_INPUT)
+    expect(result.status).toBe('gathered')
+    expect(result.draft).toBeNull()
   })
 })

--- a/apps/desktop/test/services/project.test.ts
+++ b/apps/desktop/test/services/project.test.ts
@@ -8,6 +8,7 @@ import {
 } from '../../src/main/services/project'
 import type { Item, Todo, ContextEntry } from '@mikan/contract/ipc'
 import type { TaskDraft } from '../../src/main/pipeline/draft'
+import type { TodoRunRow } from '../../src/main/db/schema'
 
 // ── factories ─────────────────────────────────────────────────────────────────
 
@@ -32,6 +33,7 @@ function makeTodo(overrides: Partial<Todo> = {}): Todo {
     status: 'open',
     day: new Date().toISOString().slice(0, 10),
     position: 0,
+    mode: 'plan',
     createdAt: new Date(),
     completedAt: null,
     ...overrides
@@ -47,6 +49,20 @@ function makeContext(overrides: Partial<ContextEntry> = {}): ContextEntry {
     excerpt: 'Relevant excerpt',
     state: 'surfaced',
     why: null,
+    ...overrides
+  }
+}
+
+function makeRunRow(overrides: Partial<TodoRunRow> = {}): TodoRunRow {
+  return {
+    todoId: 'todo-1',
+    state: 'awaiting',
+    ranOnDevice: true,
+    durationMs: 1200,
+    touched: JSON.stringify(['item-1']),
+    sentAnything: false,
+    startedAt: new Date(),
+    updatedAt: new Date(),
     ...overrides
   }
 }
@@ -120,10 +136,12 @@ describe('toMemory', () => {
   })
 
   it('uses item.uri as src when present', () => {
-    const m = toMemory(makeItem({
-      connector: 'gmail',
-      uri: 'https://mail.google.com/mail/u/0/#inbox/abc123'
-    }))
+    const m = toMemory(
+      makeItem({
+        connector: 'gmail',
+        uri: 'https://mail.google.com/mail/u/0/#inbox/abc123'
+      })
+    )
     expect(m.src).toBe('https://mail.google.com/mail/u/0/#inbox/abc123')
   })
 
@@ -343,6 +361,53 @@ describe('toTask', () => {
   it('when is "today" for day=null', () => {
     const task = toTask(makeTodo({ day: null }), [])
     expect(task.when).toBe('today')
+  })
+})
+
+// ── toTask — Group 03 auto-mode run row ───────────────────────────────────────
+
+describe('toTask — run row (Group 03)', () => {
+  it('mode passes through from todo.mode', () => {
+    expect(toTask(makeTodo({ mode: 'auto' }), []).mode).toBe('auto')
+    expect(toTask(makeTodo({ mode: 'plan' }), []).mode).toBe('plan')
+  })
+
+  it('falls back to the status-based derivation when no run row exists (regression guard)', () => {
+    const task = toTask(makeTodo(), [], makeDraft({ status: 'drafted' }), undefined)
+    expect(task.state).toBe('awaiting')
+    expect(task.receipt).toBeUndefined()
+  })
+
+  it('a run row at "awaiting" overrides the derived state and populates the receipt', () => {
+    const task = toTask(makeTodo(), [], undefined, makeRunRow({ state: 'awaiting' }))
+    expect(task.state).toBe('awaiting')
+    expect(task.receipt).toEqual({
+      ranOnDevice: true,
+      durationMs: 1200,
+      touched: ['item-1'],
+      sentAnything: false
+    })
+  })
+
+  it('a run row at "done" overrides the derived state', () => {
+    const task = toTask(makeTodo(), [], undefined, makeRunRow({ state: 'done' }))
+    expect(task.state).toBe('done')
+  })
+
+  it('a run row at "listed" (never run, or reverted by pause) defers to the derivation and carries no receipt', () => {
+    const task = toTask(
+      makeTodo({ status: 'done' }),
+      [],
+      undefined,
+      makeRunRow({ state: 'listed' })
+    )
+    expect(task.state).toBe('done') // derivation wins — done comes from todo.status here
+    expect(task.receipt).toBeUndefined()
+  })
+
+  it('touched parses to [] when the run row has no touched JSON', () => {
+    const task = toTask(makeTodo(), [], undefined, makeRunRow({ touched: null }))
+    expect(task.receipt?.touched).toEqual([])
   })
 })
 

--- a/apps/desktop/test/services/todo-service.test.ts
+++ b/apps/desktop/test/services/todo-service.test.ts
@@ -6,7 +6,8 @@
  * tokens with todo titles so the hash embedder surfaces them as context.
  */
 import { describe, it, expect, beforeAll, beforeEach } from 'vitest'
-import { initDb } from '../../src/main/db/index'
+import { initDb, db } from '../../src/main/db/index'
+import { todoRun } from '../../src/main/db/schema'
 import { todoService } from '../../src/main/services/todo-service'
 import { pipelineService } from '../../src/main/services/pipeline-service'
 import { CAP_REACHED } from '@mikan/contract/ipc'
@@ -378,5 +379,101 @@ describe('todoService.schedule — re-surfaces context', () => {
     expect(scheduled).not.toBeNull()
     // surfaceContext should have run, giving the task a non-empty pool.
     expect(scheduled!.ctx.length).toBeGreaterThan(0)
+  })
+})
+
+// ── Group 03 — Auto mode run loop ─────────────────────────────────────────────
+// NEEME_DRAFTER=off is forced globally (test/setup.ts), so run() exercises the
+// documented "unconfigured → no-op" path here. The "configured → real run"
+// path (awaiting/done settlement, the abort revert) needs a live drafter and
+// is covered by the manual pnpm dev smoke test instead (no Electron/API key in CI).
+
+describe('todoService.setMode', () => {
+  it('defaults to "plan" for a new todo', async () => {
+    const t = await todoService.add('Mode default check')
+    expect(t.mode).toBe('plan')
+  })
+
+  it('persists a mode change and round-trips through today()', async () => {
+    const t = await todoService.add('Toggle me')
+    const updated = await todoService.setMode(t.id, 'auto')
+    expect(updated!.mode).toBe('auto')
+
+    const tasks = await todoService.today()
+    expect(tasks.find((x) => x.id === t.id)!.mode).toBe('auto')
+  })
+
+  it('returns null for a non-existent id', async () => {
+    expect(await todoService.setMode('no-such-id', 'auto')).toBeNull()
+  })
+})
+
+describe('todoService.run — drafter unconfigured (NEEME_DRAFTER=off)', () => {
+  it('is a documented no-op: task unchanged, no receipt, no todo_run row', async () => {
+    const t = await todoService.add('Auto run me')
+    await todoService.setMode(t.id, 'auto')
+
+    const ran = await todoService.run(t.id)
+    expect(ran).not.toBeNull()
+    expect(ran!.state).toBe('listed')
+    expect(ran!.receipt).toBeUndefined()
+
+    const rows = await db.select().from(todoRun)
+    expect(rows).toHaveLength(0)
+  })
+
+  it('returns null for a non-existent id', async () => {
+    expect(await todoService.run('no-such-id')).toBeNull()
+  })
+})
+
+describe('todoService.approve', () => {
+  it('no-ops (returns the task unchanged) when nothing is awaiting', async () => {
+    const t = await todoService.add('Nothing awaiting')
+    const result = await todoService.approve(t.id)
+    expect(result).not.toBeNull()
+    expect(result!.state).toBe('listed')
+  })
+
+  it('settles an awaiting run to done and keeps the receipt', async () => {
+    const t = await todoService.add('Seeded awaiting run')
+    // NEEME_DRAFTER=off never naturally produces an awaiting run — seed the
+    // todo_run row directly to exercise the approve() transition.
+    await db.insert(todoRun).values({
+      todoId: t.id,
+      state: 'awaiting',
+      ranOnDevice: true,
+      durationMs: 500,
+      touched: JSON.stringify(['m1']),
+      sentAnything: false
+    })
+
+    const approved = await todoService.approve(t.id)
+    expect(approved!.state).toBe('done')
+    expect(approved!.receipt).toEqual({
+      ranOnDevice: true,
+      durationMs: 500,
+      touched: ['m1'],
+      sentAnything: false
+    })
+    // approve() is orthogonal to complete() — the todo's own done flag is untouched.
+    expect(approved!.done).toBe(false)
+  })
+
+  it('returns null for a non-existent id', async () => {
+    expect(await todoService.approve('no-such-id')).toBeNull()
+  })
+})
+
+describe('todoService.pause', () => {
+  it('no-ops when nothing is running for this task', async () => {
+    const t = await todoService.add('Nothing running')
+    const result = await todoService.pause(t.id)
+    expect(result).not.toBeNull()
+    expect(result!.state).toBe('listed')
+  })
+
+  it('returns null for a non-existent id', async () => {
+    expect(await todoService.pause('no-such-id')).toBeNull()
   })
 })

--- a/docs/INTEGRATION.md
+++ b/docs/INTEGRATION.md
@@ -18,17 +18,26 @@ so the build stays green — `Task.status` stays; new fields are added alongside
 
 | Field | Type | Real / AI-gap |
 | --- | --- | --- |
-| `Task.state` | `'listed' \| 'planning' \| 'planned' \| 'working' \| 'awaiting' \| 'done'` | **Real** — derived from `status` at the projector (`toTask`) |
-| `Task.mode` | `'plan' \| 'auto'` | **Real** — defaults to `'plan'` (no stored per-task mode yet) |
-| `Task.steps` | `PlanStep[]` | **AI-gap** — `undefined` until the planner lands |
-| `Task.receipt` | `RunReceipt` | **AI-gap** — present once a run settles |
+| `Task.state` | `'listed' \| 'planning' \| 'planned' \| 'working' \| 'awaiting' \| 'done'` | **Real** — derived from `status`, overridden by a persisted run row when one exists (`toTask`) |
+| `Task.mode` | `'plan' \| 'auto'` | **Real** — persisted per-task (`todos.mode` column); toggle via `todos.setMode(id, mode)` (S5) |
+| `Task.steps` | `PlanStep[]` | **AI-gap** — `undefined` until the planner lands (S4) |
+| `Task.receipt` | `RunReceipt` | **Real when the drafter is configured** — populated by `todos.run()`/`todos.approve()` (S5, backed by the `todo_run` table); `undefined` otherwise (no-op) |
 
-Projector mapping today (`services/project.ts` → `toTask`): `done → 'done'`,
-drafted (a landed AI draft) `→ 'awaiting'` (the approval gate), otherwise `→ 'listed'`. The
-intermediate `'planning' / 'planned' / 'working'` states become real once the planner +
-run-loop land (slices S4/S5). Group-01 presentation states are **derived in the renderer**,
-not stored: `delegated = mode:auto & working`, `deferred = planning`, `in-progress = working`,
-`done = done`. Decision of record: `docs/adr/0010-task-lifecycle.md`.
+Projector mapping today (`services/project.ts` → `toTask`): `done → 'done'`, drafted (a landed
+AI draft) `→ 'awaiting'` (the approval gate), otherwise `→ 'listed'` — **unless** a `todo_run`
+row exists and its `state` isn't `'listed'`, in which case the run row's `state` wins (it's a
+real signal from `todos.run()`, not a derivation). `'planned'` stays unmapped — there is still
+no persisted multi-step plan (S4-scope); `run()` (S5) goes straight from `listed` to
+`working`/`awaiting`/`done` around a single gather-and-draft step, not a step sequence. Group-01
+presentation states are **derived in the renderer**, not stored: `delegated = mode:auto &
+working`, `deferred = planning`, `in-progress = working`, `done = done`. Decision of record:
+`docs/adr/0010-task-lifecycle.md`.
+
+**`RunReceipt.sentAnything` is always `false`** — there is no outbound "send"/action-taking
+integration anywhere in this codebase yet (connectors only *ingest*); this is a structural gap,
+not a placeholder to read as evidence of a real send capability. Likewise, `todos.pause()` is a
+blunt abort of the in-flight run, not a mid-run "steer" — redirecting an active run via chat
+input is out of scope until a real step-by-step execution engine (S4+) exists.
 
 ## Current renderer wiring
 
@@ -58,6 +67,10 @@ and static suggestion chips. Track them in `docs/agent-sync/UX-PUNCHLIST.md`.
 | Pull from backlog                  | `window.api.todos.schedule(id, day?)`                      | `Task \| null`        |
 | Pin / dismiss context              | `window.api.todos.{pinContext,dismissContext}(id, itemId)` | `Task \| null`        |
 | "Search more" context              | `window.api.todos.searchMoreContext(id)`                   | `Task \| null`        |
+| Set a task's mode (Group 03)       | `window.api.todos.setMode(id, mode)`                       | `Task \| null`        |
+| Run a task on device (Group 03)    | `window.api.todos.run(id)`                                 | `Task \| null`        |
+| Approve an awaiting run (Group 03) | `window.api.todos.approve(id)`                             | `Task \| null`        |
+| Pause an in-flight run (Group 03)  | `window.api.todos.pause(id)`                               | `Task \| null`        |
 | Capture a note                     | `window.api.pipeline.captureText(text, name?)`             | `{ memory, created }` |
 | Capture a file                     | `window.api.pipeline.captureFile(bytes, name, mime?)`      | `{ memory, created }` |
 

--- a/packages/contract/src/ipc.ts
+++ b/packages/contract/src/ipc.ts
@@ -9,7 +9,7 @@
  * projects them to the view model (see
  * `apps/desktop/src/main/services/project.ts`).
  */
-import type { BacklogItem, FedItem, MatchHit, Memory, Task, UncoveredTodo } from './views'
+import type { BacklogItem, FedItem, MatchHit, Memory, Task, TaskMode, UncoveredTodo } from './views'
 
 export const IPC = {
   // Pipeline (on-device capture → extract → index → surface; runs in the worker)
@@ -31,6 +31,10 @@ export const IPC = {
   todoContextSearch: 'todo:context-search',
   todoContextPin: 'todo:context-pin',
   todoContextDismiss: 'todo:context-dismiss',
+  todoSetMode: 'todo:set-mode',
+  todoRun: 'todo:run',
+  todoApprove: 'todo:approve',
+  todoPause: 'todo:pause',
   // Auth (Logto OIDC flow lives in main; see src/main/auth/logto.ts)
   authLogin: 'auth:login',
   authLogout: 'auth:logout',
@@ -152,6 +156,13 @@ export interface Todo {
   /** ISO date the todo lives on; null = backlog (unscheduled). */
   day: string | null
   position: number
+  /**
+   * Persisted per-task mode (Group 03 auto switch). Defaults to 'plan'. Reuses
+   * the view model's `TaskMode` rather than a parallel worker-internal alias —
+   * unlike `status` (which the projector transforms into the richer `TaskState`),
+   * `mode` passes straight through with no transformation, so one type suffices.
+   */
+  mode: TaskMode
   createdAt: Date
   completedAt: Date | null
 }
@@ -194,6 +205,20 @@ export interface TodoApi {
   searchMoreContext: (id: string) => Promise<Task | null>
   pinContext: (id: string, itemId: string) => Promise<Task | null>
   dismissContext: (id: string, itemId: string) => Promise<Task | null>
+  /** Set a task's run mode (Group 03 auto switch, set on the list). */
+  setMode: (id: string, mode: TaskMode) => Promise<Task | null>
+  /**
+   * Run the task on device: gathers context + drafts (the current unit of
+   * AI-gap work), synchronously, to settlement — lands on `awaiting` (a draft
+   * is ready to approve) or `done` (nothing to gate on). No-op — returns the
+   * task unchanged — when the drafter is unconfigured.
+   */
+  run: (id: string) => Promise<Task | null>
+  /** Approve an awaiting run: closes the gate, settles the receipt. `receipt.sentAnything`
+   *  stays false — there is no outbound "send" integration yet. */
+  approve: (id: string) => Promise<Task | null>
+  /** Cancel an in-flight run. Reverts to `listed`; writes no receipt. No-op if nothing running. */
+  pause: (id: string) => Promise<Task | null>
 }
 
 /** Capture + surface, backed by the on-device pipeline in the worker. */


### PR DESCRIPTION
## Summary

Implements **S5 — Auto mode (Group 03)**, [RETRO-15](https://linear.app/retrospct/issue/RETRO-15/s5-auto-mode-group-03), part of the Mikan Flows task-lifecycle spine (`docs/plans/mikan-flows.prd.md`).

- **Contract** (`packages/contract`): `TodoApi.setMode/run/approve/pause`, a persisted `mode` column on `todos`, and a new `todo_run` table holding run state + `RunReceipt`.
- **Backend**: `todoService.run()` reuses the existing `draftService`/`drafter` seam (gather context + draft) as the run loop's single unit of work, settling at `awaiting` (a draft landed — the approval gate) or `done` (nothing to gate on). No-ops when the drafter is unconfigured. `approve()` closes the gate; `pause()` aborts the in-flight drafter call via a threaded `AbortSignal` and reverts to `listed`. `receipt.sentAnything` is always `false` — there's no outbound "send" integration anywhere in this codebase, a disclosed structural gap, not a bug.
- **Frontend**: the Today-list mode badge is now a real Plan/Auto toggle; the S1 growing card (`growing-card.tsx`) gets real Run/Approve/Pause wiring plus a local "busy" flag standing in for the run loop's unobservable mid-flight `working` state (single request-response, no push channel exists). The task workspace (`task.tsx`) gets the same run/approve/pause panel for auto-mode tasks, replacing the plan-mode draft CTA only for tasks in Auto mode.

### Mid-flight discovery

This branch was cut before S1 (growing-card, #115), S3 (task-workspace, #116), and S2 (Today/Stack, #117) landed on `main`. Rebased onto `main` partway through and redid the frontend integration against the real growing-card/workspace components instead of the stale pre-S1 UI.

### Explicitly out of scope (disclosed in `docs/INTEGRATION.md`)

- True step-by-step execution — S4 (plan-mode step editor) hasn't landed, so `run()` is a single-shot gather-and-draft, not a `PlanStep[]` sequence.
- Real "send" — `sentAnything` is hardcoded `false`.
- Mid-run "steer" via chat — `pause()` is a blunt abort, not a redirect.

## Test plan

- [x] `pnpm typecheck && pnpm build` — green
- [x] `pnpm lint` on all changed files — clean (pre-existing lint debt elsewhere is untouched)
- [x] `pnpm --filter @mikan/desktop test` — 289/289 passing, including new Tier A (`project.test.ts`, `draft.test.ts` abort-signal plumbing) and Tier B (`todo-service.test.ts`: setMode/run/approve/pause, unconfigured no-op, seeded-awaiting approve) coverage
- [x] Two-axis `/review` (Standards + Spec) against `main` — findings addressed (contract type consolidation; the Today-list Pause affordance now reachable via a local busy flag, since a real run's `working` state is otherwise never observably written before settling)
- [x] **Needs a live `pnpm dev` smoke test** with a real `NEEME_ANTHROPIC_KEY` (worker behavior — Electron can't run in this sandboxed environment, confirmed by attempting it here). Suggested steps: toggle a task to Auto on Today, confirm persistence across reload; open it, click Run, verify it settles to `awaiting` (rich context) or `done` (thin context) with a receipt; Approve an awaiting task; start a Run on a slower task and Pause mid-flight, confirm a clean revert to `listed`; confirm `NEEME_DRAFTER=off pnpm dev` makes Run a true no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)